### PR TITLE
Cortex HTML chunker does not handle long blobs of text

### DIFF
--- a/server/chunker.js
+++ b/server/chunker.js
@@ -152,7 +152,7 @@ const getSemanticChunks = (text, chunkSize, inputFormat = 'text') => {
       }
     });
 
-    if (chunks.some(chunk => encode(chunk).length > chunkSize)) {
+    if (chunks.filter(c => determineTextFormat(c) === 'html').some(chunk => encode(chunk).length > chunkSize)) {
       throw new Error('The HTML contains elements that are larger than the chunk size. Please try again with HTML that has smaller elements.');
     }
 


### PR DESCRIPTION
Since there is no way to split a HTML element effectively, the cortex chunker is designed to give up if it encounters a large HTML element.

Example: <p>(long paragraph that may contain other html as well)</p>

However, per the current implementation, it complains even if the large element is non-html.

Example:
```
<p>(short paragraph)</p>
(long text-only paragraph)
<p>(short paragraph)</p>
```

It should be OK to chunk the long text-only paragraph instead of erroring out.