### PR TITLE
Remove buffer force from non-voice streaming

### DIFF
--- a/lib/pathwayTools.js
+++ b/lib/pathwayTools.js
@@ -48,7 +48,7 @@ const gpt3Decode = (text) => {
     return decode(text);
 }
 
-const say = async (requestId, message, maxMessageLength = Infinity) => {
+const say = async (requestId, message, maxMessageLength = Infinity, voiceResponse = true) => {
     try {
         const chunks = getSemanticChunks(message, maxMessageLength);
 
@@ -60,11 +60,13 @@ const say = async (requestId, message, maxMessageLength = Infinity) => {
             });
         }
 
-        await publishRequestProgress({
-            requestId,
-            progress: 0.5,
-            data: " ... "
-        });
+        if (voiceResponse) {
+            await publishRequestProgress({
+                requestId,
+                progress: 0.5,
+                data: " ... "
+            });
+        }
 
         await publishRequestProgress({
             requestId,

--- a/pathways/system/entity/sys_entity_start.js
+++ b/pathways/system/entity/sys_entity_start.js
@@ -231,7 +231,7 @@ export default {
 
                 if (args.stream) {
                     if (!ackResponse) {
-                        await say(pathwayResolver.requestId, toolCallbackMessage || "One moment please.", 10);
+                        await say(pathwayResolver.requestId, toolCallbackMessage || "One moment please.", 10, args.voiceResponse ? true : false);
                     }
                     pathwayResolver.tool = JSON.stringify({ hideFromModel: false, search: false, title });  
                     await callPathway('sys_entity_continue', { ...args, stream: true, generatorPathway: toolCallbackName }, pathwayResolver);


### PR DESCRIPTION
This pull request includes changes to the `lib/pathwayTools.js` and `pathways/system/entity/sys_entity_start.js` files to add an optional voice response feature to the `say` function. The most important changes include modifying the `say` function to accept a new parameter and conditionally publishing progress based on this parameter.

Enhancements to the `say` function:

* [`lib/pathwayTools.js`](diffhunk://#diff-024e7e5ebbc75e94b187245e0463d17b39c273e7efe08ce3a0c9ae48459994a3L51-R51): Added a `voiceResponse` parameter to the `say` function and updated the function to conditionally publish request progress based on this new parameter. [[1]](diffhunk://#diff-024e7e5ebbc75e94b187245e0463d17b39c273e7efe08ce3a0c9ae48459994a3L51-R51) [[2]](diffhunk://#diff-024e7e5ebbc75e94b187245e0463d17b39c273e7efe08ce3a0c9ae48459994a3R63-R69)

Integration with other modules:

* [`pathways/system/entity/sys_entity_start.js`](diffhunk://#diff-d1b38bbcc80b29c52567d12734c6da25eb46ea4df076c461d571c5749c597f8dL234-R234): Updated the call to the `say` function to pass the `voiceResponse` parameter based on the `args.voiceResponse` value.