### PR TITLE
Make sure auth tokens aren't accumulated in the CortexRequest

### DIFF
--- a/lib/cortexRequest.js
+++ b/lib/cortexRequest.js
@@ -1,12 +1,13 @@
 import { selectEndpoint } from './requestExecutor.js';
 
 class CortexRequest {
-    constructor( { url, urlSuffix, data, params, headers, cache, model, pathwayResolver, selectedEndpoint, stream } = {}) { 
+    constructor( { url, urlSuffix, data, params, headers, auth, cache, model, pathwayResolver, selectedEndpoint, stream } = {}) { 
         this._url = url || '';
         this._urlSuffix = urlSuffix || '';
         this._data = data || {};
         this._params = params || {};
         this._headers = headers || {};
+        this._auth = auth || {};
         this._cache = cache || {};
         this._model = model || '';
         this._pathwayResolver = pathwayResolver || {};
@@ -30,6 +31,9 @@ class CortexRequest {
             this._url = sep.url;
             this._data = { ...this._data, ...sep.params };
             this._headers = { ...this._headers, ...sep.headers };
+            if (sep.auth) {
+                this._auth = { ...sep.auth };
+            }
             this._params = { ...this._params, ...sep.params };
         }
     }
@@ -81,11 +85,20 @@ class CortexRequest {
 
     // headers getter and setter
     get headers() {
-        return this._headers;
+        return { ...this._headers, ...this._auth };
     }
 
     set headers(value) {
         this._headers = value;
+    }
+
+    // auth getter and setter
+    get auth() {
+        return this._auth;
+    }
+
+    set auth(value) {
+        this._auth = value;
     }
 
     // cache getter and setter

--- a/lib/requestExecutor.js
+++ b/lib/requestExecutor.js
@@ -311,9 +311,9 @@ const makeRequest = async (cortexRequest) => {
                 throw new Error(`Received error response: ${response.status}`);
             }
         } catch (error) {
-            const { response, duration } = error;
-            if (response) {
-                const status = response.status;
+            const { response, duration, code } = error;
+            if (response || code === 'ECONNRESET') {
+                const status = response?.status || 502; // default to 502 if ECONNRESET
                 // if there is only one endpoint, only retry select error codes
                 if (cortexRequest.model.endpoints.length === 1) {
                     if (status !== 429 &&

--- a/server/plugins/claude3VertexPlugin.js
+++ b/server/plugins/claude3VertexPlugin.js
@@ -263,7 +263,7 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
 
     const gcpAuthTokenHelper = this.config.get("gcpAuthTokenHelper");
     const authToken = await gcpAuthTokenHelper.getAccessToken();
-    cortexRequest.headers.Authorization = `Bearer ${authToken}`;
+    cortexRequest.auth.Authorization = `Bearer ${authToken}`;
 
     return this.executeRequest(cortexRequest);
   }

--- a/server/plugins/gemini15ChatPlugin.js
+++ b/server/plugins/gemini15ChatPlugin.js
@@ -164,7 +164,7 @@ class Gemini15ChatPlugin extends ModelPlugin {
 
         const gcpAuthTokenHelper = this.config.get('gcpAuthTokenHelper');
         const authToken = await gcpAuthTokenHelper.getAccessToken();
-        cortexRequest.headers.Authorization = `Bearer ${authToken}`;
+        cortexRequest.auth.Authorization = `Bearer ${authToken}`;
 
         return this.executeRequest(cortexRequest);
     }

--- a/server/plugins/geminiChatPlugin.js
+++ b/server/plugins/geminiChatPlugin.js
@@ -159,7 +159,7 @@ class GeminiChatPlugin extends ModelPlugin {
 
         const gcpAuthTokenHelper = this.config.get('gcpAuthTokenHelper');
         const authToken = await gcpAuthTokenHelper.getAccessToken();
-        cortexRequest.headers.Authorization = `Bearer ${authToken}`;
+        cortexRequest.auth.Authorization = `Bearer ${authToken}`;
 
         return this.executeRequest(cortexRequest);
     }

--- a/server/plugins/palmChatPlugin.js
+++ b/server/plugins/palmChatPlugin.js
@@ -147,7 +147,7 @@ class PalmChatPlugin extends ModelPlugin {
 
         const gcpAuthTokenHelper = this.config.get('gcpAuthTokenHelper');
         const authToken = await gcpAuthTokenHelper.getAccessToken();
-        cortexRequest.headers.Authorization = `Bearer ${authToken}`;
+        cortexRequest.auth.Authorization = `Bearer ${authToken}`;
 
         return this.executeRequest(cortexRequest);
     }

--- a/server/plugins/palmCompletionPlugin.js
+++ b/server/plugins/palmCompletionPlugin.js
@@ -61,7 +61,7 @@ class PalmCompletionPlugin extends ModelPlugin {
 
         const gcpAuthTokenHelper = this.config.get('gcpAuthTokenHelper');
         const authToken = await gcpAuthTokenHelper.getAccessToken();
-        cortexRequest.headers.Authorization = `Bearer ${authToken}`;
+        cortexRequest.auth.Authorization = `Bearer ${authToken}`;
 
         return this.executeRequest(cortexRequest);
     }


### PR DESCRIPTION
### Added
- New `auth` property in `CortexRequest` class to handle authentication separately from headers
- Support for `ECONNRESET` error handling in `makeRequest` function

### Changed
- Modified `CortexRequest` constructor to accept `auth` parameter
- Updated `headers` getter in `CortexRequest` to merge `_headers` and `_auth`
- Adjusted error handling in `makeRequest` to set default status 502 for `ECONNRESET` errors
- Updated plugins (Claude3Vertex, Gemini15Chat, GeminiChat, PalmChat, PalmCompletion) to use `auth` instead of `headers` for authorization

### Fixed
- Improved error handling for network-related issues in request execution