### PR TITLE
typeDef generator should detect string arrays as potential pathway inputs

### DIFF
--- a/server/typeDef.js
+++ b/server/typeDef.js
@@ -11,7 +11,12 @@ const getGraphQlType = (value) => {
       break;
     case 'object':
       if (Array.isArray(value)) {
-        return {type: '[Message]', defaultValue: '[]'};
+        if (value.length > 0 && typeof(value[0]) === 'string') {
+          return {type: '[String]', defaultValue: '[]'};
+        }
+        else {
+          return {type: '[Message]', defaultValue: '[]'};
+        }
       } else {
         return {type: `[${value.objName}]`, defaultValue: 'null'};
       }


### PR DESCRIPTION
When an array is defined as an input parameter to a pathway, the default assumption is that it is a message. For one of my custom pathways, I needed a string array as an input.

So I ended up defining it as:
```
inputParameters: {
   foo: ''
   bar: ['']
}
```

With this code update, the empty string in `bar` is detected as a string and cortex builds the pathway with the correct GraphQL signature.