### PR TITLE
Include system prompt in published pathways

### DIFF
--- a/lib/pathwayManager.js
+++ b/lib/pathwayManager.js
@@ -3,6 +3,7 @@ import { S3 } from '@aws-sdk/client-s3';
 import fs from 'fs';
 import path from 'path';
 import logger from './logger.js';
+import { Prompt } from '../server/prompt.js';
 
 class StorageStrategy {
   async load() { throw new Error('Not implemented'); }
@@ -285,6 +286,33 @@ class PathwayManager {
     await this.storage.save(pathways);
   }
 
+  /**
+   * Transforms the prompts in a pathway to include the system prompt.
+   * @param {Object} pathway - The pathway object to transform.
+   * @param {string[]} pathway.prompt - Array of user prompts.
+   * @param {string} pathway.systemPrompt - The system prompt to prepend to each user prompt.
+   * @returns {Object} A new pathway object with transformed prompts.
+   */
+  async transformPrompts(pathway) {
+    const { prompt, systemPrompt } = pathway;
+
+    const newPathway = { ...pathway };
+
+    // Transform each prompt in the array
+    newPathway.prompt = prompt.map(p => {
+      return new Prompt({
+        messages: [
+          // Prepend the system prompt as a system message
+          { "role": "system", "content": systemPrompt },
+          // Add the original prompt as a user message
+          { "role": "user", "content": p },
+        ]
+      })
+    });
+
+    return newPathway;
+  }
+
   async putPathway(name, pathway, userId, secret, displayName) {
     if (!userId || !secret) {
       throw new Error('Both userId and secret are mandatory for adding or updating a pathway');
@@ -329,6 +357,7 @@ class PathwayManager {
     
     input PathwayInput {
       prompt: [String!]!
+      systemPrompt: String
       inputParameters: JSONObject
       model: String
       enableCache: Boolean
@@ -413,7 +442,7 @@ class PathwayManager {
       throw new Error(`Pathway '${pathwayName}' not found for user '${userId}'`);
     }
 
-    return pathways[userId][pathwayName];
+    return this.transformPrompts(pathways[userId][pathwayName]);
   }
 }
 


### PR DESCRIPTION
This PR enhances the functionality of our pathway management system by incorporating the system prompt into the published pathways. This change ensures that when pathways are retrieved, they include both the user prompts and the associated system prompt, providing a more complete context for each interaction.

## Implementation Details

#### New Method: `transformPrompts`
- Added a new method `transformPrompts` to the `PathwayManager` class.
- This method takes a pathway object and transforms its prompts to include the system prompt.
- Each prompt in the pathway is now wrapped in a `Prompt` object with two messages:
  1. A system message containing the system prompt
  2. A user message containing the original prompt
