### PR TITLE
HOTFIX: Jmac handle unencrypted

### DIFF
--- a/lib/redisSubscription.js
+++ b/lib/redisSubscription.js
@@ -57,7 +57,7 @@ if (connectionString) {
         subscriptionClient.on('message', (channel, message) => {
             logger.debug(`Received message from ${channel}: ${message}`);
             
-            let decryptedMessage = message;
+            let decryptedMessage;
 
             if (channel === requestProgressChannel && redisEncryptionKey) {
                 try {
@@ -67,7 +67,7 @@ if (connectionString) {
                 }
             }
 
-            let parsedMessage = decryptedMessage;
+            let parsedMessage = decryptedMessage || message;
             try {
                 parsedMessage = JSON.parse(decryptedMessage);
             } catch (error) {

--- a/lib/redisSubscription.js
+++ b/lib/redisSubscription.js
@@ -67,7 +67,10 @@ if (connectionString) {
                 }
             }
 
-            let parsedMessage = decryptedMessage || message;
+            decryptedMessage = decryptedMessage || message;
+
+            let parsedMessage;
+
             try {
                 parsedMessage = JSON.parse(decryptedMessage);
             } catch (error) {
@@ -76,10 +79,10 @@ if (connectionString) {
 
             switch(channel) {
                 case requestProgressChannel:
-                    pubsubHandleMessage(parsedMessage);
+                    parsedMessage && pubsubHandleMessage(parsedMessage);
                     break;
                 case requestProgressSubscriptionsChannel:
-                    handleSubscription(parsedMessage);
+                    parsedMessage && handleSubscription(parsedMessage);
                     break;
                 default:
                     logger.error(`Unsupported channel: ${channel}`);


### PR DESCRIPTION
There's an issue in the current code base if unencrypted messages appear in a channel in which encrypted is expected.  This fixes that case and cleans up the opposite case as well.