### PR TITLE
Fix sending model to recraft pathway

### DIFF
--- a/pathways/system/entity/sys_generator_image.js
+++ b/pathways/system/entity/sys_generator_image.js
@@ -100,7 +100,7 @@ Instructions: As part of a conversation with the user, you have been asked to cr
                     model = "replicate-flux-1-schnell";
                 }
                 if (renderText) {
-                    return await callPathway('image_recraft', {...args, text: prompt, stream: false });
+                    return await callPathway('image_recraft', {...args, text: prompt, model, stream: false });
                 } else {
                     return await callPathway('image_flux', {...args, text: prompt, negativePrompt, numberResults, model, stream: false });
                 }

--- a/pathways/system/entity/sys_router_tool.js
+++ b/pathways/system/entity/sys_router_tool.js
@@ -58,7 +58,8 @@ toolMessage Guidelines:
 - The message is a filler message to the user to let them know you're working on their request.
 - The message should be consistent in style and tone with the rest of your responses in the conversation history.
 - The message should be brief and conversational and flow naturally with the conversation history.
-- The message should not refer to the tool directly, but rather what you're trying to accomplish. E.g. for the memory tool, the message would be something like "Let me think about that for a moment..." or "I'm trying to remember...", etc.
+- The message should not refer to the tool use directly, but rather what you're trying to do.
+- The message should never be an attempt to answer the user's question directly.
 
 If no tool is required, return:
 {"toolRequired": false, "toolReason": "explanation of why no tool was necessary"}


### PR DESCRIPTION
This pull request includes several updates to the `pathways/system/entity` directory, focusing on enhancing the functionality and improving the guidelines for tool messages.

### Enhancements to functionality:

* [`pathways/system/entity/sys_generator_image.js`](diffhunk://#diff-ba6ddd09ee13350265e25ed4783d68010b6eb28a77a0dc7b51dd02071df2b8b5L103-R103): Added the `model` parameter to the `callPathway` function when `renderText` is true to ensure the correct model is used.

### Improvements to tool message guidelines:

* [`pathways/system/entity/sys_router_tool.js`](diffhunk://#diff-7855593195ded770e1c8a58052c911ed89a8443c0669cadb70cc35f5fe69f14bL61-R62): Updated the guidelines to clarify that messages should not refer to tool use directly and should never attempt to answer the user's question directly.