### PR TITLE
Fix realtime as they have started giving back a bad parameter

### DIFF
--- a/helper-apps/cortex-realtime-voice-server/src/realtime/client.ts
+++ b/helper-apps/cortex-realtime-voice-server/src/realtime/client.ts
@@ -355,14 +355,19 @@ export class RealtimeVoiceClient extends EventEmitter implements TypedEmitter {
     if (!this.isConnected) {
       throw new Error('Not connected');
     }
+    
+    // Create a new config object without custom_voice_id
+    const { custom_voice_id, ...filteredConfig } = {
+      ...this.sessionConfig,
+      ...sessionConfig
+    };
+
     const message = JSON.stringify({
       event_id: createId(),
       type: 'session.update',
-      session: {
-        ...this.sessionConfig,
-        ...sessionConfig,
-      },
+      session: filteredConfig,
     });
+    
     // No need to log session update messages as they can be noisy
     logger.log('Sending session update message:', message);
     this.ws?.send(message);

--- a/helper-apps/cortex-realtime-voice-server/src/realtime/realtimeTypes.ts
+++ b/helper-apps/cortex-realtime-voice-server/src/realtime/realtimeTypes.ts
@@ -46,6 +46,7 @@ export type RealtimeSessionConfig = {
   modalities: Array<Modality>,
   instructions: string,
   voice: Voice,
+  custom_voice_id?: string | null,
   input_audio_format: AudioFormat,
   output_audio_format: AudioFormat,
   input_audio_transcription: null | { model: 'whisper-1' | (string & {}) },


### PR DESCRIPTION
This pull request includes changes to the `cortex-realtime-voice-server` to improve the handling of session configurations by removing the `custom_voice_id` from the session update messages.

Changes to session configuration handling:

* [`helper-apps/cortex-realtime-voice-server/src/realtime/client.ts`](diffhunk://#diff-faeb50cc2efaa6fe51a53cd586534eb9590bce52cf438bb0f5e70362169031f0R358-R370): Updated the `RealtimeVoiceClient` class to filter out the `custom_voice_id` from the session configuration before sending the session update message.

* [`helper-apps/cortex-realtime-voice-server/src/realtime/realtimeTypes.ts`](diffhunk://#diff-72f15bf543b5eba220e597e1df72779cbf8ef9dde38dbb14ce0082ce506493f7R49): Added an optional `custom_voice_id` property to the `RealtimeSessionConfig` type.