### PR TITLE
Reload pathways on publish and remove

### DIFF
--- a/lib/pathwayManager.js
+++ b/lib/pathwayManager.js
@@ -1,6 +1,7 @@
 import { BlobServiceClient } from '@azure/storage-blob';
 import { S3 } from '@aws-sdk/client-s3';
 import fs from 'fs';
+import path from 'path';
 import logger from './logger.js';
 
 class StorageStrategy {
@@ -19,6 +20,8 @@ class LocalStorage extends StorageStrategy {
     if (!fs.existsSync(this.filePath)) {
       // create it. log
       logger.info(`Creating dynamic pathways local file: ${this.filePath}`);
+      // create directory if it doesn't exist
+      await fs.promises.mkdir(path.dirname(this.filePath), { recursive: true });
       await fs.promises.writeFile(this.filePath, JSON.stringify({}));
     }
 
@@ -287,6 +290,7 @@ class PathwayManager {
       throw new Error('Both userId and secret are mandatory for adding or updating a pathway');
     }
 
+    await this.getLatestPathways();
     this.pathways[userId] = this.pathways[userId] || {};
 
     if (this.pathways[userId][name] && this.pathways[userId][name].secret !== secret) {
@@ -300,9 +304,12 @@ class PathwayManager {
   }
 
   async removePathway(name, userId, secret) {
+    await this.getLatestPathways();
+
     if (!this.pathways[userId] || !this.pathways[userId][name]) {
       return;
     }
+
     if (this.pathways[userId][name].secret !== secret) {
       throw new Error('Invalid secret');
     }
@@ -382,7 +389,7 @@ class PathwayManager {
     };
   }
 
-  async getPathways() {
+  async getLatestPathways() {
     try {
       const currentTimestamp = await this.storage.getLastModified();
 
@@ -394,13 +401,13 @@ class PathwayManager {
 
       return this.pathways;
     } catch (error) {
-      logger.error('Error in getPathways:', error);
+      logger.error('Error in getLatestPathways:', error);
       throw error;
     }
   }
 
   async getPathway(userId, pathwayName) {
-    const pathways = await this.getPathways();
+    const pathways = await this.getLatestPathways();
 
     if (!pathways[userId] || !pathways[userId][pathwayName]) {
       throw new Error(`Pathway '${pathwayName}' not found for user '${userId}'`);


### PR DESCRIPTION
We were checking for new pathways on get, but were not checking on publish and remove. This prevents a user from publishing and unpublishing in quick succession when session affinity is turned off (e.g. the user's publish request would go to one instance and then the unpublish request would go to a separate instance and fail).