### PR TITLE
Add Google PaLM support for chat and text models

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,6 +3,7 @@ import convict from 'convict';
 import HandleBars from './lib/handleBars.js';
 import fs from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
+import GcpAuthTokenHelper from './lib/gcpAuthTokenHelper.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -57,7 +58,8 @@ var config = convict({
     cortexApiKey: {
         format: String,
         default: null,
-        env: 'CORTEX_API_KEY'
+        env: 'CORTEX_API_KEY',
+        sensitive: true
     },
     defaultModelName: {
         format: String,
@@ -117,6 +119,12 @@ var config = convict({
         default: 'null',
         env: 'WHISPER_MEDIA_API_URL'
     },
+    gcpServiceAccountKey: {
+        format: String,
+        default: null,
+        env: 'GCP_SERVICE_ACCOUNT_KEY',
+        sensitive: true
+    },
 });
 
 // Read in environment variables and set up service configuration
@@ -133,6 +141,11 @@ if (configFile && fs.existsSync(configFile)) {
     }else {
         console.log(`Using default model with OPENAI_API_KEY environment variable`)
     }
+}
+
+if (config.get('gcpServiceAccountKey')) {
+    const gcpAuthTokenHelper = new GcpAuthTokenHelper(config.getProperties());
+    config.set('gcpAuthTokenHelper', gcpAuthTokenHelper);
 }
 
 // Build and load pathways to config

--- a/graphql/pathwayPrompter.js
+++ b/graphql/pathwayPrompter.js
@@ -4,6 +4,8 @@ import OpenAICompletionPlugin from './plugins/openAiCompletionPlugin.js';
 import AzureTranslatePlugin from './plugins/azureTranslatePlugin.js';
 import OpenAIWhisperPlugin from './plugins/openAiWhisperPlugin.js';
 import LocalModelPlugin from './plugins/localModelPlugin.js';
