### PR TITLE
Export test server for use in downstream projects

### DIFF
--- a/server/graphql.js
+++ b/server/graphql.js
@@ -20,6 +20,7 @@ import { cancelRequestResolver } from './resolver.js';
 import { buildPathways, buildModels } from '../config.js';
 import { requestState } from './requestState.js';
 import { buildRestEndpoints } from './rest.js';
+import { startTestServer } from '../tests/server.js'
 
 // Utility functions
 // Server plugins
@@ -222,7 +223,7 @@ const build = async (config) => {
         });
     };
 
-    return { server, startServer, cache, plugins, typeDefs, resolvers }
+    return { server, startServer, startTestServer, cache, plugins, typeDefs, resolvers }
 }
 
 

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,0 +1,23 @@
+import 'dotenv/config'
+import { ApolloServer } from '@apollo/server';
+import { config } from '../config.js';
+import typeDefsresolversFactory from '../index.js';
+
+let typeDefs;
+let resolvers;
+
+const initTypeDefsResolvers = async () => {
+    const result = await typeDefsresolversFactory();
+    typeDefs = result.typeDefs;
+    resolvers = result.resolvers;
+};
+
+export const startTestServer = async () => {
+    await initTypeDefsResolvers();
+
+    return new ApolloServer({
+        typeDefs,
+        resolvers,
+        context: () => ({ config, requestState: {} }),
+    });
+};


### PR DESCRIPTION
We have the `startServer` function that can be used by downstream projects to start a cortex-based server.

I've now also added a `startTestServer` which gives downstream projects to start a test server that can be used for test automation.