### PR TITLE
Enable coding agent in the streaming case.

### DIFF
--- a/pathways/system/entity/sys_entity_continue.js
+++ b/pathways/system/entity/sys_entity_continue.js
@@ -48,6 +48,10 @@ export default {
                 chatHistory: args.chatHistory.slice(-20)
             };
 
+            if (generatorPathway === 'coding') {
+                return;
+            }
+
             if (generatorPathway === 'sys_generator_document') {
                 generatorPathway = 'sys_generator_results';
                 newArgs.dataSources = ["mydata"];

--- a/pathways/system/entity/sys_entity_start.js
+++ b/pathways/system/entity/sys_entity_start.js
@@ -215,9 +215,18 @@ export default {
 
             title = await fetchTitleResponsePromise;
 
+            pathwayResolver.tool = JSON.stringify({ 
+                hideFromModel: toolCallbackName ? true : false, 
+                toolCallbackName, 
+                title,
+                search: toolCallbackName === 'sys_generator_results' ? true : false,
+                coding: toolCallbackName === 'coding' ? true : false,
+                codeRequestId,
+                toolCallbackId
+            });
+
             if (toolCallbackMessage) {
                 if (args.skipCallbackMessage) {
-                    pathwayResolver.tool = JSON.stringify({ hideFromModel: false, search: false, title });  
                     return await callPathway('sys_entity_continue', { ...args, stream: false, model: styleModel, generatorPathway: toolCallbackName }, pathwayResolver);
                 }
 
@@ -225,20 +234,10 @@ export default {
                     if (!ackResponse) {
                         await say(pathwayResolver.requestId, toolCallbackMessage || "One moment please.", 10, args.voiceResponse ? true : false);
                     }
-                    await callPathway('sys_entity_continue', { ...args, stream: true, generatorPathway: toolCallbackName }, pathwayResolver);
-                    pathwayResolver.tool = JSON.stringify({ hideFromModel: false, search: false, title }); 
+                    await callPathway('sys_entity_continue', { ...args, stream: true, generatorPathway: toolCallbackName }, pathwayResolver); 
                     return;
                 }
                 
-                pathwayResolver.tool = JSON.stringify({ 
-                    hideFromModel: toolCallbackName ? true : false, 
-                    toolCallbackName, 
-                    title,
-                    search: toolCallbackName === 'sys_generator_results' ? true : false,
-                    coding: toolCallbackName === 'coding' ? true : false,
-                    codeRequestId,
-                    toolCallbackId
-                });
                 return toolCallbackMessage || "One moment please.";
             }
 


### PR DESCRIPTION
This pull request includes changes to the `pathways/system/entity` files to enhance the handling of the `toolCallbackName` and streamline the `pathwayResolver.tool` assignment. The most important changes are the addition of conditions to handle specific `toolCallbackName` values and the refactoring of redundant code.

Enhancements to handling `toolCallbackName`:

* [`pathways/system/entity/sys_entity_continue.js`](diffhunk://#diff-8ba73fc158d2b2bad10249a7c521fe7a967bbae1516205878243c50e1b05c8d3R51-R54): Added a condition to return early if `generatorPathway` is 'coding'.
* [`pathways/system/entity/sys_entity_start.js`](diffhunk://#diff-d1b38bbcc80b29c52567d12734c6da25eb46ea4df076c461d571c5749c597f8dR218-L220): Added a comprehensive assignment for `pathwayResolver.tool` with various properties based on `toolCallbackName`.

Code refactoring:

* [`pathways/system/entity/sys_entity_start.js`](diffhunk://#diff-d1b38bbcc80b29c52567d12734c6da25eb46ea4df076c461d571c5749c597f8dL229-L241): Removed redundant `pathwayResolver.tool` assignments and streamlined the code by consolidating the logic.