### PR TITLE
Adding support for full o1, reasoning_effort, and response_format

### DIFF
--- a/config.js
+++ b/config.js
@@ -171,6 +171,21 @@ var config = convict({
                 "maxReturnTokens": 4096,
                 "supportsStreaming": true
             },
+            "oai-o1": {
+                "type": "OPENAI-REASONING",
+                "url": "https://api.openai.com/v1/chat/completions",
+                "headers": {
+                    "Authorization": "Bearer {{OPENAI_API_KEY}}",
+                    "Content-Type": "application/json"
+                },
+                "params": {
+                    "model": "o1"
+                },
+                "requestsPerSecond": 10,
+                "maxTokenLength": 200000,
+                "maxReturnTokens": 100000,
+                "supportsStreaming": false
+            },
             "oai-o1-mini": {
                 "type": "OPENAI-REASONING",
                 "url": "https://api.openai.com/v1/chat/completions",

--- a/pathways/system/entity/sys_generator_reasoning.js
+++ b/pathways/system/entity/sys_generator_reasoning.js
@@ -15,7 +15,7 @@ export default {
         aiName: "Jarvis",
         language: "English",
     },
-    model: 'oai-o1-mini',
+    model: 'oai-o1',
     useInputChunking: false,
     enableDuplicateRequests: false,
     timeout: 600,

--- a/pathways/system/rest_streaming/sys_openai_chat_o1.js
+++ b/pathways/system/rest_streaming/sys_openai_chat_o1.js
@@ -1,0 +1,19 @@
+// sys_openai_chat_o1.js
+
+import { Prompt } from '../../../server/prompt.js';
+
+export default {
+    prompt:
+    [
+        new Prompt({ messages: [
+            "{{messages}}",
+        ]}),
+    ],
+    inputParameters: {
+        messages: [],
+    },
+    model: 'oai-o1',
+    useInputChunking: false,
+    emulateOpenAIChatModel: 'o1',
+    enableDuplicateRequests: false,
+}

--- a/pathways/system/rest_streaming/sys_openai_chat_o1_mini.js
+++ b/pathways/system/rest_streaming/sys_openai_chat_o1_mini.js
@@ -1,0 +1,19 @@
+// sys_openai_chat_o1_mini.js
+
+import { Prompt } from '../../../server/prompt.js';
+
+export default {
+    prompt:
+    [
+        new Prompt({ messages: [
+            "{{messages}}",
+        ]}),
+    ],
+    inputParameters: {
+        messages: [],
+    },
+    model: 'oai-o1-mini',
+    useInputChunking: false,
+    emulateOpenAIChatModel: 'o1-mini',
+    enableDuplicateRequests: false,
+}

--- a/server/plugins/openAiReasoningPlugin.js
+++ b/server/plugins/openAiReasoningPlugin.js
@@ -49,8 +49,17 @@ class OpenAIReasoningPlugin extends OpenAIChatPlugin {
         requestParameters.max_completion_tokens = maxTokens ? Math.min(maxTokens, modelMaxReturnTokens) : modelMaxReturnTokens;
         requestParameters.temperature = 1;
 
-        if (this.promptParameters.json) {
-            //requestParameters.response_format = { type: "json_object", }
+        if (this.promptParameters.reasoningEffort) {
+            const effort = this.promptParameters.reasoningEffort.toLowerCase();
+            if (['high', 'medium', 'low'].includes(effort)) {
+                requestParameters.reasoning_effort = effort;
+            } else {
+                requestParameters.reasoning_effort = 'low';
+            }
+        }
+        
+        if (this.promptParameters.responseFormat) {
+            requestParameters.response_format = this.promptParameters.responseFormat;
         }
 
         return requestParameters;


### PR DESCRIPTION
- Added support for OpenAI's O1 model configuration including higher token limits (200K input/100K output)
- Updated system generator reasoning pathway to use full O1 model instead of mini version
- Added new REST streaming pathways for both O1 and O1-mini models
- Enhanced OpenAI reasoning plugin to support configurable reasoning effort levels (high/medium/low) and custom response formats