### PR TITLE
Making subscription test serial so they don't step on each other

### DIFF
--- a/tests/subscription.test.js
+++ b/tests/subscription.test.js
@@ -171,7 +171,7 @@ function validateProgressMessage(t, progress, requestId = null) {
   }
 }
 
-test('Request progress messages have string data and info fields', async (t) => {
+test.serial('Request progress messages have string data and info fields', async (t) => {
   // Execute an async pathway that will generate progress messages
   const response = await testServer.executeOperation({
     query: `
@@ -219,7 +219,7 @@ test('Request progress messages have string data and info fields', async (t) => 
   }
 });
 
-test('sys_entity_start streaming works correctly', async (t) => {
+test.serial('sys_entity_start streaming works correctly', async (t) => {
   // Execute sys_entity_start with streaming
   const response = await testServer.executeOperation({
     query: `
@@ -283,7 +283,7 @@ test('sys_entity_start streaming works correctly', async (t) => {
   }
 });
 
-test('Translate pathway handles chunked async processing correctly', async (t) => {
+test.serial('Translate pathway handles chunked async processing correctly', async (t) => {
   // Create a long text that will be split into chunks
   const longText = `In the heart of the bustling metropolis, where skyscrapers pierce the clouds and streets pulse with endless energy, 
     a story unfolds. It's a tale of innovation and perseverance, of dreams taking flight in the digital age. 


### PR DESCRIPTION
This pull request includes changes to the `tests/subscription.test.js` file to ensure that certain tests are run in sequence rather than in parallel. This is achieved by marking the tests as serial.

Changes to test execution:

* [`tests/subscription.test.js`](diffhunk://#diff-6ddbacf19e2d0057aa3043e49ac43598c0460d08ffb11d07f153940f3af2e610L174-R174): Changed the test for request progress messages to run serially instead of in parallel.
* [`tests/subscription.test.js`](diffhunk://#diff-6ddbacf19e2d0057aa3043e49ac43598c0460d08ffb11d07f153940f3af2e610L222-R222): Updated the test for `sys_entity_start` streaming to run serially.
* [`tests/subscription.test.js`](diffhunk://#diff-6ddbacf19e2d0057aa3043e49ac43598c0460d08ffb11d07f153940f3af2e610L286-R286): Modified the test for the translate pathway to handle chunked async processing to run serially.