### PR TITLE
Support OpenAI Dall-E model in Cortex

### DIFF
--- a/config.js
+++ b/config.js
@@ -148,6 +148,11 @@ var config = convict({
         sensitive: true,
         env: 'STORAGE_CONNECTION_STRING'
     },
+    dalleImageApiUrl: {
+        format: String,
+        default: 'null',
+        env: 'DALLE_IMAGE_API_URL'
+    },
     whisperMediaApiUrl: {
         format: String,
         default: 'null',

--- a/lib/request.js
+++ b/lib/request.js
@@ -169,7 +169,8 @@ const postRequest = async ({ url, data, params, headers, cache }, model, request
         try {
             const response = await Promise.race(promises);
 
-            if (response.status === 200) {
+            // if response status is 2xx
+            if (response.status >= 200 && response.status < 300) {
                 return response;
             } else {
                 throw new Error(`Received error response: ${response.status}`);

--- a/lib/requestDurationEstimator.js
+++ b/lib/requestDurationEstimator.js
@@ -1,0 +1,90 @@
+/**
+ * A class to get request durations and estimate their average.
+ */
+export default class RequestDurationEstimator {
+    // Initializing the class with given number of durations to track.
+    constructor(n = 10) {
+        this.n = n;  // Number of last durations to consider
+        this.durations = [];  // List to keep track of last n durations
+    }
+
+    /**
+     * Private method to add a request duration to the durations list.
+     * If the list is full (n durations already), the oldest duration is removed.
+     * @param {number} duration - The duration of the request
+     */
+    #add(duration) {
+        this.durations.push(duration);
+        // Remove the oldest duration if we have stored n durations
+        if (this.durations.length > this.n) {
+            this.durations.shift();
+        }
+    }
+
+    /**
+     * To be invoked when a request starts.
+     * If there is an ongoing request, it ends that request.
+     * @param {string} requestId - The ID of the request
+     */
+    startRequest(requestId) {
+        // If there is an ongoing request, end it
+        if (this.requestId) {
+            this.endRequest();
+        }
+
+        // Store the starting details of the new request
+        this.requestId = requestId;
+        this.startTime = Date.now();
+    }
+
+    /**
+     * To be invoked when a request ends.
+     * Calculates the duration of the request and adds it to the durations list.
+     */
+    endRequest() {
+        // If there is an ongoing request, add its duration to the durations list
+        if (this.requestId) {
+            this.#add(Date.now() - this.startTime);
+            this.requestId = null;
+        }
+    }
+
+    /**
+     * Calculate and return the average of the request durations.
+     * @return {number} The average request duration
+     */
+    getAverage() {
+        // If no duration is stored, return 0
+        if (!this.durations.length) {
+            return 0;
+        }
+
+        // Calculate the sum of the durations and divide by the number of durations to get the average
+        return this.durations.reduce((a, b) => a + b) / this.durations.length;
+    }
+
+    /**
+     * Calculate the percentage completion of the current request based on the average of past durations.
+     * @return {number} The estimated percent completion of the ongoing request
+     */
+    calculatePercentComplete() {
+        // If no duration is stored, return 0
+        if (!this.durations.length) {
+            return 0;
+        }
+
+
+        // Calculate the duration of the current request
+        const duration = Date.now() - this.startTime;
+        // Get the average of the durations
+        const average = this.getAverage();
+        // Calculate the percentage completion
+        let percentComplete = duration / average;
+
+        if (percentComplete > .8) {
+            percentComplete = 0.8;
+        }
+
+        return percentComplete;
+    }
+}

--- a/pathways/image.js
+++ b/pathways/image.js
@@ -1,0 +1,4 @@
+export default {
+    prompt:["{{text}}"],
+    model: 'azure-dalle',
+}

--- a/server/graphql.js
+++ b/server/graphql.js
@@ -72,6 +72,7 @@ const getTypedefs = (pathways) => {
     type RequestSubscription {
         requestId: String
         progress: Float
+        status: String
         data: String
     }
 

--- a/server/pathwayPrompter.js
+++ b/server/pathwayPrompter.js
@@ -12,15 +12,19 @@ import CohereGeneratePlugin from './plugins/cohereGeneratePlugin.js';
 import CohereSummarizePlugin from './plugins/cohereSummarizePlugin.js';
 import AzureCognitivePlugin from './plugins/azureCognitivePlugin.js';
 import OpenAiEmbeddingsPlugin from './plugins/openAiEmbeddingsPlugin.js';
+import OpenAIImagePlugin from './plugins/openAiImagePlugin.js';
 
 class PathwayPrompter {
     constructor(config, pathway, modelName, model) {
-        
+
         let plugin;
 
         switch (model.type) {
             case 'OPENAI-CHAT':
                 plugin = new OpenAIChatPlugin(config, pathway, modelName, model);
+                break;
+            case 'OPENAI-IMAGE':
+                plugin = new OpenAIImagePlugin(config, pathway, modelName, model);
                 break;
             case 'OPENAI-CHAT-EXTENSION':
                 plugin = new OpenAIChatExtensionPlugin(config, pathway, modelName, model);

--- a/server/plugins/openAiImagePlugin.js
+++ b/server/plugins/openAiImagePlugin.js
@@ -1,0 +1,85 @@
+// OpenAIImagePlugin.js
+import FormData from 'form-data';
+import { config } from '../../config.js';
+import ModelPlugin from './modelPlugin.js';
+import pubsub from '../pubsub.js';
+import axios from 'axios';
+import RequestDurationEstimator from '../../lib/requestDurationEstimator.js';
+
+const API_URL = config.get('dalleImageApiUrl'); // URL for the DALL-E API
+const requestDurationEstimator = new RequestDurationEstimator(10);
+
+class OpenAIImagePlugin extends ModelPlugin {
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
+    }
+
+    // Implement the method to call the DALL-E API
+    async execute(text, parameters, _, pathwayResolver) {
+        const url = this.requestUrl(text);
+        const data = JSON.stringify({ prompt: text });
+
+        let id;
+        const { requestId, pathway } = pathwayResolver;
+
+        try {
+            requestDurationEstimator.startRequest(requestId);
+            id = (await this.executeRequest(url, data, {}, { ...this.model.headers }, {}, requestId, pathway))?.id;
+        } catch (error) {
+            const errMsg = `Error generating image: ${error?.message || JSON.stringify(error)}`;
+            console.error(errMsg);
+            return errMsg;
+        }
+
+        if (!parameters.async) {
+            return await this.getStatus(text, id, requestId);
+        }
+        else {
+            this.getStatus(text, id, requestId);
+        }
+    }
+
+    async getStatus(text, id, requestId) {
+        // get the post URL which is used to send the request
+        const url = this.requestUrl(text);
+
+        // conver it to the GET URL which is used to check the status
+        const statusUrl = url.replace("images/generations:submit", `operations/images/${id}`);
+        let status;
+        let attemptCount = 0;
+        let data = null;
+
+        do {
+            const response = (await axios.get(statusUrl, { cache: false, headers: { ...this.model.headers } })).data;
+            status = response.status;
+            let progress = 
+                requestDurationEstimator.calculatePercentComplete();
+
+            if (status === "succeeded") {
+                progress = 1;
+                data = JSON.stringify(response);
+            }
+
+            pubsub.publish('REQUEST_PROGRESS', {
+                requestProgress: {
+                    requestId,
+                    status,
+                    progress,
+                    data,
+                }
+            });
+
+            if (status === "succeeded") {
+                requestDurationEstimator.endRequest();
+                break;
+            }
+            // sleep for 5 seconds
+            await new Promise(resolve => setTimeout(resolve, 2000));
+        }
+        while (status !== "succeeded" && attemptCount++ < 30);
+
+        return data;
+    }
+}
+
+export default OpenAIImagePlugin;

--- a/tests/requestDurationEstimator.test.js
+++ b/tests/requestDurationEstimator.test.js
@@ -1,0 +1,59 @@
+import test from 'ava';
+import RequestDurationEstimator from '../lib/requestDurationEstimator.js';
+
+test('add and get average request duration', async (t) => {
+    const estimator = new RequestDurationEstimator(5);
+
+    estimator.startRequest('req1');
+    await new Promise(resolve => setTimeout(() => {
+        estimator.endRequest();
+
+        const average = estimator.calculatePercentComplete();
+
+        // An average should be calculated after the first completed request  
+        t.not(average, 0);
+        resolve();
+    }, 1000));
+});
+
+test('add more requests than size of durations array', (t) => {
+    const estimator = new RequestDurationEstimator(5);
+
+    for (let i = 0; i < 10; i++) {
+        estimator.startRequest(`req${i}`);
+        estimator.endRequest();
+    }
+
+    // Array size should not exceed maximum length (5 in this case)
+    t.is(estimator.durations.length, 5);
+});
+
+test('calculate percent complete of current request based on average of past durations', async (t) => {
+    const estimator = new RequestDurationEstimator(5);
+
+    for (let i = 0; i < 4; i++) {
+        estimator.startRequest(`req${i}`);
+        // wait 1 second
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        estimator.endRequest();
+    }
+
+    estimator.startRequest('req5');
+
+    await new Promise(resolve => setTimeout(() => {
+        const percentComplete = estimator.calculatePercentComplete();
+
+        // Depending on how fast the operations are,
+        // the percentage may not be exactly 50%, but
+        // we'll affirm it should be at least partially complete.
+        t.true(percentComplete > 0);
+        resolve();
+    }, 500));
+});
+
+test('calculate percent complete based on average of past durations', async (t) => {
+    const estimator = new RequestDurationEstimator(5);
+    estimator.durations = [1000, 2000, 3000];
+    const average = estimator.getAverage();
+    t.is(average, 2000);
+});


### PR DESCRIPTION
Added a new model type `OPENAI-IMAGE`. This is implemented using a new plugin called openAiImagePlugin.

The preferred way to use this is to use cortex's async flag, but a sync call is also supported. If the client requests a synchronous operation, the plugin does a polling loop and sends the result as soon as its available.

Implementation of progress updates:

* request progress is not available from the Dall-E API. So we estimate generation time using a rolling average of the previous n requests and send it to the client 
* pathwayResolver automatically sends progress updates using the number of prompts * number of chunks. This logic is not applicable to the dall-E API since the progress has nothing to do with the number of prompts you're sending. So if the model is of type `OPENAI-IMAGE`, pathwayResolver does not send updates anymore and relies on the plugin to send updates instead.
