### PR TITLE
Move publish key to dynamicPathwaysConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,8 @@ The configuration should include the following properties:
   "awsAccessKeyId": "your_access_key_id",  // Only for AWS S3
   "awsSecretAccessKey": "your_secret_access_key",  // Only for AWS S3
   "awsRegion": "your_aws_region",  // Only for AWS S3
-  "awsBucketName": "cortexdynamicpathways"  // Optional, default is "cortexdynamicpathways"
+  "awsBucketName": "cortexdynamicpathways",  // Optional, default is "cortexdynamicpathways"
+  "publishKey": "your_publish_key"
 }
 ```
 
@@ -559,7 +560,7 @@ query ExecuteWorkspace($userId: String!, $pathwayName: String!, $text: String!) 
 
 To ensure the security of dynamic pathways:
 
-1. A `PATHWAY_PUBLISH_KEY` environment variable must be set to enable pathway publishing.
+1. A `publishKey` must be set in the dynamic pathways configuration to enable pathway publishing.
 2. This key must be provided in the `key` parameter when adding, updating, or deleting pathways.
 3. Each pathway is associated with a `userId` and `secret`. The secret must be provided to modify or delete an existing pathway.
 

--- a/config.js
+++ b/config.js
@@ -321,6 +321,7 @@ const createDynamicPathwayManager = async (config, basePathway) => {
         awsSecretAccessKey: dynamicPathwayConfig.awsSecretAccessKey,
         awsRegion: dynamicPathwayConfig.awsRegion,
         awsBucketName: dynamicPathwayConfig.awsBucketName || 'cortexdynamicpathways',
+        publishKey: dynamicPathwayConfig.publishKey,
     };
 
     const pathwayManager = new PathwayManager(storageConfig, basePathway);

--- a/config/dynamicPathwaysConfig.example.json
+++ b/config/dynamicPathwaysConfig.example.json
@@ -1,4 +1,5 @@
 {
     "storageType": "azure",
     "filePath": "./pathways/dynamic/pathways.json",
+    "publishKey": "development"
 }

--- a/lib/pathwayManager.js
+++ b/lib/pathwayManager.js
@@ -2,7 +2,6 @@ import { BlobServiceClient } from '@azure/storage-blob';
 import { S3 } from '@aws-sdk/client-s3';
 import fs from 'fs';
 import logger from './logger.js';
-const { PATHWAY_PUBLISH_KEY } = process.env;
 
 class StorageStrategy {
   async load() { throw new Error('Not implemented'); }
@@ -219,12 +218,17 @@ class S3Storage extends StorageStrategy {
 class PathwayManager {
   constructor(config, basePathway) {
     this.storage = this.getStorageStrategy(config);
+    this.publishKey = config.publishKey;
     this.pathways = {};
     this.lastUpdated = 0;
     this.basePathway = basePathway;
 
     if (config.storageType === 'local') {
       logger.warn('WARNING: Local file storage is being used for dynamic pathways. If there are multiple instances of Cortex, they will not be synced. Consider using cloud storage such as S3 or Azure for production environments.');
+    }
+
+    if (!this.publishKey) {
+      logger.warn('WARNING: dynamicPathwaysConfig.publishKey is not set. Dynamic pathways will not be editable in this instance of Cortex.');
     }
   }
 
@@ -344,11 +348,11 @@ class PathwayManager {
     return {
       Mutation: {
         putPathway: async (_, { name, pathway, userId, secret, displayName, key }) => {
-          if (!PATHWAY_PUBLISH_KEY) {
+          if (!this.publishKey) {
             throw new Error("Invalid configuration. Pathway publishing key is not configured in Cortex.")
           }
 
-          if (key !== PATHWAY_PUBLISH_KEY) {
+          if (key !== this.publishKey) {
             throw new Error('Invalid pathway publishing key. The key provided did not match the key configured in Cortex.');
           }
 
@@ -360,10 +364,10 @@ class PathwayManager {
           }
         },
         deletePathway: async (_, { name, userId, secret, key }) => {
-          if (!PATHWAY_PUBLISH_KEY) {
+          if (!this.publishKey) {
             throw new Error("Invalid configuration. Pathway publishing key is not configured in Cortex.")
           }
-          if (key !== PATHWAY_PUBLISH_KEY) {
+          if (key !== this.publishKey) {
             throw new Error('Invalid pathway publishing key. The key provided did not match the key configured in Cortex.');
           }
 


### PR DESCRIPTION
To reduce the amount of configuration required for dynamic pathways, moved the publishing key to the config