### PR TITLE
Support Youtube URLs as a special case

### DIFF
--- a/server/plugins/gemini15VisionPlugin.js
+++ b/server/plugins/gemini15VisionPlugin.js
@@ -66,6 +66,13 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
                                         data: base64Data
                                     }
                                 };
+                            } else if (fileUrl.includes('youtube.com/') || fileUrl.includes('youtu.be/')) {
+                                return {
+                                    fileData: {
+                                        mimeType: 'video/youtube',
+                                        fileUri: fileUrl
+                                    }
+                                };
                             }
                             return null;
                         }


### PR DESCRIPTION
This pull request includes an enhancement to the `Gemini15VisionPlugin` class in the `server/plugins/gemini15VisionPlugin.js` file. The change adds support for handling YouTube video URLs.

Enhancements:

* [`server/plugins/gemini15VisionPlugin.js`](diffhunk://#diff-e58323c31899408e5b1180c7cf561518841b4e97ca332fcc021726d2e4bfc464R69-R75): Added a condition to handle YouTube video URLs by checking if the `fileUrl` includes 'youtube.com/' or 'youtu.be/' and returning the appropriate `fileData` object with `mimeType` set to 'video/youtube'.