### PR TITLE
Dynamic pathways should include the user's provided text as context

### DIFF
--- a/lib/pathwayManager.js
+++ b/lib/pathwayManager.js
@@ -305,7 +305,7 @@ class PathwayManager {
           // Prepend the system prompt as a system message
           { "role": "system", "content": systemPrompt },
           // Add the original prompt as a user message
-          { "role": "user", "content": p },
+          { "role": "user", "content": `{{text}}\n\n${p}` },
         ]
       })
     });


### PR DESCRIPTION
The input parameter "text" was not being passed to the model because the prompt that was being constructed for dynamic pathways did not contain the {{text}} parameter.