### PR TITLE
Update @aj-archipelago/subvibe to version 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.23",
       "license": "MIT",
       "dependencies": {
-        "@aj-archipelago/subvibe": "^1.0.3",
+        "@aj-archipelago/subvibe": "^1.0.5",
         "@apollo/server": "^4.7.3",
         "@apollo/server-plugin-response-cache": "^4.1.2",
         "@apollo/utils.keyvadapter": "^3.0.0",
@@ -53,10 +53,9 @@
       }
     },
     "node_modules/@aj-archipelago/subvibe": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@aj-archipelago/subvibe/-/subvibe-1.0.3.tgz",
-      "integrity": "sha512-yHlUPLbPslY9GGUQNlJInA1YxKjIlX9hP5Y1KfLQVqROWiv4tgNstSVxhWgszvR9UrIhl1rvzwFNDHeGfce3Rw==",
-      "license": "MIT",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@aj-archipelago/subvibe/-/subvibe-1.0.5.tgz",
+      "integrity": "sha512-4BekGa70RNXQ/R8/8lL8P62OGYIJmDAITXpUgxEvkEqXqo8Z20zPudBWtdL3G/sGHrIJN09go/K5xq+NiQBmnA==",
       "engines": {
         "node": ">=14.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "type": "module",
   "homepage": "https://github.com/aj-archipelago/cortex#readme",
   "dependencies": {
-    "@aj-archipelago/subvibe": "^1.0.3",
+    "@aj-archipelago/subvibe": "^1.0.5",
     "@apollo/server": "^4.7.3",
     "@apollo/server-plugin-response-cache": "^4.1.2",
     "@apollo/utils.keyvadapter": "^3.0.0",


### PR DESCRIPTION
Upgrade the @aj-archipelago/subvibe dependency to the latest version for improved functionality and performance.