### PR TITLE
Allow model to be passed as input parameter

### DIFF
--- a/server/pathwayPrompter.js
+++ b/server/pathwayPrompter.js
@@ -9,37 +9,34 @@ import PalmCompletionPlugin from './plugins/palmCompletionPlugin.js';
 import PalmCodeCompletionPlugin from './plugins/palmCodeCompletionPlugin.js';
 
 class PathwayPrompter {
-    constructor(pathwayResolver) {
-
-        this.pathwayResolver = pathwayResolver;
-        const { model } = pathwayResolver;
+    constructor(config, pathway, modelName, model) {
         
         let plugin;
 
         switch (model.type) {
             case 'OPENAI-CHAT':
-                plugin = new OpenAIChatPlugin(this.pathwayResolver);
+                plugin = new OpenAIChatPlugin(config, pathway, modelName, model);
                 break;
             case 'AZURE-TRANSLATE':
-                plugin = new AzureTranslatePlugin(this.pathwayResolver);
+                plugin = new AzureTranslatePlugin(config, pathway, modelName, model);
                 break;
             case 'OPENAI-COMPLETION':
-                plugin = new OpenAICompletionPlugin(this.pathwayResolver);
+                plugin = new OpenAICompletionPlugin(config, pathway, modelName, model);
                 break;
             case 'OPENAI-WHISPER':
-                plugin = new OpenAIWhisperPlugin(this.pathwayResolver);
+                plugin = new OpenAIWhisperPlugin(config, pathway, modelName, model);
                 break;
             case 'LOCAL-CPP-MODEL':
-                plugin = new LocalModelPlugin(this.pathwayResolver);
+                plugin = new LocalModelPlugin(config, pathway, modelName, model);
                 break;
             case 'PALM-CHAT':
-                plugin = new PalmChatPlugin(this.pathwayResolver);
+                plugin = new PalmChatPlugin(config, pathway, modelName, model);
                 break;
             case 'PALM-COMPLETION':
-                plugin = new PalmCompletionPlugin(this.pathwayResolver);
+                plugin = new PalmCompletionPlugin(config, pathway, modelName, model);
                 break;
             case 'PALM-CODE-COMPLETION':
-                plugin = new PalmCodeCompletionPlugin(this.pathwayResolver);
+                plugin = new PalmCodeCompletionPlugin(config, pathway, modelName, model);
                 break;
             default:
                 throw new Error(`Unsupported model type: ${model.type}`);

--- a/server/pathwayPrompter.js
+++ b/server/pathwayPrompter.js
@@ -9,41 +9,37 @@ import PalmCompletionPlugin from './plugins/palmCompletionPlugin.js';
 import PalmCodeCompletionPlugin from './plugins/palmCodeCompletionPlugin.js';
 
 class PathwayPrompter {
-    constructor({ config, pathway }) {
+    constructor(pathwayResolver) {
 
-        const modelName = pathway.model || config.get('defaultModelName');
-        const model = config.get('models')[modelName];
-
-        if (!model) {
-            throw new Error(`Model ${modelName} not found in config`);
-        }
-
+        this.pathwayResolver = pathwayResolver;
+        const { model } = pathwayResolver;
+        
         let plugin;
 
         switch (model.type) {
             case 'OPENAI-CHAT':
-                plugin = new OpenAIChatPlugin(config, pathway);
+                plugin = new OpenAIChatPlugin(this.pathwayResolver);
                 break;
             case 'AZURE-TRANSLATE':
-                plugin = new AzureTranslatePlugin(config, pathway);
+                plugin = new AzureTranslatePlugin(this.pathwayResolver);
                 break;
             case 'OPENAI-COMPLETION':
-                plugin = new OpenAICompletionPlugin(config, pathway);
+                plugin = new OpenAICompletionPlugin(this.pathwayResolver);
                 break;
             case 'OPENAI-WHISPER':
-                plugin = new OpenAIWhisperPlugin(config, pathway);
+                plugin = new OpenAIWhisperPlugin(this.pathwayResolver);
                 break;
             case 'LOCAL-CPP-MODEL':
-                plugin = new LocalModelPlugin(config, pathway);
+                plugin = new LocalModelPlugin(this.pathwayResolver);
                 break;
             case 'PALM-CHAT':
-                plugin = new PalmChatPlugin(config, pathway);
+                plugin = new PalmChatPlugin(this.pathwayResolver);
                 break;
             case 'PALM-COMPLETION':
-                plugin = new PalmCompletionPlugin(config, pathway);
+                plugin = new PalmCompletionPlugin(this.pathwayResolver);
                 break;
             case 'PALM-CODE-COMPLETION':
-                plugin = new PalmCodeCompletionPlugin(config, pathway);
+                plugin = new PalmCodeCompletionPlugin(this.pathwayResolver);
                 break;
             default:
                 throw new Error(`Unsupported model type: ${model.type}`);

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -44,7 +44,7 @@ class PathwayResolver {
 
         this.previousResult = '';
         this.prompts = [];
-        this.pathwayPrompter = new PathwayPrompter(this);
+        this.pathwayPrompter = new PathwayPrompter(this.config, this.pathway, this.modelName, this.model);
 
         Object.defineProperty(this, 'pathwayPrompt', {
             get() {

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -20,9 +20,24 @@ class PathwayResolver {
         this.warnings = [];
         this.requestId = uuidv4();
         this.responseParser = new PathwayResponseParser(pathway);
-        this.pathwayPrompter = new PathwayPrompter({ config, pathway });
+        this.modelName = [
+            pathway.model,
+            args?.model,
+            config.get('defaultModelName')
+            ].find(modelName => modelName && config.get('models').hasOwnProperty(modelName));
+        this.model = config.get('models')[this.modelName];
+
+        if (!this.model) {
+            throw new Error(`Model ${this.modelName} not found in config`);
+        }
+
+        if (this.modelName !== (pathway.model || args?.model)) {
+            this.logWarning(`Model ${pathway.model || args?.model} not found in config, using ${this.modelName} instead.`);
+        }
+
         this.previousResult = '';
         this.prompts = [];
+        this.pathwayPrompter = new PathwayPrompter(this);
 
         Object.defineProperty(this, 'pathwayPrompt', {
             get() {

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -78,37 +78,41 @@ class PathwayResolver {
                 }
             });
         } else { // stream
-            const incomingMessage = Array.isArray(responseData) && responseData.length > 0 ? responseData[0] : responseData;
-            incomingMessage.on('data', data => {
-                const events = data.toString().split('\n');
-        
-                events.forEach(event => {
-                    if (event.trim() === '') return; // Skip empty lines
-        
-                    const message = event.replace(/^data: /, '');
-                    
-                    //console.log(`====================================`);
-                    //console.log(`STREAM EVENT: ${event}`);
-                    //console.log(`MESSAGE: ${message}`);
-        
-                    const requestProgress = {
-                        requestId: this.requestId,
-                        data: message,
-                    }
-        
-                    if (message.trim() === '[DONE]') {
-                        requestProgress.progress = 1;
-                    }
-        
-                    try {
-                        pubsub.publish('REQUEST_PROGRESS', {
-                            requestProgress: requestProgress
-                        });
-                    } catch (error) {
-                        console.error('Could not JSON parse stream message', message, error);
-                    }
+            try {
+                const incomingMessage = Array.isArray(responseData) && responseData.length > 0 ? responseData[0] : responseData;
+                incomingMessage.on('data', data => {
+                    const events = data.toString().split('\n');
+            
+                    events.forEach(event => {
+                        if (event.trim() === '') return; // Skip empty lines
+            
+                        const message = event.replace(/^data: /, '');
+                        
+                        //console.log(`====================================`);
+                        //console.log(`STREAM EVENT: ${event}`);
+                        //console.log(`MESSAGE: ${message}`);
+            
+                        const requestProgress = {
+                            requestId: this.requestId,
+                            data: message,
+                        }
+            
+                        if (message.trim() === '[DONE]') {
+                            requestProgress.progress = 1;
+                        }
+            
+                        try {
+                            pubsub.publish('REQUEST_PROGRESS', {
+                                requestProgress: requestProgress
+                            });
+                        } catch (error) {
+                            console.error('Could not JSON parse stream message', message, error);
+                        }
+                    });
                 });
-            });
+            } catch (error) {
+                console.error('Could not subscribe to stream', error);
+            }
         }
     }
 

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -32,7 +32,11 @@ class PathwayResolver {
         }
 
         if (this.modelName !== (pathway.model || args?.model)) {
-            this.logWarning(`Model ${pathway.model || args?.model} not found in config, using ${this.modelName} instead.`);
+            if (pathway.model || args?.model) {
+                this.logWarning(`Specified model ${pathway.model || args?.model} not found in config, using ${this.modelName} instead.`);
+            } else {
+                this.logWarning(`No model specified in the pathway, using ${this.modelName}.`);
+            }
         }
 
         this.previousResult = '';

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -23,6 +23,7 @@ class PathwayResolver {
         this.modelName = [
             pathway.model,
             args?.model,
+            pathway.inputParameters?.model,
             config.get('defaultModelName')
             ].find(modelName => modelName && config.get('models').hasOwnProperty(modelName));
         this.model = config.get('models')[this.modelName];
@@ -31,9 +32,11 @@ class PathwayResolver {
             throw new Error(`Model ${this.modelName} not found in config`);
         }
 
-        if (this.modelName !== (pathway.model || args?.model)) {
-            if (pathway.model || args?.model) {
-                this.logWarning(`Specified model ${pathway.model || args?.model} not found in config, using ${this.modelName} instead.`);
+        const specifiedModelName = pathway.model || args?.model || pathway.inputParameters?.model;
+
+        if (this.modelName !== (specifiedModelName)) {
+            if (specifiedModelName) {
+                this.logWarning(`Specified model ${specifiedModelName} not found in config, using ${this.modelName} instead.`);
             } else {
                 this.logWarning(`No model specified in the pathway, using ${this.modelName}.`);
             }

--- a/server/plugins/azureTranslatePlugin.js
+++ b/server/plugins/azureTranslatePlugin.js
@@ -2,8 +2,8 @@
 import ModelPlugin from './modelPlugin.js';
 
 class AzureTranslatePlugin extends ModelPlugin {
-    constructor(pathwayResolver) {
-        super(pathwayResolver);
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
     }
     
     // Set up parameters specific to the Azure Translate API

--- a/server/plugins/azureTranslatePlugin.js
+++ b/server/plugins/azureTranslatePlugin.js
@@ -2,8 +2,8 @@
 import ModelPlugin from './modelPlugin.js';
 
 class AzureTranslatePlugin extends ModelPlugin {
-    constructor(config, pathway) {
-        super(config, pathway);
+    constructor(pathwayResolver) {
+        super(pathwayResolver);
     }
     
     // Set up parameters specific to the Azure Translate API

--- a/server/plugins/localModelPlugin.js
+++ b/server/plugins/localModelPlugin.js
@@ -4,8 +4,8 @@ import { execFileSync } from 'child_process';
 import { encode } from 'gpt-3-encoder';
 
 class LocalModelPlugin extends ModelPlugin {
-    constructor(config, pathway) {
-        super(config, pathway);
+    constructor(pathwayResolver) {
+        super(pathwayResolver);
     }
 
     // if the input starts with a chatML response, just return that

--- a/server/plugins/localModelPlugin.js
+++ b/server/plugins/localModelPlugin.js
@@ -4,8 +4,8 @@ import { execFileSync } from 'child_process';
 import { encode } from 'gpt-3-encoder';
 
 class LocalModelPlugin extends ModelPlugin {
-    constructor(pathwayResolver) {
-        super(pathwayResolver);
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
     }
 
     // if the input starts with a chatML response, just return that

--- a/server/plugins/modelPlugin.js
+++ b/server/plugins/modelPlugin.js
@@ -10,8 +10,7 @@ const DEFAULT_MAX_RETURN_TOKENS = 256;
 const DEFAULT_PROMPT_TOKEN_RATIO = 0.5;
 
 class ModelPlugin {
-    constructor(pathwayResolver) {
-        const { config, pathway, modelName, model } = pathwayResolver;
+    constructor(config, pathway, modelName, model) {
         this.modelName = modelName;
         this.model = model;
         this.config = config;

--- a/server/plugins/modelPlugin.js
+++ b/server/plugins/modelPlugin.js
@@ -10,16 +10,10 @@ const DEFAULT_MAX_RETURN_TOKENS = 256;
 const DEFAULT_PROMPT_TOKEN_RATIO = 0.5;
 
 class ModelPlugin {
-    constructor(config, pathway) {
-        // If the pathway specifies a model, use that, otherwise use the default
-        this.modelName = pathway.model || config.get('defaultModelName');
-        // Get the model from the config
-        this.model = config.get('models')[this.modelName];
-        // If the model doesn't exist, throw an exception
-        if (!this.model) {
-            throw new Error(`Model ${this.modelName} not found in config`);
-        }
-
+    constructor(pathwayResolver) {
+        const { config, pathway, modelName, model } = pathwayResolver;
+        this.modelName = modelName;
+        this.model = model;
         this.config = config;
         this.environmentVariables = config.getEnv();
         this.temperature = pathway.temperature;

--- a/server/plugins/openAiChatPlugin.js
+++ b/server/plugins/openAiChatPlugin.js
@@ -3,8 +3,8 @@ import ModelPlugin from './modelPlugin.js';
 import { encode } from 'gpt-3-encoder';
 
 class OpenAIChatPlugin extends ModelPlugin {
-    constructor(config, pathway) {
-        super(config, pathway);
+    constructor(pathwayResolver) {
+        super(pathwayResolver);
     }
 
     // convert to OpenAI messages array format if necessary

--- a/server/plugins/openAiChatPlugin.js
+++ b/server/plugins/openAiChatPlugin.js
@@ -3,8 +3,8 @@ import ModelPlugin from './modelPlugin.js';
 import { encode } from 'gpt-3-encoder';
 
 class OpenAIChatPlugin extends ModelPlugin {
-    constructor(pathwayResolver) {
-        super(pathwayResolver);
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
     }
 
     // convert to OpenAI messages array format if necessary

--- a/server/plugins/openAiCompletionPlugin.js
+++ b/server/plugins/openAiCompletionPlugin.js
@@ -15,8 +15,8 @@ const truncatePromptIfNecessary = (text, textTokenCount, modelMaxTokenCount, tar
 }
 
 class OpenAICompletionPlugin extends ModelPlugin {
-    constructor(pathwayResolver) {
-        super(pathwayResolver);
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
     }
 
     // Set up parameters specific to the OpenAI Completion API

--- a/server/plugins/openAiCompletionPlugin.js
+++ b/server/plugins/openAiCompletionPlugin.js
@@ -15,8 +15,8 @@ const truncatePromptIfNecessary = (text, textTokenCount, modelMaxTokenCount, tar
 }
 
 class OpenAICompletionPlugin extends ModelPlugin {
-    constructor(config, pathway) {
-        super(config, pathway);
+    constructor(pathwayResolver) {
+        super(pathwayResolver);
     }
 
     // Set up parameters specific to the OpenAI Completion API

--- a/server/plugins/openAiWhisperPlugin.js
+++ b/server/plugins/openAiWhisperPlugin.js
@@ -81,8 +81,8 @@ const downloadFile = async (fileUrl) => {
 };
 
 class OpenAIWhisperPlugin extends ModelPlugin {
-    constructor(config, pathway) {
-        super(config, pathway);
+    constructor(pathwayResolver) {
+        super(pathwayResolver);
     }
 
     async getMediaChunks(file, requestId) {

--- a/server/plugins/openAiWhisperPlugin.js
+++ b/server/plugins/openAiWhisperPlugin.js
@@ -81,8 +81,8 @@ const downloadFile = async (fileUrl) => {
 };
 
 class OpenAIWhisperPlugin extends ModelPlugin {
-    constructor(pathwayResolver) {
-        super(pathwayResolver);
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
     }
 
     async getMediaChunks(file, requestId) {

--- a/server/plugins/palmChatPlugin.js
+++ b/server/plugins/palmChatPlugin.js
@@ -4,8 +4,8 @@ import { encode } from 'gpt-3-encoder';
 import HandleBars from '../../lib/handleBars.js';
 
 class PalmChatPlugin extends ModelPlugin {
-    constructor(config, pathway) {
-        super(config, pathway);
+    constructor(pathwayResolver) {
+        super(pathwayResolver);
     }
 
     // Convert to PaLM messages array format if necessary

--- a/server/plugins/palmChatPlugin.js
+++ b/server/plugins/palmChatPlugin.js
@@ -4,8 +4,8 @@ import { encode } from 'gpt-3-encoder';
 import HandleBars from '../../lib/handleBars.js';
 
 class PalmChatPlugin extends ModelPlugin {
-    constructor(pathwayResolver) {
-        super(pathwayResolver);
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
     }
 
     // Convert to PaLM messages array format if necessary

--- a/server/plugins/palmCodeCompletionPlugin.js
+++ b/server/plugins/palmCodeCompletionPlugin.js
@@ -4,8 +4,8 @@ import PalmCompletionPlugin from './palmCompletionPlugin.js';
 
 // PalmCodeCompletionPlugin class for handling requests and responses to the PaLM API Code Completion API
 class PalmCodeCompletionPlugin extends PalmCompletionPlugin {
-    constructor(pathwayResolver) {
-        super(pathwayResolver);
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
     }
 
     // Set up parameters specific to the PaLM API Code Completion API

--- a/server/plugins/palmCodeCompletionPlugin.js
+++ b/server/plugins/palmCodeCompletionPlugin.js
@@ -4,8 +4,8 @@ import PalmCompletionPlugin from './palmCompletionPlugin.js';
 
 // PalmCodeCompletionPlugin class for handling requests and responses to the PaLM API Code Completion API
 class PalmCodeCompletionPlugin extends PalmCompletionPlugin {
-    constructor(config, pathway) {
-        super(config, pathway);
+    constructor(pathwayResolver) {
+        super(pathwayResolver);
     }
 
     // Set up parameters specific to the PaLM API Code Completion API

--- a/server/plugins/palmCompletionPlugin.js
+++ b/server/plugins/palmCompletionPlugin.js
@@ -4,8 +4,8 @@ import ModelPlugin from './modelPlugin.js';
 
 // PalmCompletionPlugin class for handling requests and responses to the PaLM API Text Completion API
 class PalmCompletionPlugin extends ModelPlugin {
-    constructor(pathwayResolver) {
-        super(pathwayResolver);
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
     }
 
     truncatePromptIfNecessary (text, textTokenCount, modelMaxTokenCount, targetTextTokenCount, pathwayResolver) {

--- a/server/plugins/palmCompletionPlugin.js
+++ b/server/plugins/palmCompletionPlugin.js
@@ -4,8 +4,8 @@ import ModelPlugin from './modelPlugin.js';
 
 // PalmCompletionPlugin class for handling requests and responses to the PaLM API Text Completion API
 class PalmCompletionPlugin extends ModelPlugin {
-    constructor(config, pathway) {
-        super(config, pathway);
+    constructor(pathwayResolver) {
+        super(pathwayResolver);
     }
 
     truncatePromptIfNecessary (text, textTokenCount, modelMaxTokenCount, targetTextTokenCount, pathwayResolver) {

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -37,3 +37,44 @@ export const mockConfig = {
         ],
       }),
   };
+
+  export const mockPathwayResolverString = {
+    model: {
+      url: 'https://api.example.com/testModel',
+      type: 'OPENAI-COMPLETION',
+    },
+    modelName: 'testModel',
+    pathway: mockPathwayString,
+    config: mockConfig,
+    prompt: new Prompt('User: {{text}}\nAssistant: Please help {{name}} who is {{age}} years old.'),
+  };
+
+  export const mockPathwayResolverFunction = {
+    model: {
+      url: 'https://api.example.com/testModel',
+      type: 'OPENAI-COMPLETION',
+    },
+    modelName: 'testModel',
+    pathway: mockPathwayFunction,
+    config: mockConfig,
+    prompt: () => {
+        return new Prompt('User: {{text}}\nAssistant: Please help {{name}} who is {{age}} years old.')
+    }
+  };
+
+  export const mockPathwayResolverMessages = {
+    model: {
+      url: 'https://api.example.com/testModel',
+      type: 'OPENAI-COMPLETION',
+    },
+    modelName: 'testModel',
+    pathway: mockPathwayMessages,
+    config: mockConfig,
+    prompt: new Prompt({
+        messages: [
+          { role: 'user', content: 'Translate this: {{{text}}}' },
+          { role: 'assistant', content: 'Translating: {{{text}}}' },
+        ],
+      }),
+  };
+

--- a/tests/modelPlugin.test.js
+++ b/tests/modelPlugin.test.js
@@ -2,7 +2,7 @@
 import test from 'ava';
 import ModelPlugin from '../server/plugins/modelPlugin.js';
 import HandleBars from '../lib/handleBars.js';
-import { mockConfig, mockPathwayString, mockPathwayFunction, mockPathwayMessages } from './mocks.js';
+import { mockConfig, mockPathwayString, mockPathwayFunction, mockPathwayMessages, mockPathwayResolverString } from './mocks.js';
 
 const DEFAULT_MAX_TOKENS = 4096;
 const DEFAULT_PROMPT_TOKEN_RATIO = 0.5;
@@ -12,7 +12,7 @@ const config = mockConfig;
 const pathway = mockPathwayString;
 
 test('ModelPlugin constructor', (t) => {
-    const modelPlugin = new ModelPlugin(config, pathway);
+    const modelPlugin = new ModelPlugin(mockPathwayResolverString);
 
     t.is(modelPlugin.modelName, pathway.model, 'modelName should be set from pathway');
     t.deepEqual(modelPlugin.model, config.get('models')[pathway.model], 'model should be set from config');
@@ -21,7 +21,7 @@ test('ModelPlugin constructor', (t) => {
 });
 
 test.beforeEach((t) => {
-  t.context.modelPlugin = new ModelPlugin(mockConfig, mockPathwayString);
+  t.context.modelPlugin = new ModelPlugin(mockPathwayResolverString);
 });
 
 test('getCompiledPrompt - text and parameters', (t) => {

--- a/tests/openAiChatPlugin.test.js
+++ b/tests/openAiChatPlugin.test.js
@@ -1,17 +1,17 @@
 import test from 'ava';
 import OpenAIChatPlugin from '../server/plugins/openAiChatPlugin.js';
-import { mockConfig, mockPathwayString, mockPathwayFunction, mockPathwayMessages } from './mocks.js';
+import { mockPathwayResolverMessages } from './mocks.js';
 
 // Test the constructor
 test('constructor', (t) => {
-    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
-    t.is(plugin.config, mockConfig);
-    t.is(plugin.pathwayPrompt, mockPathwayString.prompt);
+    const plugin = new OpenAIChatPlugin(mockPathwayResolverMessages);
+    t.is(plugin.config, mockPathwayResolverMessages.config);
+    t.is(plugin.pathwayPrompt, mockPathwayResolverMessages.pathway.prompt);
 });
 
 // Test the convertPalmToOpenAIMessages function
 test('convertPalmToOpenAIMessages', (t) => {
-    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const plugin = new OpenAIChatPlugin(mockPathwayResolverMessages);
     const context = 'This is a test context.';
     const examples = [
         {
@@ -35,14 +35,21 @@ test('convertPalmToOpenAIMessages', (t) => {
 
 // Test the getRequestParameters function
 test('getRequestParameters', async (t) => {
-    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const plugin = new OpenAIChatPlugin(mockPathwayResolverMessages);
     const text = 'Help me';
     const parameters = { name: 'John', age: 30 };
-    const prompt = mockPathwayString.prompt;
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
     const result = await plugin.getRequestParameters(text, parameters, prompt);
     t.deepEqual(result, {
         messages: [
-            { role: 'user', content: 'User: Help me\nAssistant: Please help John who is 30 years old.' },
+            {
+                content: 'Translate this: Help me',
+                role: 'user',
+            },
+            {
+                content: 'Translating: Help me',
+                role: 'assistant',
+            },
         ],
         temperature: 0.7,
     });
@@ -50,10 +57,10 @@ test('getRequestParameters', async (t) => {
 
 // Test the execute function
 test('execute', async (t) => {
-    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const plugin = new OpenAIChatPlugin(mockPathwayResolverMessages);
     const text = 'Help me';
     const parameters = { name: 'John', age: 30 };
-    const prompt = mockPathwayString.prompt;
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
 
     // Mock the executeRequest function
     plugin.executeRequest = () => {
@@ -82,7 +89,7 @@ test('execute', async (t) => {
 
 // Test the parseResponse function
 test('parseResponse', (t) => {
-    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const plugin = new OpenAIChatPlugin(mockPathwayResolverMessages);
     const data = {
         choices: [
             {
@@ -98,7 +105,7 @@ test('parseResponse', (t) => {
 
 // Test the logRequestData function
 test('logRequestData', (t) => {
-    const plugin = new OpenAIChatPlugin(mockConfig, mockPathwayString);
+    const plugin = new OpenAIChatPlugin(mockPathwayResolverMessages);
     const data = {
         messages: [
             { role: 'user', content: 'User: Help me\nAssistant: Please help John who is 30 years old.' },
@@ -113,7 +120,7 @@ test('logRequestData', (t) => {
             },
         ],
     };
-    const prompt = mockPathwayString.prompt;
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
 
     // Mock console.log function
     const originalConsoleLog = console.log;

--- a/tests/palmChatPlugin.test.js
+++ b/tests/palmChatPlugin.test.js
@@ -1,11 +1,10 @@
 // test_palmChatPlugin.js
 import test from 'ava';
 import PalmChatPlugin from '../server/plugins/palmChatPlugin.js';
-import { mockConfig } from './mocks.js';
+import { mockPathwayResolverMessages } from './mocks.js';
 
 test.beforeEach((t) => {
-  const pathway = 'testPathway';
-  const palmChatPlugin = new PalmChatPlugin(mockConfig, pathway);
+  const palmChatPlugin = new PalmChatPlugin(mockPathwayResolverMessages);
   t.context = { palmChatPlugin };
 });
 

--- a/tests/palmCompletionPlugin.test.js
+++ b/tests/palmCompletionPlugin.test.js
@@ -2,11 +2,10 @@
 
 import test from 'ava';
 import PalmCompletionPlugin from '../server/plugins/palmCompletionPlugin.js';
-import { mockConfig } from './mocks.js';
+import { mockPathwayResolverString } from './mocks.js';
 
 test.beforeEach((t) => {
-  const pathway = 'testPathway';
-  const palmCompletionPlugin = new PalmCompletionPlugin(mockConfig, pathway);
+  const palmCompletionPlugin = new PalmCompletionPlugin(mockPathwayResolverString);
   t.context = { palmCompletionPlugin };
 });
 

--- a/tests/truncateMessages.test.js
+++ b/tests/truncateMessages.test.js
@@ -2,12 +2,11 @@
 import test from 'ava';
 import ModelPlugin from '../server/plugins/modelPlugin.js';
 import { encode } from 'gpt-3-encoder';
-import { mockConfig, mockPathwayString } from './mocks.js';
+import { mockPathwayResolverString } from './mocks.js';
 
-const config = mockConfig;
-const pathway = mockPathwayString;
+const { config, pathway } = mockPathwayResolverString;
 
-const modelPlugin = new ModelPlugin(config, pathway);
+const modelPlugin = new ModelPlugin(mockPathwayResolverString);
 
 const generateMessage = (role, content) => ({ role, content });
 


### PR DESCRIPTION
Refactored plugins a bit to allow passing of the PathwayResolver instead of all of the separate properties.  This simplifies them somewhat, but primarily I wanted to allow the passing of model as an inputParameter and beef up the model detection / default failover case.  Now if a model is specified on the pathway, that will take precedence, but the pathway can opt to take model as an inputParameter instead.  In that case, the pathway will try to use the model specified on the input parameter.  Failing either, it will still default to use the default model.  There will be a warning if the default model is used.