### PR TITLE
Set package private false for release-it cortex open source public release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@aj-archipelago/cortex",
   "version": "1.0.21",
   "description": "Cortex is a GraphQL API for AI. It provides a simple, extensible interface for using AI services from OpenAI, Azure and others.",
+  "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aj-archipelago/cortex.git"


### PR DESCRIPTION
Set package.json private setting false for release-it, so when you call `npx release-it` it publishes as public release. otherwise it returns to private which causes access retriction for the open source cortex package