### PR TITLE
Add Replicate as a Flux Image source for Cortex

### DIFF
--- a/config.js
+++ b/config.js
@@ -202,6 +202,33 @@ var config = convict({
                     "Content-Type": "application/json"
                 },
             },
+            "replicate-flux-11-pro": {
+                "type": "REPLICATE-API",
+                "url": "https://api.replicate.com/v1/models/black-forest-labs/flux-1.1-pro/predictions",
+                "headers": {
+                    "Prefer": "wait",
+                    "Authorization": "Token {{REPLICATE_API_KEY}}",
+                    "Content-Type": "application/json"
+                },
+            },
+            "replicate-flux-1-schnell": {
+                "type": "REPLICATE-API",
+                "url": "https://api.replicate.com/v1/models/black-forest-labs/flux-schnell/predictions",
+                "headers": {
+                    "Prefer": "wait",
+                    "Authorization": "Token {{REPLICATE_API_KEY}}",
+                    "Content-Type": "application/json"
+                },
+            },
+            "replicate-flux-1-dev": {
+                "type": "REPLICATE-API",
+                "url": "https://api.replicate.com/v1/models/black-forest-labs/flux-dev/predictions",
+                "headers": {
+                    "Prefer": "wait",
+                    "Authorization": "Token {{REPLICATE_API_KEY}}",
+                    "Content-Type": "application/json"
+                },
+            },
         },
         env: 'CORTEX_MODELS'
     },
@@ -246,6 +273,12 @@ var config = convict({
         format: String,
         default: null,
         env: 'REDIS_ENCRYPTION_KEY',
+        sensitive: true
+    },
+    replicateApiKey: {
+        format: String,
+        default: null,
+        env: 'REPLICATE_API_KEY',
         sensitive: true
     },
     runwareAiApiKey: {

--- a/pathways/flux_image.js
+++ b/pathways/flux_image.js
@@ -1,8 +1,9 @@
 export default {
   prompt: ["{{text}}"],
-  model: "runware-flux-schnell",
+
   enableDuplicateRequests: false,
   inputParameters: {
+    model: "runware-flux-schnell",
     negativePrompt: "",
     width: 512,
     height: 512,

--- a/server/modelExecutor.js
+++ b/server/modelExecutor.js
@@ -25,7 +25,8 @@ import Gemini15VisionPlugin from './plugins/gemini15VisionPlugin.js';
 import AzureBingPlugin from './plugins/azureBingPlugin.js';
 import Claude3VertexPlugin from './plugins/claude3VertexPlugin.js';
 import NeuralSpacePlugin from './plugins/neuralSpacePlugin.js';
-import RunwareAiPlugin from './plugins/runwareAIPlugin.js';
+import RunwareAiPlugin from './plugins/runwareAiPlugin.js';
+import ReplicateApiPlugin from './plugins/replicateApiPlugin.js';
 
 class ModelExecutor {
     constructor(pathway, model) {
@@ -107,6 +108,9 @@ class ModelExecutor {
                 break;
             case 'RUNWARE-AI':
                 plugin = new RunwareAiPlugin(pathway, model);
+                break;
+            case 'REPLICATE-API':
+                plugin = new ReplicateApiPlugin(pathway, model);
                 break;
             default:
                 throw new Error(`Unsupported model type: ${model.type}`);

--- a/server/plugins/azureCognitivePlugin.js
+++ b/server/plugins/azureCognitivePlugin.js
@@ -123,7 +123,7 @@ class AzureCognitivePlugin extends ModelPlugin {
             data.filter = `owner eq '${savedContextId}'`;
 
             if(chatId){
-                data.filter += ` and chatId eq '${chatId}'`;
+                data.filter += ` and (chatId eq '${chatId}' or docId eq '${savedContextId}-indexmainpane')`;
             }
         }
 

--- a/server/plugins/replicateApiPlugin.js
+++ b/server/plugins/replicateApiPlugin.js
@@ -1,0 +1,71 @@
+// replicateApiPlugin.js
+import ModelPlugin from "./modelPlugin.js";
+import logger from "../../lib/logger.js";
+
+class ReplicateApiPlugin extends ModelPlugin {
+  constructor(pathway, model) {
+    super(pathway, model);
+  }
+
+  // Set up parameters specific to the Replicate API
+  getRequestParameters(text, parameters, prompt) {
+    const combinedParameters = { ...this.promptParameters, ...parameters };
+    const { modelPromptText } = this.getCompiledPrompt(
+      text,
+      parameters,
+      prompt,
+    );
+
+    const requestParameters = {
+      input: {
+        aspect_ratio: "1:1",
+        output_format: "webp",
+        output_quality: 80,
+        prompt: modelPromptText,
+        //prompt_upsampling: false,
+        //safety_tolerance: 5,
+        go_fast: true,
+        megapixels: "1",
+        num_outputs: combinedParameters.numberResults,
+      },
+    };
+
+    return requestParameters;
+  }
+
+  // Execute the request to the Replicate API
+  async execute(text, parameters, prompt, cortexRequest) {
+    const requestParameters = this.getRequestParameters(
+      text,
+      parameters,
+      prompt,
+    );
+
+    cortexRequest.data = requestParameters;
+    cortexRequest.params = requestParameters.params;
+
+    return this.executeRequest(cortexRequest);
+  }
+
+  // Parse the response from the Replicate API
+  parseResponse(data) {
+    if (data.data) {
+      return JSON.stringify(data.data);
+    }
+    return JSON.stringify(data);
+  }
+
+  // Override the logging function to display the request and response
+  logRequestData(data, responseData, prompt) {
+    const modelInput = data?.input?.prompt;
+
+    logger.verbose(`${modelInput}`);
+    logger.verbose(`${this.parseResponse(responseData)}`);
+
+    prompt &&
+      prompt.debugInfo &&
+      (prompt.debugInfo += `\n${JSON.stringify(data)}`);
+  }
+}
+
+export default ReplicateApiPlugin;

--- a/server/plugins/runwareAIPlugin.js
+++ b/server/plugins/runwareAIPlugin.js
@@ -57,7 +57,7 @@ class RunwareAiPlugin extends ModelPlugin {
     return this.executeRequest(cortexRequest);
   }
 
-  // Parse the response from the Azure Translate API
+  // Parse the response from the Runware API
   parseResponse(data) {
     if (data.data) {
       return JSON.stringify(data.data);


### PR DESCRIPTION
## Release Notes

### New Features
- Added support for Replicate API models:
  - `replicate-flux-11-pro`
  - `replicate-flux-1-schnell`
  - `replicate-flux-1-dev`
- Implemented a new `ReplicateApiPlugin` for handling Replicate API requests

### Enhancements
- Updated `flux_image` pathway to use dynamic model selection

### Configuration Changes
- Added `replicateApiKey` configuration option