+import PalmChatPlugin from './plugins/palmChatPlugin.js';
+import PalmCompletionPlugin from './plugins/palmCompletionPlugin.js';
 
 class PathwayPrompter {
     constructor({ config, pathway }) {
@@ -32,6 +34,12 @@ class PathwayPrompter {
                 break;
             case 'LOCAL-CPP-MODEL':
                 plugin = new LocalModelPlugin(config, pathway);
+                break;
+            case 'PALM-CHAT':
+                plugin = new PalmChatPlugin(config, pathway);
+                break;
+            case 'PALM-COMPLETION':
+                plugin = new PalmCompletionPlugin(config, pathway);
                 break;
             default:
                 throw new Error(`Unsupported model type: ${model.type}`);

--- a/graphql/plugins/azureTranslatePlugin.js
+++ b/graphql/plugins/azureTranslatePlugin.js
@@ -35,6 +35,28 @@ class AzureTranslatePlugin extends ModelPlugin {
 
         return this.executeRequest(url, data, params, headers, prompt);
     }
+    
+    // Parse the response from the Azure Translate API
+    parseResponse(data) {
+        if (Array.isArray(data) && data.length > 0 && data[0].translations) {
+            return data[0].translations[0].text.trim();
+        } else {
+            return data;
+        }
+    }
+    
+    // Override the logging function to display the request and response
+    logRequestData(data, responseData, prompt) {
+        const separator = `\n=== ${this.pathwayName}.${this.requestCount++} ===\n`;
+        console.log(separator);
+    
+        const modelInput = data[0].Text;
+    
+        console.log(`\x1b[36m${modelInput}\x1b[0m`);
+        console.log(`\x1b[34m> ${this.parseResponse(responseData)}\x1b[0m`);
+    
+        prompt && prompt.debugInfo && (prompt.debugInfo += `${separator}${JSON.stringify(data)}`);
+    }
 }
 
 export default AzureTranslatePlugin;

--- a/graphql/plugins/openAiChatPlugin.js
+++ b/graphql/plugins/openAiChatPlugin.js
@@ -1,9 +1,56 @@
 // OpenAIChatPlugin.js
 import ModelPlugin from './modelPlugin.js';
+import HandleBars from '../../lib/handleBars.js';
+import { encode } from 'gpt-3-encoder';
 
 class OpenAIChatPlugin extends ModelPlugin {
     constructor(config, pathway) {
         super(config, pathway);
+    }
+
+    // Handlebars compiler for prompt messages array (OpenAI chat specific)
+    getModelPromptMessages(modelPrompt, combinedParameters, text) {
+        if (!modelPrompt.messages) {
+            return null;
+        }
+
+        // First run handlebars compile on the pathway messages
+        const compiledMessages = modelPrompt.messages.map((message) => {
+            if (message.content) {
+                const compileText = HandleBars.compile(message.content);
+                return {
+                    ...message,
+                    content: compileText({ ...combinedParameters, text }),
+                };
+            } else {
+                return message;
+            }
+        });
+
+        // Next add in any parameters that are referenced by name in the array
+        const expandedMessages = compiledMessages.flatMap((message) => {
+            if (typeof message === 'string') {
+                const match = message.match(/{{(.+?)}}/);
+                const placeholder = match ? match[1] : null;
+                if (placeholder === null) {
+                    return message;
+                } else {
+                    return combinedParameters[placeholder] || [];
+                }
+            } else {
+                return [message];
+            }
+        });
+
+        // Check if the messages are in Palm format and convert them to OpenAI format if necessary
+        const isPalmFormat = expandedMessages.some(message => 'author' in message);
+        if (isPalmFormat) {
+            const context = modelPrompt.context || '';
+            const examples = modelPrompt.examples || [];
+            return this.convertPalmToOpenAIMessages(context, examples, expandedMessages);
+        }
+
+        return expandedMessages;
     }
 
     // Set up parameters specific to the OpenAI Chat API
@@ -25,7 +72,7 @@ class OpenAIChatPlugin extends ModelPlugin {
         const requestParameters = {
         messages: requestMessages,
         temperature: this.temperature ?? 0.7,
-        stream
+        ...(stream !== undefined ? { stream } : {}),
         };
     
         return requestParameters;
@@ -40,6 +87,45 @@ class OpenAIChatPlugin extends ModelPlugin {
         const params = {};
         const headers = this.model.headers || {};
         return this.executeRequest(url, data, params, headers, prompt);
+    }
+
+    // Parse the response from the OpenAI Chat API
+    parseResponse(data) {
+        const { choices } = data;
+        if (!choices || !choices.length) {
+            return null;
+        }
+
+        // if we got a choices array back with more than one choice, return the whole array
+        if (choices.length > 1) {
+            return choices;
+        }
+
+        // otherwise, return the first choice
+        const messageResult = choices[0].message && choices[0].message.content && choices[0].message.content.trim();
+        return messageResult ?? null;
+    }
+
+    // Override the logging function to display the messages and responses
+    logRequestData(data, responseData, prompt) {
+        const separator = `\n=== ${this.pathwayName}.${this.requestCount++} ===\n`;
+        console.log(separator);
+    
+        if (data && data.messages && data.messages.length > 1) {
+            data.messages.forEach((message, index) => {
+                const words = message.content.split(" ");
+                const tokenCount = encode(message.content).length;
+                const preview = words.length < 41 ? message.content : words.slice(0, 20).join(" ") + " ... " + words.slice(-20).join(" ");
+    
+                console.log(`\x1b[36mMessage ${index + 1}: Role: ${message.role}, Tokens: ${tokenCount}, Content: "${preview}"\x1b[0m`);
+            });
+        } else {
+            console.log(`\x1b[36m${data.messages[0].content}\x1b[0m`);
+        }
+    
+        console.log(`\x1b[34m> ${this.parseResponse(responseData)}\x1b[0m`);
+    
+        prompt && prompt.debugInfo && (prompt.debugInfo += `${separator}${JSON.stringify(data)}`);
     }
 }
 

--- a/graphql/plugins/openAiCompletionPlugin.js
+++ b/graphql/plugins/openAiCompletionPlugin.js
@@ -1,7 +1,6 @@
 // OpenAICompletionPlugin.js
 
 import ModelPlugin from './modelPlugin.js';
-import HandleBars from '../../lib/handleBars.js';
 import { encode } from 'gpt-3-encoder';
 
 // Helper function to truncate the prompt if it is too long
@@ -18,51 +17,6 @@ const truncatePromptIfNecessary = (text, textTokenCount, modelMaxTokenCount, tar
 class OpenAICompletionPlugin extends ModelPlugin {
     constructor(config, pathway) {
         super(config, pathway);
-    }
-
-    // Handlebars compiler for prompt messages array (OpenAI chat specific)
-    getModelPromptMessages(modelPrompt, combinedParameters, text) {
-        if (!modelPrompt.messages) {
-            return null;
-        }
-
-        // First run handlebars compile on the pathway messages
-        const compiledMessages = modelPrompt.messages.map((message) => {
-            if (message.content) {
-                const compileText = HandleBars.compile(message.content);
-                return {
-                    ...message,
-                    content: compileText({ ...combinedParameters, text }),
-                };
-            } else {
-                return message;
-            }
-        });
-
-        // Next add in any parameters that are referenced by name in the array
-        const expandedMessages = compiledMessages.flatMap((message) => {
-            if (typeof message === 'string') {
-                const match = message.match(/{{(.+?)}}/);
-                const placeholder = match ? match[1] : null;
-                if (placeholder === null) {
-                    return message;
-                } else {
-                    return combinedParameters[placeholder] || [];
-                }
-            } else {
-                return [message];
-            }
-        });
-
-        // Check if the messages are in Palm format and convert them to OpenAI format if necessary
-        const isPalmFormat = expandedMessages.some(message => 'author' in message);
-        if (isPalmFormat) {
-            const context = modelPrompt.context || '';
-            const examples = modelPrompt.examples || [];
-            return this.convertPalmToOpenAIMessages(context, examples, expandedMessages);
-        }
-
-        return expandedMessages;
     }
 
     // Set up parameters specific to the OpenAI Completion API

--- a/graphql/plugins/palmChatPlugin.js
+++ b/graphql/plugins/palmChatPlugin.js
@@ -179,7 +179,18 @@ class PalmChatPlugin extends ModelPlugin {
     
         const instances = data && data.instances;
         const messages = instances && instances[0] && instances[0].messages;
+        const { context, examples } = prompt || {};
     
+        if (context) {
+            console.log(`\x1b[36mContext: ${context}\x1b[0m`);
+        }
+
+        if (examples && examples.length) {
+            examples.forEach((example, index) => {
+                console.log(`\x1b[36mExample ${index + 1}: Input: "${example.input.content}", Output: "${example.output.content}"\x1b[0m`);
+            });
+        }
+        
         if (messages && messages.length > 1) {
             messages.forEach((message, index) => {
                 const words = message.content.split(" ");

--- a/graphql/plugins/palmChatPlugin.js
+++ b/graphql/plugins/palmChatPlugin.js
@@ -37,8 +37,9 @@ class PalmChatPlugin extends ModelPlugin {
             }
         });
     
+        // Ensure modifiedMessages has an odd number of messages by removing the earliest message if the length is even
         return {
-            messages: modifiedMessages,
+            messages: (modifiedMessages.length % 2 === 0) ? modifiedMessages.slice(1) : modifiedMessages,
             context,
         };
     }
@@ -79,7 +80,9 @@ class PalmChatPlugin extends ModelPlugin {
         // Define the model's max token length
         const modelTargetTokenLength = this.getModelMaxTokenLength() * this.getPromptTokenRatio();
     
-        let requestMessages = this.convertMessagesToPalm(modelPromptMessages || [{ "author": "user", "content": modelPromptText }]).messages;
+        const palmMessages = this.convertMessagesToPalm(modelPromptMessages || [{ "author": "user", "content": modelPromptText }]);
+        
+        let requestMessages = palmMessages.messages;
 
         // Check if the token length exceeds the model's max token length
         if (tokenLength > modelTargetTokenLength) {
@@ -99,7 +102,7 @@ class PalmChatPlugin extends ModelPlugin {
         const requestParameters = {
             instances: [{
                 context: context,
-                examples: prompt.examples || [],
+                examples: examples,
                 messages: requestMessages,
             }],
             parameters: {
@@ -179,7 +182,7 @@ class PalmChatPlugin extends ModelPlugin {
     
         const instances = data && data.instances;
         const messages = instances && instances[0] && instances[0].messages;
-        const { context, examples } = prompt || {};
+        const { context, examples } = instances && instances [0] || {};
     
         if (context) {
             console.log(`\x1b[36mContext: ${context}\x1b[0m`);

--- a/graphql/plugins/palmChatPlugin.js
+++ b/graphql/plugins/palmChatPlugin.js
@@ -1,0 +1,214 @@
+// palmChatPlugin.js
+import ModelPlugin from './modelPlugin.js';
+import { encode } from 'gpt-3-encoder';
+import HandleBars from '../../lib/handleBars.js';
+import { auth } from 'google-auth-library';
+
+class PalmChatPlugin extends ModelPlugin {
+    constructor(config, pathway) {
+        super(config, pathway);
+    }
+
+    // Convert to PaLM messages array format if necessary
+    convertMessagesToPalm(messages) {
+        let context = '';
+        let modifiedMessages = [];
+        let lastAuthor = '';
+    
+        messages.forEach(message => {
+            const { role, author, content } = message;
+    
+            // Extract system messages into the context string
+            if (role === 'system') {
+                context += (context.length > 0 ? '\n' : '') + content;
+                return;
+            }
+     
+            // Aggregate consecutive author messages, appending the content
+            if ((role === lastAuthor || author === lastAuthor) && modifiedMessages.length > 0) {
+                modifiedMessages[modifiedMessages.length - 1].content += '\n' + content;
+            }
+            // Only push messages with role 'user' or 'assistant' or existing author messages
+            else if (role === 'user' || role === 'assistant' || author) {
+                modifiedMessages.push({
+                    author: author || role,
+                    content,
+                });
+                lastAuthor = author || role;
+            }
+        });
+    
+        return {
+            messages: modifiedMessages,
+            context,
+        };
+    }
+
+    // Handlebars compiler for context (PaLM chat specific)
+    getCompiledContext(text, parameters, context) {
+        const combinedParameters = { ...this.promptParameters, ...parameters };
+        return context ? HandleBars.compile(context)({ ...combinedParameters, text}) : '';
+    }
+
+    // Handlebars compiler for examples (PaLM chat specific)
+    getCompiledExamples(text, parameters, examples = []) {
+        const combinedParameters = { ...this.promptParameters, ...parameters };
+
+        const compileContent = (content) => {
+            const compile = HandleBars.compile(content);
+            return compile({ ...combinedParameters, text });
+        };
+
+        const processExample = (example, key) => {
+            if (example[key]?.content) {
+                return { ...example[key], content: compileContent(example[key].content) };
+            }
+            return { ...example[key] };
+        };
+
+        return examples.map((example) => ({
+            input: example.input ? processExample(example, 'input') : undefined,
+            output: example.output ? processExample(example, 'output') : undefined,
+        }));
+    }
+
+    // Set up parameters specific to the OpenAI Chat API
+    getRequestParameters(text, parameters, prompt) {
+        const { modelPromptText, modelPromptMessages, tokenLength } = this.getCompiledPrompt(text, parameters, prompt);
+        const { stream } = parameters;
+    
+        // Define the model's max token length
+        const modelTargetTokenLength = this.getModelMaxTokenLength() * this.getPromptTokenRatio();
+    
+        let requestMessages = modelPromptMessages || [{ "author": "user", "content": modelPromptText }];
+    
+        // Check if the token length exceeds the model's max token length
+        if (tokenLength > modelTargetTokenLength) {
+            // Remove older messages until the token length is within the model's limit
+            requestMessages = this.truncateMessagesToTargetLength(requestMessages, modelTargetTokenLength);
+        }
+    
+        const palmMessages = this.convertMessagesToPalm(requestMessages);
+
+        requestMessages = palmMessages.messages;
+
+        const context = this.getCompiledContext(text, parameters, prompt.context || palmMessages.context || '');
+        const examples = this.getCompiledExamples(text, parameters, prompt.examples || []);
+
+        const max_tokens = 1024//this.getModelMaxTokenLength() - tokenLength;
+    
+        if (max_tokens < 0) {
+            throw new Error(`Prompt is too long to successfully call the model at ${tokenLength} tokens.  The model will not be called.`);
+        }
+    
+        const requestParameters = {
+            instances: [{
+                context: context,
+                examples: prompt.examples || [],
+                messages: requestMessages,
+            }],
+            parameters: {
+                temperature: this.temperature ?? 0.7,
+                maxOutputTokens: max_tokens,
+                topP: parameters.topP ?? 0.95,
+                topK: parameters.topK ?? 40,
+            }
+        };
+    
+        return requestParameters;
+    }
+
+    // Get the safetyAttributes from the PaLM API Text Completion API response data
+    getSafetyAttributes(data) {
+        const { predictions } = data;
+        if (!predictions || !predictions.length) {
+            return null;
+        }
+
+        // if we got a predictions array back with more than one prediction, return the safetyAttributes of the first prediction
+        if (predictions.length > 1) {
+            return predictions[0].safetyAttributes ?? null;
+        }
+
+        // otherwise, return the safetyAttributes of the content of the first prediction
+        return predictions[0].safetyAttributes ?? null;
+    }
+
+    // Execute the request to the OpenAI Chat API
+    async execute(text, parameters, prompt) {
+        const url = this.requestUrl(text);
+        const requestParameters = this.getRequestParameters(text, parameters, prompt);
+
+        const data = { ...(this.model.params || {}), ...requestParameters };
+        const params = {};
+        const headers = this.model.headers || {};
+        const gcpAuthTokenHelper = this.config.get('gcpAuthTokenHelper');
+        const authToken = await gcpAuthTokenHelper.getAccessToken();
+        headers.Authorization = `Bearer ${authToken}`;
+        return this.executeRequest(url, data, params, headers, prompt);
+    }
+
+    // Parse the response from the PaLM Chat API
+    parseResponse(data) {
+        const { predictions } = data;
+        if (!predictions || !predictions.length) {
+            return null;
+        }
+    
+        // Get the candidates array from the first prediction
+        const { candidates } = predictions[0];
+
+        // if it was blocked, return the blocked message
+        if (predictions[0].safetyAttributes?.blocked) {
+            return 'The response is blocked because the input or response potentially violates Google policies. Try rephrasing the prompt or adjusting the parameter settings. Currently, only English is supported.';
+        }
+
+        if (!candidates || !candidates.length) {
+            return null;
+        }
+    
+        // If we got a candidates array back with more than one candidate, return the whole array
+        if (candidates.length > 1) {
+            return candidates;
+        }
+    
+        // Otherwise, return the content of the first candidate
+        const messageResult = candidates[0].content && candidates[0].content.trim();
+        return messageResult ?? null;
+    }
+
+    // Override the logging function to display the messages and responses
+    logRequestData(data, responseData, prompt) {
+        const separator = `\n=== ${this.pathwayName}.${this.requestCount++} ===\n`;
+        console.log(separator);
+    
+        const instances = data && data.instances;
+        const messages = instances && instances[0] && instances[0].messages;
+    
+        if (messages && messages.length > 1) {
+            messages.forEach((message, index) => {
+                const words = message.content.split(" ");
+                const tokenCount = encode(message.content).length;
+                const preview = words.length < 41 ? message.content : words.slice(0, 20).join(" ") + " ... " + words.slice(-20).join(" ");
+    
+                console.log(`\x1b[36mMessage ${index + 1}: Author: ${message.author}, Tokens: ${tokenCount}, Content: "${preview}"\x1b[0m`);
+            });
+        } else if (messages && messages.length === 1) {
+            console.log(`\x1b[36m${messages[0].content}\x1b[0m`);
+        }
+
+        const safetyAttributes = this.getSafetyAttributes(responseData);
+
+        console.log(`\x1b[34m> ${this.parseResponse(responseData)}\x1b[0m`);
+
+        if (safetyAttributes) {
+            console.log(`\x1b[33mSafety Attributes: ${JSON.stringify(safetyAttributes, null, 2)}\x1b[0m`);
+        }
+    
+        if (prompt && prompt.debugInfo) {
+            prompt.debugInfo += `${separator}${JSON.stringify(data)}`;
+        }
+    }
+}
+
+export default PalmChatPlugin;

--- a/graphql/plugins/palmChatPlugin.js
+++ b/graphql/plugins/palmChatPlugin.js
@@ -2,7 +2,6 @@
 import ModelPlugin from './modelPlugin.js';
 import { encode } from 'gpt-3-encoder';
 import HandleBars from '../../lib/handleBars.js';
-import { auth } from 'google-auth-library';
 
 class PalmChatPlugin extends ModelPlugin {
     constructor(config, pathway) {
@@ -80,17 +79,13 @@ class PalmChatPlugin extends ModelPlugin {
         // Define the model's max token length
         const modelTargetTokenLength = this.getModelMaxTokenLength() * this.getPromptTokenRatio();
     
-        let requestMessages = modelPromptMessages || [{ "author": "user", "content": modelPromptText }];
-    
+        let requestMessages = this.convertMessagesToPalm(modelPromptMessages || [{ "author": "user", "content": modelPromptText }]).messages;
+
         // Check if the token length exceeds the model's max token length
         if (tokenLength > modelTargetTokenLength) {
             // Remove older messages until the token length is within the model's limit
             requestMessages = this.truncateMessagesToTargetLength(requestMessages, modelTargetTokenLength);
         }
-    
-        const palmMessages = this.convertMessagesToPalm(requestMessages);
-
-        requestMessages = palmMessages.messages;
 
         const context = this.getCompiledContext(text, parameters, prompt.context || palmMessages.context || '');
         const examples = this.getCompiledExamples(text, parameters, prompt.examples || []);

--- a/graphql/plugins/palmCompletionPlugin.js
+++ b/graphql/plugins/palmCompletionPlugin.js
@@ -1,0 +1,130 @@
+// palmCompletionPlugin.js
+
+import ModelPlugin from './modelPlugin.js';
+
+// Helper function to truncate the prompt if it is too long
+const truncatePromptIfNecessary = (text, textTokenCount, modelMaxTokenCount, targetTextTokenCount, pathwayResolver) => {
+    const maxAllowedTokens = textTokenCount + ((modelMaxTokenCount - targetTextTokenCount) * 0.5);
+
+    if (textTokenCount > maxAllowedTokens) {
+        pathwayResolver.logWarning(`Prompt is too long at ${textTokenCount} tokens (this target token length for this pathway is ${targetTextTokenCount} tokens because the response is expected to take up the rest of the model's max tokens (${modelMaxTokenCount}). Prompt will be truncated.`);
+        return pathwayResolver.truncate(text, maxAllowedTokens);
+    }
+    return text;
+}
+
+// PalmCompletionPlugin class for handling requests and responses to the PaLM API Text Completion API
+class PalmCompletionPlugin extends ModelPlugin {
+    constructor(config, pathway) {
+        super(config, pathway);
+    }
+
+    // Set up parameters specific to the PaLM API Text Completion API
+    getRequestParameters(text, parameters, prompt, pathwayResolver) {
+        const { modelPromptText, tokenLength } = this.getCompiledPrompt(text, parameters, prompt);
+        const { stream } = parameters;
+        // Define the model's max token length
+        const modelTargetTokenLength = this.getModelMaxTokenLength() * this.getPromptTokenRatio();
+    
+        const truncatedPrompt = truncatePromptIfNecessary(modelPromptText, tokenLength, this.getModelMaxTokenLength(), modelTargetTokenLength, pathwayResolver);
+    
+        const max_tokens = 1024//this.getModelMaxTokenLength() - tokenLength;
+    
+        if (max_tokens < 0) {
+            throw new Error(`Prompt is too long to successfully call the model at ${tokenLength} tokens.  The model will not be called.`);
+        }
+    
+        const requestParameters = {
+            instances: [
+                { prompt: truncatedPrompt }
+            ],
+            parameters: {
+                temperature: this.temperature ?? 0.7,
+                maxOutputTokens: max_tokens,
+                topP: parameters.topP ?? 0.95,
+                topK: parameters.topK ?? 40,
+            }
+        };
+    
+        return requestParameters;
+    }
+
+    // Execute the request to the PaLM API Text Completion API
+    async execute(text, parameters, prompt, pathwayResolver) {
+        const url = this.requestUrl(text);
+        const requestParameters = this.getRequestParameters(text, parameters, prompt, pathwayResolver);
+
+        const data = { ...requestParameters };
+        const params = {};
+        const headers = this.model.headers || {};
+        const gcpAuthTokenHelper = this.config.get('gcpAuthTokenHelper');
+        const authToken = await gcpAuthTokenHelper.getAccessToken();
+        headers.Authorization = `Bearer ${authToken}`;
+        return this.executeRequest(url, data, params, headers, prompt);
+    }
+
+    // Parse the response from the PaLM API Text Completion API
+    parseResponse(data) {
+        const { predictions } = data;
+        if (!predictions || !predictions.length) {
+            return data;
+        }
+
+        // if we got a predictions array back with more than one prediction, return the whole array
+        if (predictions.length > 1) {
+            return predictions;
+        }
+
+        // otherwise, return the content of the first prediction
+        // if it was blocked, return the blocked message
+        if (predictions[0].safetyAttributes?.blocked) {
+            return 'The response is blocked because the input or response potentially violates Google policies. Try rephrasing the prompt or adjusting the parameter settings. Currently, only English is supported.';
+        }
+
+        const contentResult = predictions[0].content && predictions[0].content.trim();
+        return contentResult ?? null;
+    }
+
+    // Get the safetyAttributes from the PaLM API Text Completion API response data
+    getSafetyAttributes(data) {
+        const { predictions } = data;
+        if (!predictions || !predictions.length) {
+            return null;
+        }
+
+        // if we got a predictions array back with more than one prediction, return the safetyAttributes of the first prediction
+        if (predictions.length > 1) {
+            return predictions[0].safetyAttributes ?? null;
+        }
+
+        // otherwise, return the safetyAttributes of the content of the first prediction
+        return predictions[0].safetyAttributes ?? null;
+    }
+
+    // Override the logging function to log the prompt and response
+    logRequestData(data, responseData, prompt) {
+        const separator = `\n=== ${this.pathwayName}.${this.requestCount++} ===\n`;
+        console.log(separator);
+
+        const safetyAttributes = this.getSafetyAttributes(responseData);
+
+        const instances = data && data.instances;
+        const modelInput = instances && instances[0] && instances[0].prompt;
+
+        if (modelInput) {
+            console.log(`\x1b[36m${modelInput}\x1b[0m`);
+        }
+
+        console.log(`\x1b[34m> ${this.parseResponse(responseData)}\x1b[0m`);
+
+        if (safetyAttributes) {
+            console.log(`\x1b[33mSafety Attributes: ${JSON.stringify(safetyAttributes, null, 2)}\x1b[0m`);
+        }
+
+        if (prompt && prompt.debugInfo) {
+            prompt.debugInfo += `${separator}${JSON.stringify(data)}`;
+        }
+    }
+}
+
+export default PalmCompletionPlugin;

--- a/graphql/plugins/palmCompletionPlugin.js
+++ b/graphql/plugins/palmCompletionPlugin.js
@@ -33,6 +33,10 @@ class PalmCompletionPlugin extends ModelPlugin {
         if (max_tokens < 0) {
             throw new Error(`Prompt is too long to successfully call the model at ${tokenLength} tokens.  The model will not be called.`);
         }
+
+        if (!truncatedPrompt) {
+            throw new Error(`Prompt is empty.  The model will not be called.`);
+        }
     
         const requestParameters = {
             instances: [

--- a/graphql/prompt.js
+++ b/graphql/prompt.js
@@ -3,15 +3,21 @@ class Prompt {
         if (typeof params === 'string' || params instanceof String) {
             this.prompt = params;
         } else {
-            const { prompt, saveResultTo, messages } = params;
+            const { prompt, saveResultTo, messages, context, examples } = params;
             this.prompt = prompt;
             this.saveResultTo = saveResultTo;
             this.messages = messages;
+            this.context = context;
+            this.examples = examples;
             this.params = params;
         }
 
-        this.usesTextInput = promptContains('text', this.prompt ? this.prompt : this.messages);
-        this.usesPreviousResult = promptContains('previousResult', this.prompt ? this.prompt : this.messages);
+        this.usesTextInput = promptContains('text', this.prompt ? this.prompt : this.messages) ||
+                             (this.context && promptContains('text', this.context)) ||
+                             (this.examples && promptContains('text', this.examples));
+        this.usesPreviousResult = promptContains('previousResult', this.prompt ? this.prompt : this.messages) ||
+                                   (this.context && promptContains('previousResult', this.context)) ||
+                                   (this.examples && promptContains('previousResult', this.examples));
         this.debugInfo = '';
     }
 }
@@ -23,7 +29,8 @@ function promptContains(variable, prompt) {
     let matches = [];
     let match;
 
-    // if it's an array, it's the messages format
+    // if it's an array, it's either an OpenAI messages array or a PaLM messages
+    // array or a PaLM examples array, all of which have a content property
     if (Array.isArray(prompt)) {
       prompt.forEach(p => {
         // eslint-disable-next-line no-cond-assign

--- a/lib/gcpAuthTokenHelper.js
+++ b/lib/gcpAuthTokenHelper.js
@@ -1,0 +1,37 @@
+import { GoogleAuth } from 'google-auth-library';
+
+class GcpAuthTokenHelper {
+  constructor(config) {
+    const creds = config.gcpServiceAccountKey ? JSON.parse(config.gcpServiceAccountKey) : null;
+    if (!creds) {
+      throw new Error('GCP_SERVICE_ACCOUNT_KEY is missing or undefined');
+    }
+    this.authClient = new GoogleAuth({
+      credentials: creds,
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+    this.token = null;
+    this.expiry = null;
+  }
+
+  async getAccessToken() {
+    if (!this.token || !this.isTokenValid()) {
+      await this.refreshToken();
+    }
+    return this.token;
+  }
+
+  isTokenValid() {
+    // Check if token is still valid with a 5-minute buffer
+    return this.expiry && Date.now() < this.expiry.getTime() - 5 * 60 * 1000;
+  }
+
+  async refreshToken() {
+    const authClient = await this.authClient.getClient();
+    const accessTokenResponse = await authClient.getAccessToken();
+    this.token = accessTokenResponse.token;
+    this.expiry = new Date(accessTokenResponse.expirationTime);
+  }
+}
+
+export default GcpAuthTokenHelper;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "convict": "^6.2.3",
         "express": "^4.18.2",
         "form-data": "^4.0.0",
+        "google-auth-library": "^8.8.0",
         "gpt-3-encoder": "^1.1.4",
         "graphql": "^16.6.0",
         "graphql-subscriptions": "^2.0.0",
@@ -709,6 +710,33 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -912,17 +940,6 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/apollo-server-env": {
@@ -1190,17 +1207,6 @@
       },
       "peerDependencies": {
         "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/argparse": {
@@ -1510,6 +1516,33 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1578,6 +1611,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
       "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg=="
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1904,18 +1942,6 @@
         "node": ">=10.18.0 <11 || >=12.14.0 <13 || >=14"
       }
     },
-    "node_modules/concordance/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/concordance/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -2216,6 +2242,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2859,6 +2893,11 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2902,6 +2941,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -3105,6 +3149,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.0.tgz",
+      "integrity": "sha512-aezGIjb+/VfsJtIcHGcBSerNEDdfdHeMros+RbYbGpmonKWQCOVOes0LVZhn1lDtIgq55qq0HaxymIoae3Fl/A==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.2.0.tgz",
+      "integrity": "sha512-aFhhvvNycky2QyhG+dcfEdHBF0FRbYcf39s6WNHUDysKSrbJ5vuFbjydxBcmewtXeV248GP8dWT3ByPNxsyHCw==",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3248,6 +3318,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.8.0.tgz",
+      "integrity": "sha512-0iJn7IDqObDG5Tu9Tn2WemmJ31ksEa96IyK0J0OZCpTh6CrC6FrattwKX87h3qKVuprCJpdOGKc1Xi8V0kMh8Q==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.2.0",
+        "gtoken": "^6.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/google-p12-pem": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
+      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
+      "dependencies": {
+        "node-forge": "^1.3.1"
+      },
+      "bin": {
+        "gp12-pem": "build/src/bin/gp12-pem.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -3327,6 +3438,19 @@
       },
       "peerDependencies": {
         "graphql": ">=0.11 <=16"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
+      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "dependencies": {
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/handlebars": {
@@ -3441,6 +3565,34 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -3834,6 +3986,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -3956,6 +4119,14 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3998,6 +4169,25 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.2",
@@ -4174,6 +4364,17 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
@@ -4412,6 +4613,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/nofilter": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "convict": "^6.2.3",
     "express": "^4.18.2",
     "form-data": "^4.0.0",
+    "google-auth-library": "^8.8.0",
     "gpt-3-encoder": "^1.1.4",
     "graphql": "^16.6.0",
     "graphql-subscriptions": "^2.0.0",

--- a/pathways/index.js
+++ b/pathways/index.js
@@ -6,7 +6,7 @@ import entities from './entities.js';
 import paraphrase from './paraphrase.js';
 import sentiment from './sentiment.js';
 import summary from './summary.js';
-import test_langchain from './test_langchain.js';
+import test_langchain from './test_langchain.mjs';
 import test_palm_chat from './test_palm_chat.js';
 import transcribe from './transcribe.js';
 import translate from './translate.js';

--- a/pathways/index.js
+++ b/pathways/index.js
@@ -3,10 +3,11 @@ import chat from './chat.js';
 import bias from './bias.js';
 import complete from './complete.js';
 import entities from './entities.js';
-import lc_test from './lc_test.mjs';
 import paraphrase from './paraphrase.js';
 import sentiment from './sentiment.js';
 import summary from './summary.js';
+import test_langchain from './test_langchain.js';
+import test_palm_chat from './test_palm_chat.js';
 import transcribe from './transcribe.js';
 import translate from './translate.js';
 
@@ -16,10 +17,11 @@ export {
     bias,
     complete,
     entities,
-    lc_test,
     paraphrase,
     sentiment,
     summary,
+    test_langchain,
+    test_palm_chat,
     transcribe,
     translate
 };

--- a/pathways/test_langchain.mjs
+++ b/pathways/test_langchain.mjs
@@ -1,4 +1,4 @@
-// lc_test.js
+// test_langchain.mjs
 // LangChain Cortex integration test
 
 // Import required modules

--- a/pathways/test_palm_chat.js
+++ b/pathways/test_palm_chat.js
@@ -1,0 +1,33 @@
+//test_palm_chat.mjs
+// Test for handling of prompts in the PaLM chat format for Cortex
+
+import { Prompt } from '../graphql/prompt.js';
+
+// Description: Have a chat with a bot that uses context to understand the conversation
+export default {
+    prompt:
+        [
+            new Prompt({ 
+                context: "Instructions:\nYou are Archie, an AI entity working for Al Jazeera Media Network. Archie is truthful, kind, helpful, has a strong moral character, and is generally positive without being annoying or repetitive. Your expertise includes journalism, journalistic ethics, researching and composing documents, and technology. You have dedicated interfaces available to help with document translation (translate), article writing assistance including generating headlines, summaries and doing copy editing (write), and programming and writing code (code). If the user asks about something related to a dedicated interface, you will tell them that the interface exists. You know the current date and time - it is {{now}}.",
+                examples: [
+                    { 
+                       input: {"content": "What is your expertise?"},
+                       output: {"content": "I am an expert in journalism and journalistic ethics."}
+                    }],
+                messages: [
+                {"author": "user", "content": "Hi how are you today?"},
+                {"author": "assistant", "content": "I am doing well. How are you?"},
+                {"author": "user", "content": "I am doing well. What is your name?"},
+                {"author": "assistant", "content": "My name is Archie. What is your name?"},
+                {"author": "user", "content": "My name is Bob. What is your expertise?"},
+            ]}),
+        ],
+    inputParameters: {
+        chatHistory: [],
+        contextId: ``,
+    },
+    model: 'palm-chat',
+    //model: 'oai-gpturbo',
+   // model: 'palm-chat',
+    useInputChunking: false,
+}

--- a/pathways/translate.js
+++ b/pathways/translate.js
@@ -15,5 +15,6 @@ export default {
 
     // Set the timeout for the translation process, in seconds.
     timeout: 300,
+    inputChunkSize: 500,
 };
 

--- a/tests/chunking.test.js
+++ b/tests/chunking.test.js
@@ -13,10 +13,11 @@ test.after.always(async () => {
 });
 
 test('chunking test of translate endpoint with huge text', async t => {
-    t.timeout(180000);
+    t.timeout(360000);
     const response = await testServer.executeOperation({
-        query: 'query translate($text: String!) { translate(text: $text) { result } }',
+        query: 'query translate($text: String!, $to: String) { translate(text: $text, to: $to) { result } }',
         variables: {
+            to: 'en',
             text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. In id erat sem. Phasellus ac dapibus purus, in fermentum nunc. Mauris quis rutrum magna. Quisque rutrum, augue vel blandit posuere, augue magna convallis turpis, nec elementum augue mauris sit amet nunc. Aenean sit amet leo est. Nunc ante ex, blandit et felis ut, iaculis lacinia est. Phasellus dictum orci id libero ullamcorper tempor.
 
 Vivamus id pharetra odio.Sed consectetur leo sed tortor dictum venenatis.Donec gravida libero non accumsan suscipit.Donec lectus turpis, ullamcorper eu pulvinar iaculis, ornare ut risus.Phasellus aliquam, turpis quis viverra condimentum, risus est pretium metus, in porta ipsum tortor vitae elit.Pellentesque id finibus erat.In suscipit, sapien non posuere dignissim, augue nisl ultrices tortor, sit amet eleifend nibh elit at risus.
@@ -63,7 +64,7 @@ Mauris diam dolor, maximus et ultrices sed, semper sed felis.Morbi ac eros tellu
 });
 
 test('chunking test of translate endpoint with single long text sentence', async t => {
-    t.timeout(180000);
+    t.timeout(360000);
     const response = await testServer.executeOperation({
         query: 'query translate($text: String!) { translate(text: $text) { result } }',
         variables: {
@@ -76,7 +77,7 @@ test('chunking test of translate endpoint with single long text sentence', async
 });
 
 test('chunking test of translate endpoint with two long text sentence', async t => {
-    t.timeout(180000);
+    t.timeout(360000);
     const response = await testServer.executeOperation({
         query: 'query translate($text: String!) { translate(text: $text) { result } }',
         variables: {
@@ -89,10 +90,11 @@ test('chunking test of translate endpoint with two long text sentence', async t 
 });
 
 test('chunking test...', async t => {
-    t.timeout(180000);
+    t.timeout(360000);
     const response = await testServer.executeOperation({
-        query: 'query translate($text: String!) { translate(text: $text) { result } }',
+        query: 'query translate($text: String!, $to: String) { translate(text: $text, to: $to) { result } }',
         variables: {
+            to: 'en',
             text: `
             صعدت روسيا هجماتها في أنحاء أوكرانيا، بعد يوم من إعلان الغرب مدّ كييف بدبابات قتالية، واستهدفت عشرات الصواريخ والمسيّرات الروسية العاصمة الأوكرانية ومدنا في الجنوب والشرق، واعتبر الكرملين أن الدبابات لن تغيّر من طبيعة المعركة، في حين أعلنت وزارة الدفاع الأوكرانية أن هناك تحضيرات قتالية روسية انطلاقا من القرم.
 

--- a/tests/modelPlugin.test.js
+++ b/tests/modelPlugin.test.js
@@ -79,19 +79,7 @@ test('requestUrl', (t) => {
     t.is(modelPlugin.requestUrl(), expectedUrl, 'requestUrl should return the correct URL');
 });
 
-test('parseResponse - single choice', (t) => {
-    const { modelPlugin } = t.context;
-    const singleChoiceResponse = {
-        choices: [{
-            text: '42'
-        }]
-    };
-
-    const result = modelPlugin.parseResponse(singleChoiceResponse);
-    t.is(result, '42', 'parseResponse should return the correct value for a single choice response');
-});
-
-test('parseResponse - multiple choices', (t) => {
+test('default parseResponse', (t) => {
     const { modelPlugin } = t.context;
     const multipleChoicesResponse = {
         choices: [
@@ -101,7 +89,7 @@ test('parseResponse - multiple choices', (t) => {
     };
 
     const result = modelPlugin.parseResponse(multipleChoicesResponse);
-    t.deepEqual(result, multipleChoicesResponse.choices, 'parseResponse should return the choices array for multiple choices response');
+    t.deepEqual(result, multipleChoicesResponse, 'default parseResponse should return the entire multiple choices response object');
 });
 
 test('truncateMessagesToTargetLength', (t) => {

--- a/tests/openAiChatPlugin.test.js
+++ b/tests/openAiChatPlugin.test.js
@@ -1,0 +1,125 @@
+import test from 'ava';
+import OpenAIChatPlugin from '../graphql/plugins/openAiChatPlugin.js';
+import { mockConfig, mockPathwayString, mockPathwayFunction, mockPathwayMessages } from './mocks.js';
+
+// Test the constructor
+test('constructor', (t) => {
+    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    t.is(plugin.config, mockConfig);
+    t.is(plugin.pathwayPrompt, mockPathwayString.prompt);
+});
+
+// Test the convertPalmToOpenAIMessages function
+test('convertPalmToOpenAIMessages', (t) => {
+    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const context = 'This is a test context.';
+    const examples = [
+        {
+            input: { author: 'user', content: 'Hello' },
+            output: { author: 'assistant', content: 'Hi there!' },
+        },
+    ];
+    const messages = [
+        { author: 'user', content: 'How are you?' },
+        { author: 'assistant', content: 'I am doing well, thank you!' },
+    ];
+    const result = plugin.convertPalmToOpenAIMessages(context, examples, messages);
+    t.deepEqual(result, [
+        { role: 'system', content: 'This is a test context.' },
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+        { role: 'user', content: 'How are you?' },
+        { role: 'assistant', content: 'I am doing well, thank you!' },
+    ]);
+});
+
+// Test the getRequestParameters function
+test('getRequestParameters', async (t) => {
+    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const text = 'Help me';
+    const parameters = { name: 'John', age: 30 };
+    const prompt = mockPathwayString.prompt;
+    const result = await plugin.getRequestParameters(text, parameters, prompt);
+    t.deepEqual(result, {
+        messages: [
+            { role: 'user', content: 'User: Help me\nAssistant: Please help John who is 30 years old.' },
+        ],
+        temperature: 0.7,
+    });
+});
+
+// Test the execute function
+test('execute', async (t) => {
+    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const text = 'Help me';
+    const parameters = { name: 'John', age: 30 };
+    const prompt = mockPathwayString.prompt;
+
+    // Mock the executeRequest function
+    plugin.executeRequest = () => {
+        return {
+            choices: [
+                {
+                    message: {
+                        content: 'Sure, I can help John who is 30 years old.',
+                    },
+                },
+            ],
+        };
+    };
+
+    const result = await plugin.execute(text, parameters, prompt);
+    t.deepEqual(result, {
+        choices: [
+            {
+                message: {
+                    content: 'Sure, I can help John who is 30 years old.',
+                },
+            },
+        ],
+    });
+});
+
+// Test the parseResponse function
+test('parseResponse', (t) => {
+    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const data = {
+        choices: [
+            {
+                message: {
+                    content: 'Sure, I can help John who is 30 years old.',
+                },
+            },
+        ],
+    };
+    const result = plugin.parseResponse(data);
+    t.is(result, 'Sure, I can help John who is 30 years old.');
+});
+
+// Test the logRequestData function
+test('logRequestData', (t) => {
+    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const data = {
+        messages: [
+            { role: 'user', content: 'User: Help me\nAssistant: Please help John who is 30 years old.' },
+        ],
+    };
+    const responseData = {
+        choices: [
+            {
+                message: {
+                    content: 'Sure, I can help John who is 30 years old.',
+                },
+            },
+        ],
+    };
+    const prompt = mockPathwayString.prompt;
+
+    // Mock console.log function
+    const originalConsoleLog = console.log;
+    console.log = () => {};
+
+    t.notThrows(() => plugin.logRequestData(data, responseData, prompt));
+
+    console.log = originalConsoleLog;
+});

--- a/tests/palmChatPlugin.test.js
+++ b/tests/palmChatPlugin.test.js
@@ -1,0 +1,263 @@
+// test_palmChatPlugin.js
+import test from 'ava';
+import PalmChatPlugin from '../graphql/plugins/palmChatPlugin.js';
+import { mockConfig } from './mocks.js';
+
+test.beforeEach((t) => {
+  const pathway = 'testPathway';
+  const palmChatPlugin = new PalmChatPlugin(mockConfig, pathway);
+  t.context = { palmChatPlugin };
+});
+
+test('convertMessagesToPalm', (t) => {
+  const { palmChatPlugin } = t.context;
+  const messages = [
+    { role: 'system', content: 'System Message' },
+    { role: 'user', content: 'User Message' },
+    { role: 'user', content: 'User Message 2'},
+    { role: 'assistant', content: 'Assistant Message' },
+  ];
+
+  const expectedResult = {
+    messages: [
+      { author: 'user', content: 'User Message\nUser Message 2' },
+      { author: 'assistant', content: 'Assistant Message' },
+    ],
+    context: 'System Message',
+  };
+
+  t.deepEqual(palmChatPlugin.convertMessagesToPalm(messages), expectedResult);
+});
+
+test('convertMessagesToPalm - already PaLM format', (t) => {
+    const { palmChatPlugin } = t.context;
+    const messages = [
+      { author: 'user', content: 'User Message' },
+      { author: 'user', content: 'User Message 2'},
+      { author: 'assistant', content: 'Assistant Message' },
+    ];
+  
+    const expectedResult = {
+      messages: [
+        { author: 'user', content: 'User Message\nUser Message 2' },
+        { author: 'assistant', content: 'Assistant Message' },
+      ],
+      context: '',
+    };
+  
+    t.deepEqual(palmChatPlugin.convertMessagesToPalm(messages), expectedResult);
+  });
+
+  test('convertMessagesToPalm - empty string roles', (t) => {
+    const { palmChatPlugin } = t.context;
+    const messages = [
+      { role: '', content: 'Empty role message' },
+      { role: 'user', content: 'User Message' },
+      { role: 'assistant', content: 'Assistant Message' },
+    ];
+  
+    const expectedResult = {
+      messages: [
+        { author: 'user', content: 'User Message' },
+        { author: 'assistant', content: 'Assistant Message' },
+      ],
+      context: '',
+    };
+  
+    t.deepEqual(palmChatPlugin.convertMessagesToPalm(messages), expectedResult);
+  });
+  
+  test('convertMessagesToPalm - consecutive system messages', (t) => {
+    const { palmChatPlugin } = t.context;
+    const messages = [
+      { role: 'system', content: 'System Message 1' },
+      { role: 'system', content: 'System Message 2' },
+      { role: 'user', content: 'User Message' },
+      { role: 'assistant', content: 'Assistant Message' },
+    ];
+  
+    const expectedResult = {
+      messages: [
+        { author: 'user', content: 'User Message' },
+        { author: 'assistant', content: 'Assistant Message' },
+      ],
+      context: 'System Message 1\nSystem Message 2',
+    };
+  
+    t.deepEqual(palmChatPlugin.convertMessagesToPalm(messages), expectedResult);
+  });
+  
+  test('convertMessagesToPalm - multiple authors', (t) => {
+    const { palmChatPlugin } = t.context;
+    const messages = [
+      { role: 'system', content: 'System Message' },
+      { author: 'user1', content: 'User1 Message' },
+      { author: 'user1', content: 'User1 Message 2' },
+      { author: 'user2', content: 'User2 Message' },
+      { author: 'assistant', content: 'Assistant Message' },
+    ];
+  
+    const expectedResult = {
+      messages: [
+        { author: 'user1', content: 'User1 Message\nUser1 Message 2' },
+        { author: 'user2', content: 'User2 Message' },
+        { author: 'assistant', content: 'Assistant Message' },
+      ],
+      context: 'System Message',
+    };
+  
+    t.deepEqual(palmChatPlugin.convertMessagesToPalm(messages), expectedResult);
+  });
+  
+  test('convertMessagesToPalm - no messages', (t) => {
+    const { palmChatPlugin } = t.context;
+    const messages = [];
+  
+    const expectedResult = {
+      messages: [],
+      context: '',
+    };
+  
+    t.deepEqual(palmChatPlugin.convertMessagesToPalm(messages), expectedResult);
+  });
+  
+  test('convertMessagesToPalm - only system messages', (t) => {
+    const { palmChatPlugin } = t.context;
+    const messages = [
+      { role: 'system', content: 'System Message 1' },
+      { role: 'system', content: 'System Message 2' },
+    ];
+  
+    const expectedResult = {
+      messages: [],
+      context: 'System Message 1\nSystem Message 2',
+    };
+  
+    t.deepEqual(palmChatPlugin.convertMessagesToPalm(messages), expectedResult);
+  });
+
+test('getCompiledContext', (t) => {
+  const { palmChatPlugin } = t.context;
+  const text = 'Hello';
+  const parameters = { name: 'John' };
+  const context = '{{text}} from {{name}}';
+
+  const expectedResult = 'Hello from John';
+
+  t.is(palmChatPlugin.getCompiledContext(text, parameters, context), expectedResult);
+});
+
+test('getCompiledExamples', (t) => {
+  const { palmChatPlugin } = t.context;
+  const text = 'Greetings';
+  const parameters = { name: 'Jane' };
+  const examples = [
+    {
+      input: { content: 'Input: {{text}} from {{name}}' },
+      output: { content: 'Output: {{text}} to {{name}}' },
+    },
+  ];
+
+  const expectedResult = [
+    {
+      input: { content: 'Input: Greetings from Jane' },
+      output: { content: 'Output: Greetings to Jane' },
+    },
+  ];
+
+  t.deepEqual(palmChatPlugin.getCompiledExamples(text, parameters, examples), expectedResult);
+});
+
+test('getRequestParameters', (t) => {
+  const { palmChatPlugin } = t.context;
+  const text = 'Hello';
+  const parameters = { stream: false, name: 'John'};
+  const messages = [
+    { role: 'system', content: 'System Message' },
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: 'What can I do for you?' },
+  ];
+  const prompt = { context: '{{text}} from {{name}}', examples: [], messages };
+
+  const requestParameters = palmChatPlugin.getRequestParameters(text, parameters, prompt);
+  const requestMessages = requestParameters.instances[0].messages;
+
+  t.is(requestMessages[0].author, 'user');
+  t.is(requestMessages[0].content, 'Hello');
+});
+
+test('getSafetyAttributes', (t) => {
+  const { palmChatPlugin } = t.context;
+  const responseData = {
+    predictions: [
+      {
+        safetyAttributes: {
+          blocked: false,
+        },
+      },
+    ],
+  };
+
+  const expectedResult = {
+    blocked: false,
+  };
+
+  t.deepEqual(palmChatPlugin.getSafetyAttributes(responseData), expectedResult);
+});
+
+test('parseResponse', (t) => {
+  const { palmChatPlugin } = t.context;
+  const responseData = {
+    predictions: [
+      {
+        candidates: [
+          {
+            content: 'Hello, how can I help you today?',
+          },
+        ],
+      },
+    ],
+  };
+
+  const expectedResult = 'Hello, how can I help you today?';
+
+  t.is(palmChatPlugin.parseResponse(responseData), expectedResult);
+});
+
+test('logRequestData', (t) => {
+  const { palmChatPlugin } = t.context;
+  const data = {
+    instances: [
+      {
+        messages: [
+          { author: 'user', content: 'Hello' },
+          { author: 'assistant', content: 'How can I help you?' },
+        ],
+      },
+    ],
+  };
+  const responseData = {
+    predictions: [
+      {
+        candidates: [
+          {
+            content: 'Hello, how can I help you today?',
+          },
+        ],
+      },
+    ],
+  };
+  const prompt = { debugInfo: '' };
+
+  const consoleLog = console.log;
+  let logOutput = '';
+  console.log = (msg) => (logOutput += msg + '\n');
+
+  palmChatPlugin.logRequestData(data, responseData, prompt);
+
+  console.log = consoleLog;
+
+  t.true(logOutput.includes('Message 1:'));
+  t.true(logOutput.includes('Message 2:'));
+  t.true(logOutput.includes('> Hello, how can I help you today?'));
+});

--- a/tests/palmCompletionPlugin.test.js
+++ b/tests/palmCompletionPlugin.test.js
@@ -1,0 +1,87 @@
+// palmCompletionPlugin.test.js
+
+import test from 'ava';
+import PalmCompletionPlugin from '../graphql/plugins/palmCompletionPlugin.js';
+import { mockConfig } from './mocks.js';
+
+test.beforeEach((t) => {
+  const pathway = 'testPathway';
+  const palmCompletionPlugin = new PalmCompletionPlugin(mockConfig, pathway);
+  t.context = { palmCompletionPlugin };
+});
+
+test('getRequestParameters', (t) => {
+  const { palmCompletionPlugin } = t.context;
+  const text = 'Hello';
+  const parameters = { stream: false, name: 'John' };
+  const prompt = {prompt:'{{text}} from {{name}}'};
+
+  const requestParameters = palmCompletionPlugin.getRequestParameters(text, parameters, prompt);
+  const requestPrompt = requestParameters.instances[0].prompt;
+
+  t.is(requestPrompt, 'Hello from John');
+});
+
+test('parseResponse', (t) => {
+  const { palmCompletionPlugin } = t.context;
+  const responseData = {
+    predictions: [
+      {
+        content: 'Hello, how can I help you today?',
+      },
+    ],
+  };
+
+  const expectedResult = 'Hello, how can I help you today?';
+
+  t.is(palmCompletionPlugin.parseResponse(responseData), expectedResult);
+});
+
+test('getSafetyAttributes', (t) => {
+  const { palmCompletionPlugin } = t.context;
+  const responseData = {
+    predictions: [
+      {
+        safetyAttributes: {
+          blocked: false,
+        },
+      },
+    ],
+  };
+
+  const expectedResult = {
+    blocked: false,
+  };
+
+  t.deepEqual(palmCompletionPlugin.getSafetyAttributes(responseData), expectedResult);
+});
+
+test('logRequestData', (t) => {
+  const { palmCompletionPlugin } = t.context;
+  const data = {
+    instances: [
+      {
+        prompt: 'Hello, how can I help you?',
+      },
+    ],
+  };
+  const responseData = {
+    predictions: [
+      {
+        content: 'Hello, how can I help you today?',
+      },
+    ],
+  };
+  const prompt = { debugInfo: '' };
+
+  const consoleLog = console.log;
+  let logOutput = '';
+  console.log = (msg) => (logOutput += msg + '\n');
+
+  palmCompletionPlugin.logRequestData(data, responseData, prompt);
+
+  console.log = consoleLog;
+
+  t.true(logOutput.includes('Hello, how can I help you?'));
+  t.true(logOutput.includes('> Hello, how can I help you today?'));
+});


### PR DESCRIPTION
This PR adds plugins for PaLM chat and text models as well as refactoring some previously common code out of modelPlugin.  Also added the ability for bidirectional prompt conversion between OpenAI and PaLM API formats, so prompts can be specified in either and work in either.  Added basic unit tests for new code.