### PR TITLE
Support private containers in Azure

### DIFF
--- a/helper-apps/cortex-file-handler/blobHandler.js
+++ b/helper-apps/cortex-file-handler/blobHandler.js
@@ -53,7 +53,7 @@ function isBase64(str) {
   }
 }
 
-const { SAS_TOKEN_LIFE_DAYS = 7 } = process.env;
+const { SAS_TOKEN_LIFE_DAYS = 30 } = process.env;
 const GCP_SERVICE_ACCOUNT_KEY =
   process.env.GCP_SERVICE_ACCOUNT_KEY_BASE64 ||
   process.env.GCP_SERVICE_ACCOUNT_KEY ||


### PR DESCRIPTION
Cortex file handler now supports uploading to private containers in Azure storage. This is done using SAS tokens to grant access. The number of days that a SAS token is valid for can be configured using the `SAS_TOKEN_LIFE_DAYS` environment variable.