### PR TITLE
Fix failing tests

### DIFF
--- a/pathways/summary.js
+++ b/pathways/summary.js
@@ -21,7 +21,7 @@ export default {
         const originalTargetLength = args.targetLength;
 
         // If targetLength is not provided, execute the prompt once and return the result.
-        if (originalTargetLength === 0) {
+        if (originalTargetLength === 0 || originalTargetLength === null) {
             let pathwayResolver = new PathwayResolver({ config, pathway, args, requestState });
             return await pathwayResolver.resolve(args);
         }

--- a/server/plugins/modelPlugin.js
+++ b/server/plugins/modelPlugin.js
@@ -22,11 +22,11 @@ class ModelPlugin {
 
         // Make all of the parameters defined on the pathway itself available to the prompt
         for (const [k, v] of Object.entries(pathway)) {
-            this.promptParameters[k] = v.default ?? v;
+            this.promptParameters[k] = v?.default ?? v;
         }
         if (pathway.inputParameters) {
             for (const [k, v] of Object.entries(pathway.inputParameters)) {
-                this.promptParameters[k] = v.default ?? v;
+                this.promptParameters[k] = v?.default ?? v;
             }
         }
 


### PR DESCRIPTION
1. If the basePathway defines a parameter but no value for it, modelPlugin throws an error trying to dereference v.default (v is null or undefined). Added handling for this case.

2. The default value for number was changed from 0 to null in [this commit](https://github.com/aj-archipelago/cortex/commit/8207794ff1e702c4261a642f323200d18b2ecc9b#diff-a964e76413396e051bee9e42be6e1ed64910212f6b4b3600a2c490a9dbaf76d9R10) which makes targetLength default to null (as opposed to zero) for the built-in summary pathway. Added handling for null in the summary pathway.