### PR TITLE
Add temperature configuration field to the base Pathway.

### DIFF
--- a/pathways/basePathway.js
+++ b/pathways/basePathway.js
@@ -26,5 +26,7 @@ export default {
     // args: the input arguments to the pathway
     // runAllPrompts: a function that runs all prompts in the pathway and returns the result
     executePathway: undefined,
+    // Set the temperature to 0 to favor more deterministic output when generating entity extraction.
+    temperature: undefined,
 };
 


### PR DESCRIPTION
I've noticed some pathways uses temperature which is not listed in the default Pathways that act as a reference of all configuration fields of a pathways.
This change will include temperature.