### PR TITLE
Do not pass "memoryContext" parameter to azure video translate

### DIFF
--- a/server/plugins/azureVideoTranslatePlugin.js
+++ b/server/plugins/azureVideoTranslatePlugin.js
@@ -27,7 +27,7 @@ class AzureVideoTranslatePlugin extends ModelPlugin {
 
     getRequestParameters(_, parameters, __) {
         const excludedParameters = [
-            'text', 'parameters', 'prompt', 'promptParameters', 'previousResult', 'stream'
+            'text', 'parameters', 'prompt', 'promptParameters', 'previousResult', 'stream', 'memoryContext'
         ];
         
         return Object.fromEntries(


### PR DESCRIPTION
This is a newly-introduced parameter and causes the DLL to throw an error since it's not a valid parameter for the DLL.