### PR TITLE
Add o3-mini! Remove o1-mini and o1-preview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cortex
-Cortex simplifies and accelerates the process of creating applications that harness the power of modern AI models like GPT-4o (chatGPT), o1, Gemini, the Claude series, Flux, Grok and more by poviding a structured interface (GraphQL or REST) to a powerful prompt execution environment. This enables complex augmented prompting and abstracts away most of the complexity of managing model connections like chunking input, rate limiting, formatting output, caching, and handling errors.
+Cortex simplifies and accelerates the process of creating applications that harness the power of modern AI models like GPT-4o (chatGPT), o1, o3-mini, Gemini, the Claude series, Flux, Grok and more by poviding a structured interface (GraphQL or REST) to a powerful prompt execution environment. This enables complex augmented prompting and abstracts away most of the complexity of managing model connections like chunking input, rate limiting, formatting output, caching, and handling errors.
 ## Why build Cortex?
 Modern AI models are transformational, but a number of complexities emerge when developers start using them to deliver application-ready functions. Most models require precisely formatted, carefully engineered and sequenced prompts to produce consistent results, and the responses are typically largely unstructured text without validation or formatting. Additionally, these models are evolving rapidly, are typically costly and slow to query and implement hard request size and rate restrictions that need to be carefully navigated for optimum throughput. Cortex offers a solution to these problems and provides a simple and extensible package for interacting with NL AI models.
 
@@ -20,7 +20,7 @@ Just about anything! It's kind of an LLM swiss army knife.  Here are some ideas:
   - OpenAI models:
     - GPT-4 Omni (GPT-4o)
     - GPT-4 Omni Mini (GPT-4o-mini)
-    - O1 (including o1-mini and o1-preview) (Advanced reasoning models)
+    - O1 and O3-mini (Advanced reasoning models)
     - Most of the earlier GPT models (GPT-4, 3.5 Turbo, etc.)
   - Google models:
     - Gemini 1.5 Pro
@@ -521,7 +521,7 @@ Models are configured in the `models` section of the config. Each model can have
 
 - `OPENAI-CHAT`: For OpenAI chat models (legacy GPT-3.5)
 - `OPENAI-VISION`: For multimodal models (GPT-4o, GPT-4o-mini) supporting text, images, and other content types
-- `OPENAI-REASONING`: For O1 reasoning model with vision capabilities
+- `OPENAI-REASONING`: For O1 and O3-mini reasoning models with vision capabilities
 - `OPENAI-COMPLETION`: For OpenAI completion models
 - `OPENAI-WHISPER`: For Whisper transcription
 - `GEMINI-1.5-CHAT`: For Gemini 1.5 Pro chat models

--- a/config.js
+++ b/config.js
@@ -207,7 +207,7 @@ var config = convict({
                 "maxReturnTokens": 100000,
                 "supportsStreaming": false
             },
-            "oai-o1-mini": {
+            "oai-o3-mini": {
                 "type": "OPENAI-REASONING",
                 "url": "https://api.openai.com/v1/chat/completions",
                 "headers": {
@@ -215,26 +215,11 @@ var config = convict({
                     "Content-Type": "application/json"
                 },
                 "params": {
-                    "model": "o1-mini"
+                    "model": "o3-mini"
                 },
                 "requestsPerSecond": 10,
-                "maxTokenLength": 128000,
-                "maxReturnTokens": 65536,
-                "supportsStreaming": false
-            },
-            "oai-o1-preview": {
-                "type": "OPENAI-REASONING",
-                "url": "https://api.openai.com/v1/chat/completions",
-                "headers": {
-                    "Authorization": "Bearer {{OPENAI_API_KEY}}",
-                    "Content-Type": "application/json"
-                },
-                "params": {
-                    "model": "o1-preview"
-                },
-                "requestsPerSecond": 10,
-                "maxTokenLength": 128000,
-                "maxReturnTokens": 32768,
+                "maxTokenLength": 200000,
+                "maxReturnTokens": 100000,
                 "supportsStreaming": false
             },
             "azure-bing": {

--- a/pathways/system/entity/sys_generator_reasoning.js
+++ b/pathways/system/entity/sys_generator_reasoning.js
@@ -15,7 +15,7 @@ export default {
         aiName: "Jarvis",
         language: "English",
     },
-    model: 'oai-o1',
+    model: 'oai-o3-mini',
     useInputChunking: false,
     enableDuplicateRequests: false,
     timeout: 600,

--- a/pathways/system/rest_streaming/sys_openai_chat_o3_mini.js
+++ b/pathways/system/rest_streaming/sys_openai_chat_o3_mini.js
@@ -1,4 +1,4 @@
-// sys_openai_chat_o1_mini.js
+// sys_openai_chat_o3_mini.js
 
 import { Prompt } from '../../../server/prompt.js';
 
@@ -12,8 +12,8 @@ export default {
     inputParameters: {
         messages: [],
     },
-    model: 'oai-o1-mini',
+    model: 'oai-o3-mini',
     useInputChunking: false,
-    emulateOpenAIChatModel: 'o1-mini',
+    emulateOpenAIChatModel: 'o3-mini',
     enableDuplicateRequests: false,
 }


### PR DESCRIPTION
This pull request includes changes to update the Cortex application to support the new `o3-mini` model, replacing the older `o1-mini` and `o1-preview` models. The most important changes include updates to the documentation, configuration files, and model references in the code.

Updates to documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R2): Updated the model list and configuration sections to include `o3-mini` and remove `o1-mini` and `o1-preview` references. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R2) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L524-R524)

Changes to configuration:

* [`config.js`](diffhunk://#diff-e8e9eea3276b2de9a74fd257902dc74c846f6fc8653bbddf45d738b71201f93dL210-R222): Replaced the `oai-o1-mini` and `oai-o1-preview` configurations with `oai-o3-mini`, updating relevant parameters and removing the outdated configurations.

Model references in code:

* [`pathways/system/entity/sys_generator_reasoning.js`](diffhunk://#diff-0690f190dc8a8157a5227c7a5ef5e758370c7ca9af59d79039ca0c7000bc06e3L18-R18): Updated the model reference from `oai-o1` to `oai-o3-mini`.
* [`pathways/system/rest_streaming/sys_openai_chat_o3_mini.js`](diffhunk://#diff-e17aab0b65102d44b7840309e370b1fd8f55643d7c30bbacc5aa22a2d039c49eL1-R1): Renamed the file from `sys_openai_chat_o1_mini.js` and updated the model references within the file. [[1]](diffhunk://#diff-e17aab0b65102d44b7840309e370b1fd8f55643d7c30bbacc5aa22a2d039c49eL1-R1) [[2]](diffhunk://#diff-e17aab0b65102d44b7840309e370b1fd8f55643d7c30bbacc5aa22a2d039c49eL15-R17)