### PR TITLE
Add support for DALL-E 3 API

### DIFF
--- a/server/pathwayPrompter.js
+++ b/server/pathwayPrompter.js
@@ -13,6 +13,7 @@ import CohereSummarizePlugin from './plugins/cohereSummarizePlugin.js';
 import AzureCognitivePlugin from './plugins/azureCognitivePlugin.js';
 import OpenAiEmbeddingsPlugin from './plugins/openAiEmbeddingsPlugin.js';
 import OpenAIImagePlugin from './plugins/openAiImagePlugin.js';
+import OpenAIDallE3Plugin from './plugins/openAiDalle3Plugin.js';
 
 class PathwayPrompter {
     constructor(config, pathway, modelName, model) {
@@ -23,8 +24,11 @@ class PathwayPrompter {
             case 'OPENAI-CHAT':
                 plugin = new OpenAIChatPlugin(config, pathway, modelName, model);
                 break;
-            case 'OPENAI-IMAGE':
+            case 'OPENAI-DALLE2':
                 plugin = new OpenAIImagePlugin(config, pathway, modelName, model);
+                break;
+            case 'OPENAI-DALLE3':
+                plugin = new OpenAIDallE3Plugin(config, pathway, modelName, model);
                 break;
             case 'OPENAI-CHAT-EXTENSION':
                 plugin = new OpenAIChatExtensionPlugin(config, pathway, modelName, model);

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -10,7 +10,7 @@ import { getv, setv } from '../lib/keyValueStorageClient.js';
 import { requestState } from './requestState.js';
 import { callPathway } from '../lib/pathwayTools.js';
 
-const modelTypesExcludedFromProgressUpdates = ['OPENAI-IMAGE'];
+const modelTypesExcludedFromProgressUpdates = ['OPENAI-DALLE2', 'OPENAI-DALLE3'];
 
 class PathwayResolver {
     constructor({ config, pathway, args }) {

--- a/server/plugins/openAiDallE3Plugin.js
+++ b/server/plugins/openAiDallE3Plugin.js
@@ -21,10 +21,9 @@ class OpenAIDallE3Plugin extends ModelPlugin {
         const url = this.requestUrl(text);
         const data = JSON.stringify({ prompt: text });
 
-        let id;
         const { requestId, pathway } = pathwayResolver;
 
-        const makeRequest = () => this.executeRequest(url, data, {}, { ...this.model.headers }, {}, requestId, pathway);
+        const makeRequest = () => this.executeRequest(url, data, {}, this.model.headers, {}, requestId, pathway);
 
         if (!parameters.async) {
             // synchronous request
@@ -74,7 +73,7 @@ class OpenAIDallE3Plugin extends ModelPlugin {
             });
         });
 
-        // publish an update every 5 seconds, using the request duration estimator to calculate
+        // publish an update every 2 seconds, using the request duration estimator to calculate
         // the percent complete
         do {
             let progress =
@@ -93,7 +92,7 @@ class OpenAIDallE3Plugin extends ModelPlugin {
                 break;
             }
 
-            // sleep for 5 seconds
+            // sleep for 2 seconds
             await new Promise(resolve => setTimeout(resolve, 2000));
         }
         while (state.status !== "succeeded" && attemptCount++ < 30);

--- a/server/plugins/openAiDallE3Plugin.js
+++ b/server/plugins/openAiDallE3Plugin.js
@@ -1,0 +1,105 @@
+import RequestDurationEstimator from '../../lib/requestDurationEstimator.js';
+import pubsub from '../pubsub.js';
+import ModelPlugin from './modelPlugin.js';
+
+const requestDurationEstimator = new RequestDurationEstimator(10);
+
+/**
+ * @description This plugin is for the OpenAI DALL-E 3 model.
+ */
+class OpenAIDallE3Plugin extends ModelPlugin {
+    constructor(config, pathway, modelName, model) {
+        super(config, pathway, modelName, model);
+    }
+
+    /**
+     * @description At the time of writing, the DALL-E 3 API on Azure is sync-only, so to support async
+     * we keep the request open and send progress updates to the client 
+     * over a websocket.
+     */
+    async execute(text, parameters, _, pathwayResolver) {
+        const url = this.requestUrl(text);
+        const data = JSON.stringify({ prompt: text });
+
+        let id;
+        const { requestId, pathway } = pathwayResolver;
+
+        const makeRequest = () => this.executeRequest(url, data, {}, { ...this.model.headers }, {}, requestId, pathway);
+
+        if (!parameters.async) {
+            // synchronous request
+            return await makeRequest();
+        }
+        else {
+            // async request
+            requestDurationEstimator.startRequest(requestId);
+            const requestPromise = makeRequest();
+            this.#sendRequestUpdates(requestId, requestPromise);
+        }
+    }
+
+    /**
+     * Send progress updates to the client.
+     * 
+     * @param {*} requestId 
+     * @param {*} requestPromise 
+     * @returns 
+     */
+    async #sendRequestUpdates(requestId, requestPromise) {
+        let state = { status: "pending" };
+        let attemptCount = 0;
+        let data = null;
+
+        requestPromise.then((response) => {
+            state.status = "succeeded";
+            requestDurationEstimator.endRequest();
+            pubsub.publish('REQUEST_PROGRESS', {
+                requestProgress: {
+                    requestId,
+                    status: "succeeded",
+                    progress: 1,
+                    data: JSON.stringify(response),
+                }
+            });
+        }).catch((error) => {
+            state.status = "failed";
+            requestDurationEstimator.endRequest();
+            pubsub.publish('REQUEST_PROGRESS', {
+                requestProgress: {
+                    requestId,
+                    status: "failed",
+                    progress: 1,
+                    data: JSON.stringify(error),
+                }
+            });
+        });
+
+        // publish an update every 5 seconds, using the request duration estimator to calculate
+        // the percent complete
+        do {
+            let progress =
+                requestDurationEstimator.calculatePercentComplete();
+
+            pubsub.publish('REQUEST_PROGRESS', {
+                requestProgress: {
+                    requestId,
+                    status: "pending",
+                    progress,
+                    data,
+                }
+            });
+
+            if (state.status !== "pending") {
+                break;
+            }
+
+            // sleep for 5 seconds
+            await new Promise(resolve => setTimeout(resolve, 2000));
+        }
+        while (state.status !== "succeeded" && attemptCount++ < 30);
+
+        return data;
+    }
+}
+
+export default OpenAIDallE3Plugin;

--- a/server/plugins/openAiImagePlugin.js
+++ b/server/plugins/openAiImagePlugin.js
@@ -6,7 +6,6 @@ import pubsub from '../pubsub.js';
 import axios from 'axios';
 import RequestDurationEstimator from '../../lib/requestDurationEstimator.js';
 
-const API_URL = config.get('dalleImageApiUrl'); // URL for the DALL-E API
 const requestDurationEstimator = new RequestDurationEstimator(10);
 
 class OpenAIImagePlugin extends ModelPlugin {


### PR DESCRIPTION
DALL-E 2 and DALL-E 3 APIs are not compatible. As well, there doesn't seem to be an async version of the DALL-E 3 API, which is the version we were using for DALL-E 2. So created a new model type for DALL-E 3 and implemented the execute method. To support async operations, we keep the request open and send progress updates to the client over a websocket.