### PR TITLE
Add multimodal support to OpenAI REST compatibility

### DIFF
--- a/pathways/system/rest_streaming/sys_claude_35_sonnet.js
+++ b/pathways/system/rest_streaming/sys_claude_35_sonnet.js
@@ -11,7 +11,7 @@ export default {
         ]}),
     ],
     inputParameters: {
-        messages: [],
+        messages: [{role: '', content: []}],
     },
     model: 'claude-35-sonnet-vertex',
     useInputChunking: false,

--- a/pathways/system/rest_streaming/sys_claude_3_haiku.js
+++ b/pathways/system/rest_streaming/sys_claude_3_haiku.js
@@ -11,7 +11,7 @@ export default {
         ]}),
     ],
     inputParameters: {
-        messages: [],
+        messages: [{role: '', content: []}],
     },
     model: 'claude-3-haiku-vertex',
     useInputChunking: false,

--- a/pathways/system/rest_streaming/sys_google_gemini_chat.js
+++ b/pathways/system/rest_streaming/sys_google_gemini_chat.js
@@ -11,7 +11,7 @@ export default {
         ]}),
     ],
     inputParameters: {
-        messages: [],
+        messages: [{role: '', content: []}],
     },
     model: 'gemini-pro-chat',
     useInputChunking: false,

--- a/pathways/system/rest_streaming/sys_openai_chat_o1.js
+++ b/pathways/system/rest_streaming/sys_openai_chat_o1.js
@@ -10,7 +10,7 @@ export default {
         ]}),
     ],
     inputParameters: {
-        messages: [],
+        messages: [{role: '', content: []}],
     },
     model: 'oai-o1',
     useInputChunking: false,

--- a/pathways/system/rest_streaming/sys_openai_chat_o3_mini.js
+++ b/pathways/system/rest_streaming/sys_openai_chat_o3_mini.js
@@ -10,7 +10,7 @@ export default {
         ]}),
     ],
     inputParameters: {
-        messages: [],
+        messages: [{role: '', content: []}],
     },
     model: 'oai-o3-mini',
     useInputChunking: false,

--- a/tests/openai_api.test.js
+++ b/tests/openai_api.test.js
@@ -60,6 +60,36 @@ test('POST /chat/completions', async (t) => {
   t.true(Array.isArray(response.body.choices));
 });
 
