### PR TITLE
HOTFIX: Eslint fixes and REST api stream optimization

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,6 +18,12 @@
 # Ignore documentation
 /docs
 
+# Ignore helper apps
+/helper_apps
+
+# Ignore tests
+/tests
+
 # Ignore any generated or bundled files
 *.min.js
 *.bundle.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,8 +16,9 @@
     ],
     "rules": {
         "import/no-unresolved": "error",
-        "import/no-extraneous-dependencies": ["error", {"devDependencies": true, "dependencies": true}],
-        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+        "no-useless-escape": "off"
     },
     "settings": {
         "import/resolver": {

--- a/lib/redisSubscription.js
+++ b/lib/redisSubscription.js
@@ -95,8 +95,8 @@ if (connectionString) {
     logger.info(`Using pubsub publish for channel ${requestProgressChannel}`);
 }
 
-async function publishRequestProgress(data) {
-    if (publisherClient) {
+async function publishRequestProgress(data, useRedis = true) {
+    if (publisherClient && useRedis) {
         try {
             let message = JSON.stringify(data);
             if (redisEncryptionKey) {

--- a/pathways/sys_openai_completion.js
+++ b/pathways/sys_openai_completion.js
@@ -1,8 +1,6 @@
 // sys_openai_completion.js
 // default handler for openAI completion endpoints when REST endpoints are enabled
 
-import { Prompt } from '../server/prompt.js';
-
 export default {
     prompt: `{{text}}`,
     model: 'oai-gpturbo',

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -70,7 +70,7 @@ class PathwayResolver {
     // the graphql subscription to send progress updates to the client.  Most of 
     // the time the client will be an external client, but it could also be the
     // Cortex REST api code.
-    async asyncResolve(args) {
+    async asyncResolve(args, useRedis = true) {
         const MAX_RETRY_COUNT = 3;
         let attempt = 0;
         let streamErrorOccurred = false;
@@ -88,7 +88,7 @@ class PathwayResolver {
                             requestId: this.requestId,
                             progress: completedCount / totalCount,
                             data: JSON.stringify(responseData),
-                    });
+                    }, useRedis);
                 }
             } else {
                 try {
@@ -140,7 +140,7 @@ class PathwayResolver {
 
                                     try {
                                         //logger.info(`Publishing stream message to requestId ${this.requestId}: ${message}`);
-                                        publishRequestProgress(requestProgress);
+                                        publishRequestProgress(requestProgress, useRedis);
                                     } catch (error) {
                                         logger.error(`Could not publish the stream message: "${messageBuffer}", ${error}`);
                                     }

--- a/server/plugins/azureCognitivePlugin.js
+++ b/server/plugins/azureCognitivePlugin.js
@@ -30,7 +30,7 @@ class AzureCognitivePlugin extends ModelPlugin {
     }
 
     // Set up parameters specific to the Azure Cognitive API
-    async getRequestParameters(text, parameters, prompt, mode, indexName, savedContextId,  {headers, requestId, pathway, url}) {
+    async getRequestParameters(text, parameters, prompt, mode, indexName, savedContextId,  {headers, requestId, pathway, _url}) {
         const combinedParameters = { ...this.promptParameters, ...parameters };
         const { modelPromptText } = this.getCompiledPrompt(text, combinedParameters, prompt);
         const { inputVector, calculateInputVector, privateData, filter, docId } = combinedParameters;

--- a/server/plugins/azureTranslatePlugin.js
+++ b/server/plugins/azureTranslatePlugin.js
@@ -1,5 +1,6 @@
 // AzureTranslatePlugin.js
 import ModelPlugin from './modelPlugin.js';
+import logger from '../../lib/logger.js';
 
 class AzureTranslatePlugin extends ModelPlugin {
     constructor(config, pathway, modelName, model) {

--- a/server/plugins/cohereGeneratePlugin.js
+++ b/server/plugins/cohereGeneratePlugin.js
@@ -8,7 +8,7 @@ class CohereGeneratePlugin extends ModelPlugin {
 
     // Set up parameters specific to the Cohere API
     getRequestParameters(text, parameters, prompt) {
-        const { modelPromptText, tokenLength } = this.getCompiledPrompt(text, parameters, prompt);
+        let { modelPromptText, tokenLength } = this.getCompiledPrompt(text, parameters, prompt);
 
         // Define the model's max token length
         const modelTargetTokenLength = this.getModelMaxTokenLength() * this.getPromptTokenRatio();

--- a/server/plugins/localModelPlugin.js
+++ b/server/plugins/localModelPlugin.js
@@ -2,6 +2,7 @@
 import ModelPlugin from './modelPlugin.js';
 import { execFileSync } from 'child_process';
 import { encode } from 'gpt-3-encoder';
+import logger from '../../lib/logger.js';
 
 class LocalModelPlugin extends ModelPlugin {
     constructor(config, pathway, modelName, model) {

--- a/server/plugins/openAiCompletionPlugin.js
+++ b/server/plugins/openAiCompletionPlugin.js
@@ -1,6 +1,5 @@
 // OpenAICompletionPlugin.js
 
-import { request } from 'https';
 import ModelPlugin from './modelPlugin.js';
 import { encode } from 'gpt-3-encoder';
 import logger from '../../lib/logger.js';

--- a/server/plugins/palmChatPlugin.js
+++ b/server/plugins/palmChatPlugin.js
@@ -75,7 +75,6 @@ class PalmChatPlugin extends ModelPlugin {
     // Set up parameters specific to the PaLM Chat API
     getRequestParameters(text, parameters, prompt) {
         const { modelPromptText, modelPromptMessages, tokenLength } = this.getCompiledPrompt(text, parameters, prompt);
-        const { stream } = parameters;
     
         // Define the model's max token length
         const modelTargetTokenLength = this.getModelMaxTokenLength() * this.getPromptTokenRatio();

--- a/server/plugins/palmCodeCompletionPlugin.js
+++ b/server/plugins/palmCodeCompletionPlugin.js
@@ -11,7 +11,6 @@ class PalmCodeCompletionPlugin extends PalmCompletionPlugin {
     // Set up parameters specific to the PaLM API Code Completion API
     getRequestParameters(text, parameters, prompt, pathwayResolver) {
         const { modelPromptText, tokenLength } = this.getCompiledPrompt(text, parameters, prompt);
-        const { stream } = parameters;
         // Define the model's max token length
         const modelTargetTokenLength = this.getModelMaxTokenLength() * this.getPromptTokenRatio();
     

--- a/server/plugins/palmCompletionPlugin.js
+++ b/server/plugins/palmCompletionPlugin.js
@@ -22,7 +22,7 @@ class PalmCompletionPlugin extends ModelPlugin {
     // Set up parameters specific to the PaLM API Text Completion API
     getRequestParameters(text, parameters, prompt, pathwayResolver) {
         const { modelPromptText, tokenLength } = this.getCompiledPrompt(text, parameters, prompt);
-        const { stream } = parameters;
+        
         // Define the model's max token length
         const modelTargetTokenLength = this.getModelMaxTokenLength() * this.getPromptTokenRatio();
     

--- a/server/rest.js
+++ b/server/rest.js
@@ -1,7 +1,6 @@
 // rest.js
 // Implement the REST endpoints for the pathways
 
-import { json } from 'express';
 import pubsub from './pubsub.js';
 import { requestState } from './requestState.js';
 import { v4 as uuidv4 } from 'uuid';
@@ -168,7 +167,11 @@ const processIncomingStream = (requestId, res, jsonResponse) => {
     // Fire the resolver for the async requestProgress
     logger.info(`Rest Endpoint starting async requestProgress, requestId: ${requestId}`);
     const { resolver, args } = requestState[requestId];
-    resolver(args);
+    // The false here means never use a Redis subscription channel
+    // to handle these streaming messages. This is because we are
+    // guaranteed in this case that the stream is going to the same
+    // client.
+    resolver(args, false);
 
     return subscription;
   
@@ -236,17 +239,18 @@ function buildRestEndpoints(pathways, app, server, config) {
                 ],
             };
 
+            // eslint-disable-next-line no-extra-boolean-cast
             if (Boolean(req.body.stream)) {
                 jsonResponse.id = `cmpl-${resultText}`;
                 jsonResponse.choices[0].finish_reason = null;
                 //jsonResponse.object = "text_completion.chunk";
 
-                const subscription = processIncomingStream(resultText, res, jsonResponse);
+                processIncomingStream(resultText, res, jsonResponse);
             } else {
                 const requestId = uuidv4();
                 jsonResponse.id = `cmpl-${requestId}`;
                 res.json(jsonResponse);
-            };
+            }
         });
         
         app.post('/v1/chat/completions', async (req, res) => {
@@ -281,6 +285,7 @@ function buildRestEndpoints(pathways, app, server, config) {
                 ],
             };
 
+            // eslint-disable-next-line no-extra-boolean-cast
             if (Boolean(req.body.stream)) {
                 jsonResponse.id = `chatcmpl-${resultText}`;
                 jsonResponse.choices[0] = {
@@ -292,7 +297,7 @@ function buildRestEndpoints(pathways, app, server, config) {
                 }
                 jsonResponse.object = "chat.completion.chunk";
 
-                const subscription = processIncomingStream(resultText, res, jsonResponse);
+                processIncomingStream(resultText, res, jsonResponse);
             } else {
                 const requestId = uuidv4();
                 jsonResponse.id = `chatcmpl-${requestId}`;
@@ -330,6 +335,6 @@ function buildRestEndpoints(pathways, app, server, config) {
         });
 
     }
-};
+}
 
 export { buildRestEndpoints };

--- a/server/subscriptions.js
+++ b/server/subscriptions.js
@@ -1,5 +1,4 @@
 import pubsub from './pubsub.js';
-import logger from '../lib/logger.js';
 import { withFilter } from 'graphql-subscriptions';
 import { publishRequestProgressSubscription } from '../lib/redisSubscription.js';
 


### PR DESCRIPTION
Our linter was throwing a lot of errors and making it hard to check for things that mattered so I fixed some issues and excluded some that had good reasons to exist.  I excluded our helper_apps for now as well.

This PR also has an optimization fix to stop OpenAI-style REST endpoints from pushing their streaming messages to the Redis requestProgress subscription when it is available.  The default behavior was just causing a lot of noise for no reason as the client will always be connected to the current instance in the streaming SSE case.