### PR TITLE
Making sure error makes it back to client instead of killing server

### DIFF
--- a/server/plugins/openAiWhisperPlugin.js
+++ b/server/plugins/openAiWhisperPlugin.js
@@ -75,7 +75,7 @@ const downloadFile = async (fileUrl) => {
             fs.unlink(localFilePath, () => {
                 reject(error);
             });
-            throw error;
+            //throw error;
         }
     });
 };


### PR DESCRIPTION
The extra throw was stopping server execution and the client didn't have the opportunity to see the error.