### PR TITLE
ARC-2225: Cortex embedding now uses openai by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -122,9 +122,9 @@ var config = convict({
             },
             "oai-embeddings": {
                 "type": "OPENAI-EMBEDDINGS",
-                "url": "https://archipelago-openai.openai.azure.com/openai/deployments/archipelago-embedding/embeddings?api-version=2023-12-01",
+                "url": "https://api.openai.com/v1/embeddings",
                 "headers": {
-                    "api-key": "{{ARCHIPELAGO_OPENAI_KEY}}",
+                    "Authorization": "Bearer {{OPENAI_API_KEY}}",
                     "Content-Type": "application/json"
                 },
                 "params": {

--- a/server/plugins/openAiEmbeddingsPlugin.js
+++ b/server/plugins/openAiEmbeddingsPlugin.js
@@ -7,11 +7,13 @@ class OpenAiEmbeddingsPlugin extends ModelPlugin {
     }
 
     getRequestParameters(text, parameters, prompt) {
-        const combinedParameters = { ...this.promptParameters, ...parameters };
+        const combinedParameters = { ...this.promptParameters, ...this.model.params, ...parameters };
         const { modelPromptText } = this.getCompiledPrompt(text, combinedParameters, prompt);
+        const { model } = combinedParameters;
         const requestParameters = {
             data:  {
                 input: combinedParameters?.input?.length ? combinedParameters.input :  modelPromptText || text,
+                model
             }
         };
         return requestParameters;


### PR DESCRIPTION
- use openai by default
- add model param