### PR TITLE
Allow overriding pathway execution code without overriding entire resolver

### DIFF
--- a/pathways/basePathway.js
+++ b/pathways/basePathway.js
@@ -25,6 +25,6 @@ export default {
     // callback signature: excuteOverride({args: object, runAllPrompts: function})
     // args: the input arguments to the pathway
     // runAllPrompts: a function that runs all prompts in the pathway and returns the result
-    executeOverride: undefined,
+    executePathway: undefined,
 };
 

--- a/pathways/basePathway.js
+++ b/pathways/basePathway.js
@@ -21,5 +21,10 @@ export default {
     truncateFromFront: false, // true or false - if true, truncate from the front of the input instead of the back
     timeout: 120, // seconds, cancels the pathway after this many seconds
     duplicateRequestAfter: 10, // seconds, if the request is not completed after this many seconds, a backup request is sent
+    // override the default execution of the pathway
+    // callback signature: excuteOverride({args: object, runAllPrompts: function})
+    // args: the input arguments to the pathway
+    // runAllPrompts: a function that runs all prompts in the pathway and returns the result
+    executeOverride: undefined,
 };
 

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -74,7 +74,7 @@ class PathwayResolver {
         let streamErrorOccurred = false;
 
         while (attempt < MAX_RETRY_COUNT) {
-            const responseData = await this.promptAndParse(args);
+            const responseData = await this.runPathway(args);
 
             if (args.async || typeof responseData === 'string') {
                 const { completedCount, totalCount } = requestState[this.requestId];
@@ -187,6 +187,15 @@ class PathwayResolver {
         }
         else {
             // Syncronously process the request
+            return await this.runPathway(args);
+        }
+    }
+
+    async runPathway(args) {
+        if (this.pathway.executeOverride) {
+            return await this.pathway.executeOverride({ args, runAllPrompts: this.promptAndParse.bind(this) });
+        }
+        else {
             return await this.promptAndParse(args);
         }
     }

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -74,7 +74,7 @@ class PathwayResolver {
         let streamErrorOccurred = false;
 
         while (attempt < MAX_RETRY_COUNT) {
-            const responseData = await this.runPathway(args);
+            const responseData = await this.executePathway(args);
 
             if (args.async || typeof responseData === 'string') {
                 const { completedCount, totalCount } = requestState[this.requestId];
@@ -187,13 +187,13 @@ class PathwayResolver {
         }
         else {
             // Syncronously process the request
-            return await this.runPathway(args);
+            return await this.executePathway(args);
         }
     }
 
-    async runPathway(args) {
-        if (this.pathway.executeOverride) {
-            return await this.pathway.executeOverride({ args, runAllPrompts: this.promptAndParse.bind(this) });
+    async executePathway(args) {
+        if (this.pathway.executePathway && typeof this.pathway.executePathway === 'function') {
+            return await this.pathway.executePathway({ args, runAllPrompts: this.promptAndParse.bind(this) });
         }
         else {
             return await this.promptAndParse(args);


### PR DESCRIPTION
The use case for this is the one when the pathway would like to execute arbitrary JavaScript code before or after the prompts are executed.

To use this feature, the pathway implements the `executeOverride` method (named to indicate that this will override pathway execution logic). The `executeOverride` method supports two arguments: `args`, `runAllPrompts`. `args` gives the pathway access to all the input args, while `runAllPrompts` can be used to execute all prompts that are defined in the pathway using all relevant configuration options such as chunking, chunk size, inputFormat, etc.