### PR TITLE
Fix pathway defaults not applying over GQL schema defaults

### DIFF
--- a/pathways/summary.js
+++ b/pathways/summary.js
@@ -21,7 +21,7 @@ export default {
         const originalTargetLength = args.targetLength;
 
         // If targetLength is not provided, execute the prompt once and return the result.
-        if (originalTargetLength === 0 || originalTargetLength === null) {
+        if (!originalTargetLength) {
             let pathwayResolver = new PathwayResolver({ config, pathway, args });
             return await pathwayResolver.resolve(args);
         }

--- a/server/plugins/modelPlugin.js
+++ b/server/plugins/modelPlugin.js
@@ -127,10 +127,7 @@ class ModelPlugin {
         const mergeParameters = (promptParameters, parameters) => {
             let result = { ...promptParameters };
             for (let key in parameters) {
-                let value = parameters[key];
-                if (value !== null && value !== '') {
-                    result[key] = value;
-                }
+                if (parameters[key] !== null) result[key] = parameters[key];
             }
             return result;
         }

--- a/server/plugins/modelPlugin.js
+++ b/server/plugins/modelPlugin.js
@@ -127,7 +127,10 @@ class ModelPlugin {
         const mergeParameters = (promptParameters, parameters) => {
             let result = { ...promptParameters };
             for (let key in parameters) {
-                if (parameters[key] !== null) result[key] = parameters[key];
+                let value = parameters[key];
+                if (value !== null && value !== '') {
+                    result[key] = value;
+                }
             }
             return result;
         }

--- a/server/typeDef.js
+++ b/server/typeDef.js
@@ -1,30 +1,30 @@
 const getGraphQlType = (value) => {
   switch (typeof value) {
     case 'boolean':
-      return {type: 'Boolean', defaultValue: 'false'};
+      return {type: 'Boolean'};
     case 'string':
-      return {type: 'String', defaultValue: `""`};
+      return {type: 'String'};
     case 'number':
-      return {type: 'Int', defaultValue: 'null'};
+      return {type: 'Int'};
     case 'object':
       if (Array.isArray(value)) {
         if (value.length > 0 && typeof(value[0]) === 'string') {
-          return {type: '[String]', defaultValue: '[]'};
+          return {type: '[String]'};
         }
         else {
           // New case for MultiMessage type
           if (Array.isArray(value[0]?.content)) {
-            return {type: '[MultiMessage]', defaultValue: '[]'};
+            return {type: '[MultiMessage]'};
           }
           else {
-            return {type: '[Message]', defaultValue: '[]'};
+            return {type: '[Message]'};
           }
         }
       } else {
-        return {type: `[${value.objName}]`, defaultValue: 'null'};
+        return {type: `[${value.objName}]`};
       }
     default:
-      return {type: 'String', defaultValue: `""`};
+      return {type: 'String'};
   }
 };
 


### PR DESCRIPTION
We've had an issue with Cortex forever where pathway defaults do not apply.  This is because the GraphQL schema was always providing default values, even if the parameters were not passed in.  These default values always override the pathway defaults because anything that comes from GraphQL takes priority.  Removing the GraphQL defaults just fixed it.