### PR TITLE
Add keepAlive to cortex ApolloServer

### DIFF
--- a/server/graphql.js
+++ b/server/graphql.js
@@ -161,6 +161,9 @@ const build = async (config) => {
                 },
             }
         ]),
+        subscriptions: {
+            keepAlive: 1000,
+        }
     });
 
     // If CORTEX_API_KEY is set, we roll our own auth middleware - usually not used if you're being fronted by a proxy


### PR DESCRIPTION
In one of our applications, we saw that progress updates stop delivering abruptly when using the company VPN. This may be due to an idle timeout. Introducing keepAlive to GQL subscriptions to see if it helps with the issue.