### PR TITLE
Provide an init callback so that complex posts using streams can be r…

### DIFF
--- a/lib/cortexRequest.js
+++ b/lib/cortexRequest.js
@@ -1,12 +1,13 @@
 import { selectEndpoint } from './requestExecutor.js';
 
 class CortexRequest {
-    constructor( { url, urlSuffix, data, params, headers, auth, cache, model, pathwayResolver, selectedEndpoint, stream } = {}) { 
+    constructor( { url, urlSuffix, data, params, headers, auth, cache, model, pathwayResolver, selectedEndpoint, stream, initCallback } = {}) { 
         this._url = url || '';
         this._urlSuffix = urlSuffix || '';
         this._data = data || {};
         this._params = params || {};
         this._headers = headers || {};
+        this._addHeaders = {};
         this._auth = auth || {};
         this._cache = cache || {};
         this._model = model || '';
@@ -14,6 +15,7 @@ class CortexRequest {
         this._selectedEndpoint = selectedEndpoint || {};
         this._stream = stream || false;
         this._method = 'POST';
+        this._initCallback = initCallback || null;
 
         if (this._pathwayResolver) {
             this._model = this._pathwayResolver.model;
@@ -24,17 +26,21 @@ class CortexRequest {
         }
     }
 
+    initRequest() {
+        if (typeof this._initCallback === 'function') {
+            this._initCallback(this);
+        }
+    }
+
     selectNewEndpoint() {
         const sep = selectEndpoint(this._model);
         if (sep) {
             this._selectedEndpoint = sep;
             this._url = sep.url;
-            this._data = { ...this._data, ...sep.params };
-            this._headers = { ...this._headers, ...sep.headers };
             if (sep.auth) {
                 this._auth = { ...sep.auth };
             }
-            this._params = { ...this._params, ...sep.params };
+            this.initRequest();
         }
     }
 
@@ -74,9 +80,22 @@ class CortexRequest {
         this._data = value;
     }
 
+    // initCallback getter and setter
+    get initCallback() {
+        return this._initCallback;
+    }
+
+    set initCallback(value) {
+        if (typeof value !== 'function') {
+            throw new Error('initCallback must be a function');
+        }
+        this._initCallback = value;
+        this.initRequest();
+    }
+
     // params getter and setter
     get params() {
-        return this._params;
+        return {...this._params, ...this._selectedEndpoint.params};
     }
 
     set params(value) {
@@ -85,11 +104,27 @@ class CortexRequest {
 
     // headers getter and setter
     get headers() {
-        return { ...this._headers, ...this._auth };
+        return { ...this._headers, ...this._selectedEndpoint.headers, ...this._auth, ...this._addHeaders };
     }
 
     set headers(value) {
         this._headers = value;
+    }
+
+    // addheaders getter and setter
+    get addHeaders() {
+        return this._addHeaders;
+    }
+
+    set addHeaders(value) {
+        // Create a new object to store the processed headers
+        this._addHeaders = {};
+
+        // Iterate over the input headers and convert keys to title case
+        for (const [key, val] of Object.entries(value)) {
+            const titleCaseKey = key.replace(/(^|-)./g, m => m.toUpperCase());
+            this._addHeaders[titleCaseKey] = val;
+        }
     }
 
     // auth getter and setter

--- a/lib/cortexRequest.js
+++ b/lib/cortexRequest.js
@@ -37,6 +37,7 @@ class CortexRequest {
         if (sep) {
             this._selectedEndpoint = sep;
             this._url = sep.url;
+            this._data = { ...this._data, ...sep.data, ...sep.params };
             if (sep.auth) {
                 this._auth = { ...sep.auth };
             }

--- a/lib/requestExecutor.js
+++ b/lib/requestExecutor.js
@@ -323,6 +323,8 @@ const makeRequest = async (cortexRequest) => {
                         status !== 504) {
                         return { response, duration };
                     }
+                    // set up for a retry by reinitializing the request
+                    cortexRequest.initRequest();
                 } else {
                     // if there are multiple endpoints, retry everything by default
                     // as it could be a temporary issue with one endpoint
@@ -331,6 +333,7 @@ const makeRequest = async (cortexRequest) => {
                     if (status == 400) {
                         return { response, duration };
                     }
+                    // set up for a retry by selecting a new endpoint, which will also reinitialize the request
                     cortexRequest.selectNewEndpoint();
                 }
 


### PR DESCRIPTION
…einitialized on retry.

### Changes to `lib/cortexRequest.js`:

- Added `initCallback` parameter to `CortexRequest` constructor
- Introduced `_addHeaders` property to store additional headers
- Implemented `initRequest` method to execute the `initCallback` if provided
- Updated `selectNewEndpoint` method to call `initRequest` after setting new endpoint
- Added getter and setter for `initCallback`
- Modified `params` getter to merge with `_selectedEndpoint.params`
- Updated `headers` getter to include `_selectedEndpoint.headers` and `_addHeaders`
- Implemented `addHeaders` getter and setter with automatic title case conversion for keys

### Changes to `lib/requestExecutor.js`:

- Added `cortexRequest.initRequest()` call before retrying a request
- Updated retry logic to reinitialize the request before attempting again

### Changes to `server/plugins/neuralSpacePlugin.js`:

- Refactored request configuration into an `nsInitCallback` function
- Set `initCallback` on the `cortexRequest` instance to use `nsInitCallback`
- Moved header and data configuration into the callback for better encapsulation

### Changes to `server/plugins/openAiWhisperPlugin.js`:

- Refactored request configuration into a `whisperInitCallback` function
- Set `initCallback` on the `cortexRequest` instance to use `whisperInitCallback`
- Moved header and data configuration into the callback for better encapsulation

These changes improve the flexibility and reusability of the `CortexRequest` class, allowing for dynamic request initialization and better handling of retries and multiple endpoints.