### PR TITLE
Ensure parser returns array

### DIFF
--- a/server/parser.js
+++ b/server/parser.js
@@ -16,7 +16,7 @@ const parseNumberedList = (str) => {
 async function parseNumberedObjectList(text, format) {
     const parsedList = await callPathway('sys_parse_numbered_object_list', { text, format });
     try {
-        return JSON.parse(parsedList);
+        return JSON.parse(parsedList) || [];
     } catch (error) {
         logger.warn(`Failed to parse numbered object list: ${error.message}`);
         return [];


### PR DESCRIPTION
This pull request includes a small but important change to the `server/parser.js` file. The change ensures that the `parseNumberedObjectList` function returns an empty array if the `parsedList` is `null` or `undefined`.

* [`server/parser.js`](diffhunk://#diff-75dda319413e0108cf5d209000e98fca48c883415eb4a4b977a8889d9717a29fL19-R19): Modified the `parseNumberedObjectList` function to return an empty array if the JSON parsing of `parsedList` results in `null` or `undefined`.