+test('POST /chat/completions with multimodal content', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      model: 'claude-3.5-sonnet',
+      messages: [{
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What do you see in this image?'
+          },
+          {
+            type: 'image',
+            image_url: {
+              url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQrJyEwPENBMDQ4NDQ0QUJCSkNLS0tNSkpQUFFQR1BTYWNgY2FQYWFQYWj/2wBDARUXFyAeIBohHh4oIiE2LCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k='
+            }
+          }
+        ]
+      }],
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.choices[0].message.content);
+});
+
 async function connectToSSEEndpoint(url, endpoint, payload, t, customAssertions) {
     return new Promise(async (resolve, reject) => {
         try {
@@ -143,5 +173,307 @@ test('POST SSE: /v1/chat/completions should send a series of events and a [DONE]
     };
     
     await connectToSSEEndpoint(url, '/chat/completions', payload, t, chatCompletionsAssertions);
+});
+
+test('POST SSE: /v1/chat/completions with multimodal content should send a series of events and a [DONE] event', async (t) => {
+    const payload = {
+        model: 'claude-3.5-sonnet',
+        messages: [{
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'What do you see in this image?'
+            },
+            {
+              type: 'image',
+              image_url: {
+                url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQrJyEwPENBMDQ4NDQ0QUJCSkNLS0tNSkpQUFFQR1BTYWNgY2FQYWFQYWj/2wBDARUXFyAeIBohHh4oIiE2LCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k='
+              }
+            }
+          ]
+        }],
+        stream: true,
+    };
+    
+    const url = `http://localhost:${process.env.CORTEX_PORT}/v1`;
+    
+    const multimodalChatCompletionsAssertions = (t, messageJson) => {
+        t.truthy(messageJson.id);
+        t.is(messageJson.object, 'chat.completion.chunk');
+        t.truthy(messageJson.choices[0].delta);
+        if (messageJson.choices[0].finish_reason === 'stop') {
+          t.truthy(messageJson.choices[0].delta);
+        }
+    };
+    
+    await connectToSSEEndpoint(url, '/chat/completions', payload, t, multimodalChatCompletionsAssertions);
+});  
+
+test('POST /chat/completions should handle multimodal content for non-multimodal model', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      model: 'gpt-3.5-turbo',
+      messages: [{
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What do you see in this image?'
+          },
+          {
+            type: 'image',
+            image_url: {
+              url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD...'
+            }
+          }
+        ]
+      }],
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.choices[0].message.content);
+});
+
+test('POST SSE: /v1/chat/completions should handle streaming multimodal content for non-multimodal model', async (t) => {
+  const payload = {
+    model: 'gpt-3.5-turbo',
+    messages: [{
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'What do you see in this image?'
+        },
+        {
+          type: 'image',
+          image_url: {
+            url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD...'
+          }
+        }
+      ]
+    }],
+    stream: true,
+  };
+
+  const streamingAssertions = (t, messageJson) => {
+    t.truthy(messageJson.id);
+    t.is(messageJson.object, 'chat.completion.chunk');
+    t.truthy(messageJson.choices[0].delta);
+    if (messageJson.choices[0].finish_reason === 'stop') {
+      t.truthy(messageJson.choices[0].delta);
+    }
+  };
+
+  await connectToSSEEndpoint(
+    `http://localhost:${process.env.CORTEX_PORT}/v1`,
+    '/chat/completions',
+    payload,
+    t,
+    streamingAssertions
+  );
+});
+
+test('POST /chat/completions should handle malformed multimodal content', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      model: 'claude-3.5-sonnet',
+      messages: [{
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            // Missing text field
+          },
+          {
+            type: 'image',
+            // Missing image_url
+          }
+        ]
+      }],
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.choices[0].message.content);
+});
+
+test('POST /chat/completions should handle invalid image data', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      model: 'claude-3.5-sonnet',
+      messages: [{
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What do you see in this image?'
+          },
+          {
+            type: 'image',
+            image_url: {
+              url: 'not-a-valid-base64-image'
+            }
+          }
+        ]
+      }],
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.choices[0].message.content);
+});  
+
+test('POST /completions should handle model parameters', async (t) => {
+  const response = await got.post(`${API_BASE}/completions`, {
+    json: {
+      model: 'gpt-3.5-turbo',
+      prompt: 'Say this is a test',
+      temperature: 0.7,
+      max_tokens: 100,
+      top_p: 1,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'text_completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.choices[0].text);
+});
+
+test('POST /chat/completions should handle function calling', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: 'What is the weather in Boston?' }],
+      functions: [{
+        name: 'get_weather',
+        description: 'Get the current weather in a given location',
+        parameters: {
+          type: 'object',
+          properties: {
+            location: {
+              type: 'string',
+              description: 'The city and state, e.g. San Francisco, CA'
+            },
+            unit: {
+              type: 'string',
+              enum: ['celsius', 'fahrenheit']
+            }
+          },
+          required: ['location']
+        }
+      }],
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  const choice = response.body.choices[0];
+  t.true(['function_call', 'stop'].includes(choice.finish_reason));
+  if (choice.finish_reason === 'function_call') {
+    t.truthy(choice.message.function_call);
+    t.truthy(choice.message.function_call.name);
+    t.truthy(choice.message.function_call.arguments);
+  }
+});
+
+test('POST /chat/completions should validate response format', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: 'Hello!' }],
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.id);
+  t.truthy(response.body.created);
+  t.truthy(response.body.model);
+  
+  const choice = response.body.choices[0];
+  t.is(typeof choice.index, 'number');
+  t.truthy(choice.message);
+  t.truthy(choice.message.role);
+  t.truthy(choice.message.content);
+  t.truthy(choice.finish_reason);
+});
+
+test('POST /chat/completions should handle system messages', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'Hello!' }
+      ],
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.choices[0].message.content);
+});
+
+test('POST /chat/completions should handle errors gracefully', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      // Missing required model field
+      messages: [{ role: 'user', content: 'Hello!' }],
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.choices[0].message.content);
+});
+
+test('POST /chat/completions should handle token limits', async (t) => {
+  const response = await got.post(`${API_BASE}/chat/completions`, {
+    json: {
+      model: 'gpt-3.5-turbo',
+      messages: [{ 
+        role: 'user', 
+        content: 'Hello!'.repeat(5000) // Very long message
+      }],
+      max_tokens: 100,
+      stream: false,
+    },
+    responseType: 'json',
+  });
+
+  t.is(response.statusCode, 200);
+  t.is(response.body.object, 'chat.completion');
+  t.true(Array.isArray(response.body.choices));
+  t.truthy(response.body.choices[0].message.content);
 });  
   


### PR DESCRIPTION
This pull request includes several significant changes to the handling of messages and multimodal content in various pathways and the server. The most important changes include updates to the message structure, new handling for multimodal content, and additional tests to ensure proper functionality.

Updates to message structure:

* Updated the `messages` parameter in multiple pathway files (`sys_claude_35_sonnet.js`, `sys_claude_3_haiku.js`, `sys_google_gemini_chat.js`, `sys_openai_chat_o1.js`, `sys_openai_chat_o3_mini.js`) to include `role` and `content` fields. [[1]](diffhunk://#diff-83f278f82a22c621afb64398b00f5a97386930c4baef1db2b0e53ea99cab240fL14-R14) [[2]](diffhunk://#diff-40ae8bafbdd8c1d7c9678f21d87762bc8c77d4c53467c981d1ebfc1ea11901e0L14-R14) [[3]](diffhunk://#diff-ea7d906d4a1bf1f884417106b8b48abf757f98bc679c536964b1111cb8b407a6L14-R14) [[4]](diffhunk://#diff-a37fec05370b5b1f4a357a9bd2a863c94dd947152bb26d0dc95c13f377d285c9L13-R13) [[5]](diffhunk://#diff-e17aab0b65102d44b7840309e370b1fd8f55643d7c30bbacc5aa22a2d039c49eL13-R13)

Handling of multimodal content:

* Added processing for `[MultiMessage]` type in the `processRestRequest` function in `server/rest.js`.
* Added error handling for streaming requests in the `processRestRequest` function in `server/rest.js`.
* Added error handling for incoming streams in the `processIncomingStream` function in `server/rest.js`.

Additional tests:

* Added multiple tests in `tests/openai_api.test.js` to ensure proper handling of multimodal content, including tests for malformed content, invalid image data, and token limits. [[1]](diffhunk://#diff-c647913bd305ed0031a278c87827d3e03760ac57ae60e068b0a502fd73ac7a02R63-R92) [[2]](diffhunk://#diff-c647913bd305ed0031a278c87827d3e03760ac57ae60e068b0a502fd73ac7a02R178-R479)