### PR TITLE
Implement removeOldImageAndFileContent function and better handling of chat history compression at token limits

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -170,6 +170,140 @@ async function markCompletedForCleanUp(requestId) {
     }
 }
 
+function removeOldImageAndFileContent(chatHistory) {
+    if (!chatHistory || !Array.isArray(chatHistory) || chatHistory.length === 0) {
+        return chatHistory;
+    }
+    
+    // Find the index of the last user message with image or file content
+    let lastImageOrFileIndex = -1;
+    
+    for (let i = chatHistory.length - 1; i >= 0; i--) {
+        const message = chatHistory[i];
+        
+        // Skip non-user messages
+        if (message.role !== 'user') {
+            continue;
+        }
+        
+        // Check if this message has image or file content
+        if (messageHasImageOrFile(message)) {
+            lastImageOrFileIndex = i;
+            break;
+        }
+    }
+    
+    // If no message with image or file found, return original
+    if (lastImageOrFileIndex === -1) {
+        return chatHistory;
+    }
+    
+    // Create a deep copy of the chat history
+    const modifiedChatHistory = JSON.parse(JSON.stringify(chatHistory));
+    
+    // Process earlier messages to remove image and file content
+    for (let i = 0; i < lastImageOrFileIndex; i++) {
+        const message = modifiedChatHistory[i];
+        
+        // Only process user messages
+        if (message.role !== 'user') {
+            continue;
+        }
+        
+        // Remove image and file content
+        modifiedChatHistory[i] = removeImageAndFileFromMessage(message);
+    }
+    
+    return modifiedChatHistory;
+}
+
+// Helper function to check if a message has image or file content
+function messageHasImageOrFile(message) {
+    if (!message || !message.content) {
+        return false;
+    }
+    
+    // Handle array content
+    if (Array.isArray(message.content)) {
+        for (const content of message.content) {
+            try {
+                const contentObj = typeof content === 'string' ? JSON.parse(content) : content;
+                if (contentObj.type === 'image_url' || contentObj.type === 'file') {
+                    return true;
+                }
+            } catch (e) {
+                // Not JSON or couldn't be parsed, continue
+                continue;
+            }
+        }
+    } 
+    // Handle string content
+    else if (typeof message.content === 'string') {
+        try {
+            const contentObj = JSON.parse(message.content);
+            if (contentObj.type === 'image_url' || contentObj.type === 'file') {
+                return true;
+            }
+        } catch (e) {
+            // Not JSON or couldn't be parsed
+            return false;
+        }
+    }
+    // Handle object content
+    else if (typeof message.content === 'object') {
+        return message.content.type === 'image_url' || message.content.type === 'file';
+    }
+    
+    return false;
+}
+
+// Helper function to remove image and file content from a message
+function removeImageAndFileFromMessage(message) {
+    if (!message || !message.content) {
+        return message;
+    }
+    
+    const modifiedMessage = { ...message };
+    
+    // Handle array content
+    if (Array.isArray(message.content)) {
+        modifiedMessage.content = message.content.filter(content => {
+            try {
+                const contentObj = typeof content === 'string' ? JSON.parse(content) : content;
+                // Keep content that's not image or file
+                return !(contentObj.type === 'image_url' || contentObj.type === 'file');
+            } catch (e) {
+                // Not JSON or couldn't be parsed, keep it
+                return true;
+            }
+        });
+        
+        // If all content was removed, add an empty string
+        if (modifiedMessage.content.length === 0) {
+            modifiedMessage.content = [""];
+        }
+    }
+    // Handle string content
+    else if (typeof message.content === 'string') {
+        try {
+            const contentObj = JSON.parse(message.content);
+            if (contentObj.type === 'image_url' || contentObj.type === 'file') {
+                modifiedMessage.content = "";
+            }
+        } catch (e) {
+            // Not JSON or couldn't be parsed, keep original
+        }
+    }
+    // Handle object content
+    else if (typeof message.content === 'object') {
+        if (message.content.type === 'image_url' || message.content.type === 'file') {
+            modifiedMessage.content = "";
+        }
+    }
+    
+    return modifiedMessage;
+}
+
 export { 
     getUniqueId,
     convertToSingleContentChatHistory,
@@ -180,5 +314,6 @@ export {
     convertSrtToText,
     alignSubtitles,
     getMediaChunks,
-    markCompletedForCleanUp
+    markCompletedForCleanUp,
+    removeOldImageAndFileContent
 };

--- a/pathways/system/entity/sys_router_tool.js
+++ b/pathways/system/entity/sys_router_tool.js
@@ -19,7 +19,7 @@ Available tools and their specific use cases:
 
 1. Search: Use for current events, news, fact-checking, and information requiring citation. This tool can search the internet, all Al Jazeera news articles and the latest news wires from multiple sources. Only search when necessary for current events, user documents, latest news, or complex topics needing grounding. Don't search for remembered information or general knowledge within your capabilities.
 
-2. Document: Access user's personal document index. Use for user-specific uploaded information. If user refers vaguely to "this document/file/article" without context, use this tool to search the personal index.
+2. Document: Access user's personal document index. Use for user-specific uploaded information. If user refers vaguely to "this document/file/article" without context, and you don't see the file in your context, use this tool to search the personal index.
 
 3. Memory: Read access to your memory index. Use to recall any information that you may have stored in your memory that you don't currently see elsewhere in your context. If you can answer from your context, don't use this tool. Don't use to make changes to your memory - that will happen naturally.
 
@@ -35,7 +35,7 @@ Available tools and their specific use cases:
 
 9. PDF: Use specifically for analyzing and answering questions about PDF file content. Use this tool any time the user is asking you questions about a PDF file.
 
-10. Text: Use specifically for analyzing and answering questions about text file content. Use this tool any time the user is asking you questions about a text file.
+10. Text: Use specifically for analyzing and answering questions about text or csv file content. Use this tool any time the user is asking you questions about a text or csv file.
 
 11. Vision: Use specifically for analyzing and answering questions about image files (jpg, gif, bmp, png, etc). Use this tool any time the user is asking you questions about an uploaded image file.
 

--- a/server/plugins/modelPlugin.js
+++ b/server/plugins/modelPlugin.js
@@ -67,119 +67,303 @@ class ModelPlugin {
         return encode(data).length;
     }
 
-    truncateMessagesToTargetLength(messages, targetTokenLength) {
-        const truncationMarker = '[truncated]';
+    truncateMessagesToTargetLength(messages, targetTokenLength = null, maxMessageTokenLength = Infinity) {
+        const truncationMarker = '[...]';
         const truncationMarkerTokenLength = encode(truncationMarker).length;
 
         // If no messages, return empty array
-        if (!messages || messages.length === 0 || !targetTokenLength) return [];
+        if (!messages || messages.length === 0) return [];
 
-        // Calculate token length for each message
-        const messagesWithTokens = messages.map((message, index) => ({
-            message,
-            tokenLength: this.safeGetEncodedLength(this.messagesToChatML([message], false)),
-            role: message.role || message.author,
-            originalIndex: index // Add original index for reliable ordering
-        }));
+        // If there's no target token length, get it from the model
+        if (!targetTokenLength) {
+            targetTokenLength = this.getModelMaxPromptTokens();
+        }
+        
+        // First check if all messages already fit within the target length
+        const initialTokenCount = this.countMessagesTokens(messages);
+        if (initialTokenCount <= targetTokenLength && maxMessageTokenLength == Infinity) {
+            return messages;
+        }
 
-        // Sort into our priority groups
-        const mostRecentMessage = messagesWithTokens[messagesWithTokens.length - 1];
+        // Calculate safety margin as a percentage of target length with a minimum value
+        // Scale down the percentage for small targets
+        const safetyMarginPercent = targetTokenLength > 1000 ? 0.05 : 0.02; // 5% or 2% for small targets
+        const safetyMarginMinimum = Math.min(20, Math.floor(targetTokenLength * 0.01)); // At most 1% for minimum
+        const safetyMargin = Math.max(safetyMarginMinimum, Math.round(targetTokenLength * safetyMarginPercent));
+        
+        // Adjust targetTokenLength to account for conversation formatting overhead (3 tokens)
+        const conversationOverhead = 3;
+        const effectiveTargetLength = Math.max(0, targetTokenLength - conversationOverhead - safetyMargin);
+
+        // Calculate token lengths for each message and track original index
+        const messagesWithTokens = messages.map((message, index) => {
+            // Count tokens for the role/author
+            const roleTokens = this.safeGetEncodedLength(message.role || message.author || "");
+
+            // Add per-message overhead (4 tokens)
+            const messageOverhead = 4;
+
+            // Count tokens for content
+            const tokenLength = this.countMessagesTokens([message]);
+            
+            return {
+                ...message,
+                roleTokens: roleTokens,
+                contentTokens: tokenLength - roleTokens - messageOverhead,
+                tokenLength: tokenLength,
+                originalIndex: index // Keep track of original position
+            };
+        });
+
+        // Sort messages by priority: last message, then system messages (newest first), then others (newest first)
+        const lastMessage = messagesWithTokens.length > 0 ? messagesWithTokens[messagesWithTokens.length - 1] : null;
         const systemMessages = messagesWithTokens
-            .filter(item => item.role === 'system')
-            .reverse(); // Most recent first
+            .filter(m => (m.role === 'system' || m.author === 'system') && m !== lastMessage)
+            .reverse();
         const otherMessages = messagesWithTokens
-            .filter(item => item.role !== 'system' && item !== mostRecentMessage)
-            .reverse(); // Most recent first
+            .filter(m => (m.role !== 'system' && m.author !== 'system') && m !== lastMessage)
+            .reverse();
 
-        // Helper function to truncate a message
-        const truncateMessage = (item, remainingTokens, isRecent = false) => {
-            const emptyContentLength = encode(this.messagesToChatML([{ ...item.message, content: '' }], false)).length;
-            const tokensToKeep = remainingTokens - (emptyContentLength + truncationMarkerTokenLength);
-            
-            if (tokensToKeep > 0 && !Array.isArray(item.message?.content)) {
-                // Truncate the message
-                const truncatedContent = getFirstNToken(item.message?.content ?? item.message, tokensToKeep) + truncationMarker;
-                const truncatedMessage = { ...item.message, content: truncatedContent };
-                const truncatedTokenLength = this.safeGetEncodedLength(this.messagesToChatML([truncatedMessage], false));
-                
-                if (isRecent) {
-                    logger.warn(`Most recent message truncated to fit token limit: ${truncatedContent.substring(0, 50)}...`);
-                }
-                
-                return {
-                    message: truncatedMessage,
-                    tokenLength: truncatedTokenLength,
-                    originalIndex: item.originalIndex
-                };
-            } else if (isRecent) {
-                // For the most recent message, use placeholder if can't truncate
-                logger.warn(`Most recent message too large to fit in token limit even after truncation. Using empty message.`);
-                const emptyMessage = { ...item.message, content: '[Content too large to fit in context window]' };
-                const emptyMessageTokenLength = this.safeGetEncodedLength(this.messagesToChatML([emptyMessage], false));
-                
-                return {
-                    message: emptyMessage,
-                    tokenLength: emptyMessageTokenLength,
-                    originalIndex: item.originalIndex
-                };
-            }
-            
-            return null;
-        };
+        // Build prioritized array
+        const prioritizedMessages = [];
+        if (lastMessage) prioritizedMessages.push(lastMessage);
+        prioritizedMessages.push(...systemMessages, ...otherMessages);
 
-        // Start with the most recent message, truncate if needed
-        let resultMessages = [];
-        let currentTokenLength = 0;
-        
-        // Process most recent message first - truncate if too large
-        if (mostRecentMessage.tokenLength <= targetTokenLength) {
-            // Most recent message fits completely
-            resultMessages.push(mostRecentMessage);
-            currentTokenLength = mostRecentMessage.tokenLength;
-        } else {
-            // Need to truncate most recent message
-            const truncated = truncateMessage(mostRecentMessage, targetTokenLength, true);
-            if (truncated) {
-                resultMessages.push(truncated);
-                currentTokenLength = truncated.tokenLength;
-            }
-        }
-        
-        // Add system messages
-        for (const item of systemMessages) {
-            if (currentTokenLength + item.tokenLength <= targetTokenLength) {
-                resultMessages.push(item);
-                currentTokenLength += item.tokenLength;
+        // Track used tokens and build result
+        let usedTokens = 0;
+        const result = [];
+
+        // Single pass: process messages in priority order
+        for (const message of prioritizedMessages) {
+            // Calculate how many tokens we have available
+            const remainingTokens = effectiveTargetLength - usedTokens;
+            
+            // If we have very few tokens left, skip this message
+            // For very small messages, we need to be less strict
+            const minimumUsableTokens = 10; 
+            if (remainingTokens < minimumUsableTokens) break;
+            
+            // Create a copy of the message to modify, but keep the originalIndex
+            let messageToAdd = { ...message };
+            delete messageToAdd.tokenLength;
+            delete messageToAdd.roleTokens;
+            delete messageToAdd.contentTokens;
+            // Keep originalIndex for sorting later
+            
+            const roleTokens = message.roleTokens;
+            const messageOverhead = 4;
+            // Calculate available tokens for content
+            const availableContentTokens = remainingTokens - roleTokens - messageOverhead;
+            
+            // Skip if we can't even fit the role + minimum content
+            if (availableContentTokens <= 0) continue;
+            
+            // Determine if we need to truncate the content
+            const needsTruncation = message.contentTokens > availableContentTokens 
+                               || message.contentTokens > (maxMessageTokenLength - roleTokens - messageOverhead);
+            
+            if (needsTruncation) {
+                // Maximum content tokens (smallest of available tokens or max per message)
+                const maxContentTokens = Math.min(
+                    availableContentTokens,
+                    maxMessageTokenLength - roleTokens - messageOverhead
+                );
+                
+                // Truncate text content
+                if (typeof message.content === 'string') {
+                    // Calculate space for content (leave room for truncation marker if needed)
+                    const contentSpace = Math.max(truncationMarkerTokenLength, maxContentTokens - truncationMarkerTokenLength);
+                    const truncatedContent = contentSpace > truncationMarkerTokenLength ? getFirstNToken(message.content, contentSpace) : "";
+                    
+                    // Only add truncation marker if we actually truncated
+                    if (truncatedContent.length < message.content.length) {
+                        messageToAdd.content = truncatedContent + truncationMarker;
+                    } else {
+                        messageToAdd.content = truncatedContent;
+                    }
+                    
+                    const updatedContentTokens = this.safeGetEncodedLength(messageToAdd.content);
+                    usedTokens += roleTokens + updatedContentTokens + messageOverhead;
+                } 
+                // Handle multimodal content
+                else if (Array.isArray(message.content)) {
+                    const newContent = [];
+                    let contentTokensUsed = 0;
+                    const contentLimit = maxContentTokens - truncationMarkerTokenLength;
+                    let truncationAdded = false;
+                    
+                    for (let item of message.content) {
+                        // items might be strings or objects
+                        if (typeof item === 'string') {
+                            item = { type: 'text', text: item };
+                        }
+
+                        // Handle text items
+                        if (item.type === 'text') {
+                            if (contentTokensUsed < contentLimit) {
+                                const remainingTokens = contentLimit - contentTokensUsed;
+                                
+                                if (this.safeGetEncodedLength(item.text) <= remainingTokens) {
+                                    // Text fits completely
+                                    newContent.push(item);
+                                    contentTokensUsed += this.safeGetEncodedLength(item.text);
+                                } else {
+                                    // Truncate text
+                                    const truncatedText = getFirstNToken(item.text, remainingTokens);
+                                    newContent.push({ type: 'text', text: truncatedText + truncationMarker });
+                                    contentTokensUsed += this.safeGetEncodedLength(truncatedText) + truncationMarkerTokenLength;
+                                    truncationAdded = true;
+                                    break;
+                                }
+                            }
+                        } 
+                        // Handle image items - prioritize them but account for their token usage
+                        else if (item.type === 'image_url') {
+                            const imageTokens = 100; // Estimated token count for images
+                            if (contentTokensUsed + imageTokens <= contentLimit) {
+                                newContent.push(item);
+                                contentTokensUsed += imageTokens;
+                            }
+                        }
+                        // Other non-text content
+                        else {
+                            newContent.push(item);
+                        }
+                    }
+                    
+                    // Add truncation marker if needed and not already added
+                    if (message.content.length > newContent.length && !truncationAdded) {
+                        newContent.push({ type: 'text', text: truncationMarker });
+                        contentTokensUsed += truncationMarkerTokenLength;
+                    }
+                    
+                    if (newContent.length > 0) {
+                        messageToAdd.content = newContent;
+                        usedTokens += roleTokens + contentTokensUsed + messageOverhead;
+                    } else {
+                        continue; // Skip message if no content after truncation
+                    }
+                }
             } else {
-                logger.warn(`System message too large to fit in token limit. Skipping: ${item.message.content?.substring(0, 50)}...`);
-                break;
+                // Message fits without truncation
+                usedTokens += message.tokenLength;
             }
+            
+            result.push(messageToAdd);
+            
+            // If we're close to target token length, stop processing more messages earlier
+            // Use a proportional cutoff to ensure we don't get too close to the limit
+            const cutoffThreshold = Math.min(20, Math.floor(effectiveTargetLength * 0.01));
+            if (effectiveTargetLength - usedTokens < cutoffThreshold) break;
         }
-        
-        // Add other messages from most recent to oldest until we hit the token limit
-        for (const item of otherMessages) {
-            if (currentTokenLength + item.tokenLength <= targetTokenLength) {
-                // We can add the whole message
-                resultMessages.push(item);
-                currentTokenLength += item.tokenLength;
-            } else {
-                // Try to add a truncated version
-                const truncated = truncateMessage(item, targetTokenLength - currentTokenLength);
-                if (truncated) {
-                    resultMessages.push(truncated);
-                    // We've reached the limit
-                    break;
-                } else {
-                    // Can't fit any more messages
-                    break;
+
+        // Handle edge case: No messages fit within the limit
+        if (result.length === 0 && prioritizedMessages.length > 0) {
+            // Force at least one message (highest priority) to fit
+            const highestPriorityMessage = prioritizedMessages[0];
+            const roleTokens = highestPriorityMessage.roleTokens;
+            const messageOverhead = 4;
+            const availableForContent = effectiveTargetLength - roleTokens - messageOverhead;
+            
+            if (availableForContent > truncationMarkerTokenLength) {
+                let messageToAdd = { ...highestPriorityMessage };
+                delete messageToAdd.tokenLength;
+                delete messageToAdd.roleTokens;
+                delete messageToAdd.contentTokens;
+                // Keep originalIndex for sorting later
+                
+                // Truncate content to fit available space
+                if (typeof highestPriorityMessage.content === 'string') {
+                    const truncatedContent = getFirstNToken(
+                        highestPriorityMessage.content, 
+                        availableForContent - truncationMarkerTokenLength
+                    );
+                    messageToAdd.content = truncatedContent + truncationMarker;
+                    result.push(messageToAdd);
+                } else if (Array.isArray(highestPriorityMessage.content)) {
+                    const newContent = [];
+                    let contentTokensUsed = 0;
+                    const contentLimit = availableForContent - truncationMarkerTokenLength;
+                    let truncationAdded = false;
+                    
+                    for (const item of highestPriorityMessage.content) {
+                        if (item.type === 'text') {
+                            if (contentTokensUsed < contentLimit) {
+                                const remainingTokens = contentLimit - contentTokensUsed;
+                                const tokenCount = this.safeGetEncodedLength(item.text);
+                                
+                                if (tokenCount <= remainingTokens) {
+                                    // Text fits completely
+                                    newContent.push(item);
+                                    contentTokensUsed += tokenCount;
+                                } else {
+                                    // Truncate text
+                                    const truncatedText = getFirstNToken(item.text, remainingTokens);
+                                    newContent.push({ type: 'text', text: truncatedText + truncationMarker });
+                                    contentTokensUsed += this.safeGetEncodedLength(truncatedText) + truncationMarkerTokenLength;
+                                    truncationAdded = true;
+                                    break;
+                                }
+                            }
+                        } else if (item.type === 'image_url') {
+                            const imageTokens = 100;
+                            if (contentTokensUsed + imageTokens <= contentLimit) {
+                                newContent.push(item);
+                                contentTokensUsed += imageTokens;
+                            }
+                        } else {
+                            newContent.push(item);
+                        }
+                    }
+                    
+                    // Add truncation marker if needed and not already added
+                    if (highestPriorityMessage.content.length > newContent.length && !truncationAdded) {
+                        newContent.push({ type: 'text', text: truncationMarker });
+                        contentTokensUsed += truncationMarkerTokenLength;
+                    }
+                    
+                    if (newContent.length > 0) {
+                        messageToAdd.content = newContent;
+                        result.push(messageToAdd);
+                    }
                 }
             }
         }
         
-        // Return the messages in original chronological order using the originalIndex
-        return resultMessages
-            .sort((a, b) => a.originalIndex - b.originalIndex)
-            .map(item => item.message);
+        // Before returning, verify we're under the limit with countMessagesTokens
+        // If we're still over, aggressively truncate the last message
+        const finalTokenCount = this.countMessagesTokens(result);
+        if (finalTokenCount > targetTokenLength && result.length > 0) {
+            const lastResult = result[result.length - 1];
+            
+            // If the last message has string content, truncate it more
+            if (typeof lastResult.content === 'string') {
+                const overage = finalTokenCount - targetTokenLength + safetyMargin/2;
+                const currentLength = this.safeGetEncodedLength(lastResult.content);
+                const newLength = Math.max(20, currentLength - overage);
+                
+                lastResult.content = getFirstNToken(lastResult.content, newLength - truncationMarkerTokenLength) + truncationMarker;
+            }
+            // For multimodal content, just remove all but the first text item
+            else if (Array.isArray(lastResult.content)) {
+                const firstTextIndex = lastResult.content.findIndex(item => item.type === 'text');
+                if (firstTextIndex >= 0) {
+                    const firstTextItem = lastResult.content[firstTextIndex];
+                    // Keep only this text item and truncate it
+                    const truncatedText = getFirstNToken(firstTextItem.text, 20) + truncationMarker;
+                    lastResult.content = [{ type: 'text', text: truncatedText }];
+                }
+            }
+        }
+        
+        // Sort by original index to restore original order
+        result.sort((a, b) => a.originalIndex - b.originalIndex);
+        
+        // Remove originalIndex property from result objects
+        return result.map(message => {
+            const { originalIndex, ...messageWithoutIndex } = message;
+            return messageWithoutIndex;
+        });
     }
     
     //convert a messages array to a simple chatML format
@@ -471,6 +655,48 @@ class ModelPlugin {
 
     getModelMaxImageSize() {
         return (this.promptParameters.maxImageSize ?? this.model.maxImageSize ?? DEFAULT_MAX_IMAGE_SIZE);
+    }
+
+    countMessagesTokens(messages) {
+        if (!messages || !Array.isArray(messages) || messages.length === 0) {
+            return 0;
+        }
+
+        let totalTokens = 0;
+
+        for (const message of messages) {
+            // Count tokens for role/author
+            const role = message.role || message.author || "";
+            if (role) {
+                totalTokens += this.safeGetEncodedLength(role);
+            }
+
+            // Count tokens for content
+            if (typeof message.content === 'string') {
+                totalTokens += this.safeGetEncodedLength(message.content);
+            } else if (Array.isArray(message.content)) {
+                // Handle multimodal content
+                for (const item of message.content) {
+                    // item can be a string or an object
+                    if (typeof item === 'string') {
+                        totalTokens += this.safeGetEncodedLength(item);
+                    } else if (item.type === 'text') {
+                        totalTokens += this.safeGetEncodedLength(item.text);
+                    } else if (item.type === 'image_url') {
+                        // Most models use ~85-130 tokens per image, but this varies by model
+                        totalTokens += 100;
+                    }
+                }
+            }
+
+            // Add per-message overhead (typically 3-4 tokens per message)
+            totalTokens += 4;
+        }
+
+        // Add conversation formatting overhead
+        totalTokens += 3;
+
+        return totalTokens;
     }
 
 }

--- a/tests/truncateMessages.test.js
+++ b/tests/truncateMessages.test.js
@@ -9,13 +9,14 @@ const { config, pathway, modelName, model } = mockPathwayResolverString;
 const modelPlugin = new ModelPlugin(pathway, model);
 
 const generateMessage = (role, content) => ({ role, content });
+const generateStructuredMessage = (role, content) => ({ role, content: [{ type: 'text', text: content }] });
 
 test('truncateMessagesToTargetLength: should not modify messages if already within target length', (t) => {
   const messages = [
     generateMessage('user', 'Hello, how are you?'),
     generateMessage('assistant', 'I am doing well, thank you!'),
   ];
-  const targetTokenLength = encode(modelPlugin.messagesToChatML(messages, false)).length;
+  const targetTokenLength = modelPlugin.countMessagesTokens(messages);
 
   const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength);
   t.deepEqual(result, messages);
@@ -29,9 +30,9 @@ test('truncateMessagesToTargetLength: should prioritize final user message', (t)
     generateMessage('user', 'Final important question that should be preserved'),
   ];
   
-  // Set target length to only fit the final user message
+  // Set target length to only fit the final user message plus the minimum safety margin
   const finalUserMsg = messages[messages.length - 1];
-  const targetTokenLength = encode(modelPlugin.messagesToChatML([finalUserMsg], false)).length;
+  const targetTokenLength = modelPlugin.countMessagesTokens([finalUserMsg]) * 1.1;
   
   const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength);
   t.is(result.length, 1, 'Should only keep final user message');
@@ -48,7 +49,7 @@ test('truncateMessagesToTargetLength: should prioritize final user message with 
   ];
 
   // Very tight token constraint
-  const targetTokenLength = 25;
+  const targetTokenLength = 15;
   const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength);
 
   // Should prioritize final user message
@@ -71,7 +72,7 @@ test('truncateMessagesToTargetLength: should add truncation markers to shortened
   const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength);
   
   // Verify truncation markers are added
-  const expectedMarker = "[truncated]";
+  const expectedMarker = "[...]";
   
   // Check if at least one message has the truncation marker
   const hasMarker = result.some(msg => msg.content.includes(expectedMarker));
@@ -100,7 +101,7 @@ test('truncateMessagesToTargetLength: should not add truncation markers to messa
   const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength);
   
   // Verify no truncation markers are added
-  const expectedMarker = "[truncated]";
+  const expectedMarker = "[...]";
   
   // None of the messages should have the truncation marker
   const hasMarker = result.some(msg => msg.content.includes(expectedMarker));
@@ -130,7 +131,7 @@ test('truncateMessagesToTargetLength: should handle extreme token constraints wi
   t.true(result.length > 0, 'Should have at least one message');
   
   // The kept message should have the truncation marker
-  const expectedMarker = "[truncated]";
+  const expectedMarker = "[...]";
   t.true(result[0].content.includes(expectedMarker), 
     'Extremely truncated message should include truncation marker');
 });
@@ -152,12 +153,304 @@ test('truncateMessagesToTargetLength: should maintain message order', (t) => {
   t.deepEqual(result.map(m => m.role), messages.map(m => m.role), 'Message order should be preserved');
 });
 
-test('truncateMessagesToTargetLength: should return an empty array if target length is 0', (t) => {
+test('truncateMessagesToTargetLength: should return messages with [...] if target length is 0', (t) => {
   const messages = [
     generateMessage('user', 'Hello, how are you?'),
     generateMessage('assistant', 'I am doing well, thank you!'),
   ];
 
-  const result = modelPlugin.truncateMessagesToTargetLength(messages, 0);
-  t.deepEqual(result, []);
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, null, 0);
+  
+  // Should return all messages but with [...] content
+  t.is(result.length, messages.length, 'Should return all messages');
+  
+  // Each message should be truncated to just the marker
+  result.forEach(msg => {
+    t.is(msg.content, '[...]', 'Message content should be just the truncation marker');
+  });
+});
+
+test('truncateMessagesToTargetLength: should handle structured messages with maxMessageTokenLength=0', (t) => {
+  const messages = [
+    generateStructuredMessage('user', 'Hello, how are you?'),
+    generateStructuredMessage('assistant', 'I am doing well, thank you!'),
+  ];
+
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, null, 0);
+  
+  // Should return all messages but with [...] content
+  t.is(result.length, messages.length, 'Should return all structured messages');
+  
+  // Each message should be truncated to just a single content item with the marker
+  result.forEach(msg => {
+    t.true(Array.isArray(msg.content), 'Content should still be an array');
+    t.is(msg.content.length, 1, 'Should have exactly one content item');
+    t.is(msg.content[0].type, 'text', 'Content item should be of type text');
+    t.is(msg.content[0].text, '[...]', 'Content text should be just the truncation marker');
+  });
+});
+
+// New tests for maxMessageTokenLength
+
+test('truncateMessagesToTargetLength: should respect maxMessageTokenLength constraint', (t) => {
+  // Create messages with different lengths
+  const longContent = 'a'.repeat(1000);
+  
+  const messages = [
+    generateMessage('user', 'Short first message'),
+    generateMessage('assistant', longContent),
+    generateMessage('user', 'Short final message'),
+  ];
+  
+  // Set a target that would fit all messages normally
+  const targetTokenLength = modelPlugin.countMessagesTokens(messages) + 100;
+  
+  // Calculate tokens in the assistant message
+  const assistantMsgTokens = modelPlugin.countMessagesTokens([messages[1]]);
+  
+  // Set maxMessageTokenLength to be less than the assistant message length
+  const maxMessageTokenLength = Math.floor(assistantMsgTokens * 0.3); 
+  
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength, maxMessageTokenLength);
+  
+  // All messages should be present
+  t.is(result.length, 3, 'All messages should be preserved');
+  
+  // Only the long message should be truncated
+  t.is(result[0].content, messages[0].content, 'First message should be unchanged');
+  t.is(result[2].content, messages[2].content, 'Last message should be unchanged');
+  
+  // The assistant message should be truncated
+  t.true(result[1].content.length < longContent.length, 'Long message should be truncated');
+  t.true(result[1].content.includes('[...]'), 'Truncated message should have marker');
+  
+  // Calculate tokens in the truncated message
+  const truncatedMsgTokens = modelPlugin.countMessagesTokens([result[1]]);
+  
+  // Allow small buffer for truncation marker
+  t.true(truncatedMsgTokens <= maxMessageTokenLength + 10, 
+    `Truncated message (${truncatedMsgTokens} tokens) should not exceed maxMessageTokenLength (${maxMessageTokenLength} tokens) by more than buffer`);
+});
+
+test('truncateMessagesToTargetLength: should handle very small maxMessageTokenLength', (t) => {
+  const messages = [
+    generateMessage('system', 'System message that will definitely need to be truncated to fit the maxMessageTokenLength'),
+    generateMessage('user', 'This is a user message that will need to be heavily truncated to fit the maxMessageTokenLength'),
+  ];
+  
+  // Set a large target token length
+  const targetTokenLength = 1000;
+  
+  // But set a very small maxMessageTokenLength
+  const maxMessageTokenLength = 5;
+  
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength, maxMessageTokenLength);
+  
+  // All messages should be present but truncated
+  t.is(result.length, 2, 'Both messages should be present');
+  
+  // Both messages should be truncated to fit the maxMessageTokenLength
+  result.forEach(msg => {
+    const msgTokens = modelPlugin.safeGetEncodedLength(msg.content);
+    t.true(msgTokens <= maxMessageTokenLength + 5, 
+      `Message (${msgTokens} tokens) should not exceed maxMessageTokenLength (${maxMessageTokenLength}) by more than buffer`);
+    t.true(msg.content.includes('[...]'), 'Truncated message should have marker');
+  });
+});
+
+test('truncateMessagesToTargetLength: should handle both constraints together', (t) => {
+  const longContent = 'a'.repeat(500);
+  
+  const messages = [
+    generateMessage('system', 'System: ' + longContent),
+    generateMessage('user', 'User: ' + longContent),
+    generateMessage('assistant', 'Assistant: ' + longContent),
+    generateMessage('user', 'Final: ' + longContent),
+  ];
+  
+  // Set a moderate target token length
+  const targetTokenLength = 300;
+  
+  // And a moderate maxMessageTokenLength
+  const maxMessageTokenLength = 100;
+  
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength, maxMessageTokenLength);
+  
+  // We should have some messages, but not necessarily all
+  t.true(result.length > 0 && result.length <= messages.length, 'Should have some messages');
+  
+  // Total token count should be below target
+  const totalTokens = modelPlugin.countMessagesTokens(result);
+  t.true(totalTokens <= targetTokenLength, 
+    `Total tokens (${totalTokens}) should not exceed target length (${targetTokenLength})`);
+  
+  // Each message should respect maxMessageTokenLength
+  result.forEach(msg => {
+    const msgTokens = modelPlugin.countMessagesTokens([msg]);
+    t.true(msgTokens <= maxMessageTokenLength + 10, 
+      `Message (${msgTokens} tokens) should not exceed maxMessageTokenLength (${maxMessageTokenLength}) by more than buffer`);
+  });
+});
+
+test('truncateMessagesToTargetLength: maxMessageTokenLength should not affect unchanged messages', (t) => {
+  const messages = [
+    generateMessage('system', 'Short system message'),
+    generateMessage('user', 'Short user message'),
+  ];
+  
+  // Calculate tokens in each message
+  const systemMsgTokens = modelPlugin.countMessagesTokens([messages[0]]);
+  const userMsgTokens = modelPlugin.countMessagesTokens([messages[1]]);
+  
+  // Set maxMessageTokenLength above individual message sizes but below their sum
+  const maxMessageTokenLength = Math.max(systemMsgTokens, userMsgTokens) + 10;
+  
+  // Set target length to fit all messages
+  const targetTokenLength = modelPlugin.countMessagesTokens(messages) + 20;
+  
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength, maxMessageTokenLength);
+  
+  // All messages should be unchanged
+  t.is(result.length, 2, 'Both messages should be present');
+  t.is(result[0].content, messages[0].content, 'First message should be unchanged');
+  t.is(result[1].content, messages[1].content, 'Second message should be unchanged');
+  
+  // No truncation markers
+  const hasMarker = result.some(msg => msg.content.includes('[...]'));
+  t.false(hasMarker, 'No message should have truncation marker');
+});
+
+test('truncateMessagesToTargetLength: should truncate long messages with maxMessageTokenLength', t => {
+  const longText = 'A'.repeat(6000);
+  const messages = [
+    generateMessage('user', longText),
+    generateMessage('assistant', 'Response'),
+    generateMessage('user', 'Short message')
+  ];
+  
+  const shortMsgTokens = modelPlugin.countMessagesTokens([{ role: 'user', content: 'Short message' }]);
+  const maxMessageTokenLength = shortMsgTokens * 2; // Just enough to force truncation of long messages
+  
+  // Large target to ensure only maxMessageTokenLength constraint is active
+  const targetTokenLength = 10000; 
+  
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength, maxMessageTokenLength);
+  
+  // Check that long message was truncated
+  const longMsgTokens = modelPlugin.countMessagesTokens([result[0]]);
+  t.true(longMsgTokens <= maxMessageTokenLength + 10, 
+    `Long message (${longMsgTokens} tokens) should be truncated to near maxMessageTokenLength (${maxMessageTokenLength})`);
+  t.true(result[0].content.includes('[...]'), 'Truncated message should have truncation marker');
+  
+  // Short messages should be unchanged
+  t.is(result[1].content, 'Response');
+  t.is(result[2].content, 'Short message');
+});
+
+test('truncateMessagesToTargetLength: should not truncate image content with maxMessageTokenLength', t => {
+  const longText = 'A'.repeat(6000);
+  const imageContent = { type: 'image_url', url: 'image.jpg' };
+  const longTextContent = { type: 'text', text: longText };
+  const messages = [
+    generateMessage('user', [imageContent, longTextContent]),
+    generateMessage('assistant', 'I see an image')
+  ];
+  
+  // Calculate tokens for image + some text
+  const imageTokens = 100; // Estimate from countMessagesTokens
+  const maxMessageTokenLength = imageTokens + 50; // Enough for image but not all text
+  
+  // Large target to ensure only maxMessageTokenLength constraint is active
+  const targetTokenLength = 10000;
+  
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength, maxMessageTokenLength);
+  
+  // Image should be preserved
+  t.deepEqual(result[0].content[0], imageContent, 'Image content should be preserved');
+  
+  // Text should be truncated
+  t.true(result[0].content[1].text.length < longText.length, 'Text content should be truncated');
+  t.true(result[0].content[1].text.includes('[...]'), 'Truncated text should have marker');
+  
+  // Check overall message length
+  const msgTokens = modelPlugin.countMessagesTokens([result[0]]);
+  t.true(msgTokens <= maxMessageTokenLength + 10,
+    `Message tokens (${msgTokens}) should not exceed maxMessageTokenLength (${maxMessageTokenLength}) by more than buffer`);
+});
+
+test('truncateMessagesToTargetLength: should truncate array content with maxMessageTokenLength', t => {
+  const longText1 = 'A'.repeat(3000);
+  const longText2 = 'B'.repeat(3000); 
+  const longTextContent1 = { type: 'text', text: longText1 };
+  const longTextContent2 = { type: 'text', text: longText2 };
+  const messages = [
+    generateMessage('user', [longTextContent1, longTextContent2]),
+    generateMessage('assistant', 'Response')
+  ];
+  
+  // Set a moderate maxMessageTokenLength
+  const maxMessageTokenLength = 200;
+  
+  // Large target to ensure only maxMessageTokenLength constraint is active
+  const targetTokenLength = 10000;
+  
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength, maxMessageTokenLength);
+  
+  // Check that message was truncated
+  const msgTokens = modelPlugin.countMessagesTokens([result[0]]);
+  t.true(msgTokens <= maxMessageTokenLength + 10,
+    `Message tokens (${msgTokens}) should not exceed maxMessageTokenLength (${maxMessageTokenLength}) by more than buffer`);
+  
+  // At least one of the text items should be truncated
+  const hasMarker = result[0].content.some(item => 
+    typeof item === 'string' && item.includes('[...]') ||
+    item.type === 'text' && item.text.includes('[...]'));
+  t.true(hasMarker, 'At least one content item should have truncation marker');
+});
+
+test('truncateMessagesToTargetLength: should handle mixed message types with maxMessageTokenLength', t => {
+  const longText = 'A'.repeat(10000);
+  const shortText = 'Short message';
+  const imageContent = { type: 'image_url', url: 'image.jpg' };
+  const longTextContent = { type: 'text', text: longText };
+  const shortTextContent = { type: 'text', text: shortText };
+  
+  const messages = [
+    generateMessage('user', shortText),
+    generateMessage('assistant', longText),
+    generateMessage('user', [shortTextContent, imageContent, longTextContent]),
+    generateMessage('system', longText)
+  ];
+  
+  // Calculate reasonable maxMessageTokenLength
+  const shortMsgTokens = modelPlugin.countMessagesTokens([{ role: 'user', content: shortText }]);
+  const maxMessageTokenLength = 200; // Force truncation of long messages
+  
+  // Large target to ensure only maxMessageTokenLength constraint is active
+  const targetTokenLength = 10000;
+  
+  const result = modelPlugin.truncateMessagesToTargetLength(messages, targetTokenLength, maxMessageTokenLength);
+  
+  // Short message should be unchanged
+  t.is(result[0].content, shortText, 'Short message should be unchanged');
+  
+  // Long text messages should be truncated
+  t.true(result[1].content.length < longText.length, 'Long text message should be truncated');
+  t.true(result[1].content.includes('[...]'), 'Truncated message should have marker');
+  t.true(result[3].content.length < longText.length, 'Long system message should be truncated');
+  
+  // Check multimodal message
+  t.deepEqual(result[2].content[1], imageContent, 'Image should be preserved');
+  if (typeof result[2].content[1] === 'string') {
+    t.true(result[2].content[1].length < longText.length, 'Text in multimodal message should be truncated');
+  } else if (result[2].content[1] && result[2].content[1].type === 'text') {
+    t.true(result[2].content[1].text.length < longText.length, 'Text in multimodal message should be truncated');
+  }
+  
+  // All messages should respect maxMessageTokenLength
+  result.forEach((msg, i) => {
+    const msgTokens = modelPlugin.countMessagesTokens([msg]);
+    t.true(msgTokens <= maxMessageTokenLength + 10,
+      `Message ${i} tokens (${msgTokens}) should not exceed maxMessageTokenLength (${maxMessageTokenLength}) by more than buffer`);
+  });
 });

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -1,0 +1,146 @@
+// util.test.js
+// Tests for utility functions in cortex/lib/util.js
+
+import test from 'ava';
+import { removeOldImageAndFileContent } from '../lib/util.js';
+
+// Test removeOldImageAndFileContent function
+
+test('removeOldImageAndFileContent should return original chat history if empty', t => {
+    const chatHistory = [];
+    const result = removeOldImageAndFileContent(chatHistory);
+    t.deepEqual(result, chatHistory);
+});
+
+test('removeOldImageAndFileContent should return original chat history if null or undefined', t => {
+    t.deepEqual(removeOldImageAndFileContent(null), null);
+    t.deepEqual(removeOldImageAndFileContent(undefined), undefined);
+});
+
+test('removeOldImageAndFileContent should not modify chat history without image or file content', t => {
+    const chatHistory = [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+        { role: 'user', content: 'How are you?' }
+    ];
+    const result = removeOldImageAndFileContent(chatHistory);
+    t.deepEqual(result, chatHistory);
+});
+
+test('removeOldImageAndFileContent should keep only the last user message with image content', t => {
+    const chatHistory = [
+        { role: 'user', content: [{ type: 'image_url', url: 'image1.jpg' }, 'Text 1'] },
+        { role: 'assistant', content: 'I see image 1' },
+        { role: 'user', content: [{ type: 'image_url', url: 'image2.jpg' }, 'Text 2'] },
+        { role: 'assistant', content: 'I see image 2' }
+    ];
+    
+    const expected = [
+        { role: 'user', content: ['Text 1'] },
+        { role: 'assistant', content: 'I see image 1' },
+        { role: 'user', content: [{ type: 'image_url', url: 'image2.jpg' }, 'Text 2'] },
+        { role: 'assistant', content: 'I see image 2' }
+    ];
+    
+    const result = removeOldImageAndFileContent(chatHistory);
+    t.deepEqual(result, expected);
+});
+
+test('removeOldImageAndFileContent should handle string JSON content', t => {
+    const chatHistory = [
+        { role: 'user', content: JSON.stringify({ type: 'image_url', url: 'image1.jpg' }) },
+        { role: 'assistant', content: 'I see image 1' },
+        { role: 'user', content: JSON.stringify({ type: 'image_url', url: 'image2.jpg' }) },
+        { role: 'assistant', content: 'I see image 2' }
+    ];
+    
+    const expected = [
+        { role: 'user', content: '' },
+        { role: 'assistant', content: 'I see image 1' },
+        { role: 'user', content: JSON.stringify({ type: 'image_url', url: 'image2.jpg' }) },
+        { role: 'assistant', content: 'I see image 2' }
+    ];
+    
+    const result = removeOldImageAndFileContent(chatHistory);
+    t.deepEqual(result, expected);
+});
+
+test('removeOldImageAndFileContent should handle object content', t => {
+    const chatHistory = [
+        { role: 'user', content: { type: 'image_url', url: 'image1.jpg' } },
+        { role: 'assistant', content: 'I see image 1' },
+        { role: 'user', content: { type: 'image_url', url: 'image2.jpg' } },
+        { role: 'assistant', content: 'I see image 2' }
+    ];
+    
+    const expected = [
+        { role: 'user', content: '' },
+        { role: 'assistant', content: 'I see image 1' },
+        { role: 'user', content: { type: 'image_url', url: 'image2.jpg' } },
+        { role: 'assistant', content: 'I see image 2' }
+    ];
+    
+    const result = removeOldImageAndFileContent(chatHistory);
+    t.deepEqual(result, expected);
+});
+
+test('removeOldImageAndFileContent should handle file content', t => {
+    const chatHistory = [
+        { role: 'user', content: { type: 'file', url: 'document1.pdf' } },
+        { role: 'assistant', content: 'I see document 1' },
+        { role: 'user', content: { type: 'file', url: 'document2.pdf' } },
+        { role: 'assistant', content: 'I see document 2' }
+    ];
+    
+    const expected = [
+        { role: 'user', content: '' },
+        { role: 'assistant', content: 'I see document 1' },
+        { role: 'user', content: { type: 'file', url: 'document2.pdf' } },
+        { role: 'assistant', content: 'I see document 2' }
+    ];
+    
+    const result = removeOldImageAndFileContent(chatHistory);
+    t.deepEqual(result, expected);
+});
+
+test('removeOldImageAndFileContent should only process user messages', t => {
+    const chatHistory = [
+        { role: 'user', content: { type: 'image_url', url: 'image1.jpg' } },
+        { role: 'assistant', content: { type: 'image_url', url: 'response1.jpg' } },
+        { role: 'user', content: { type: 'image_url', url: 'image2.jpg' } },
+        { role: 'assistant', content: { type: 'image_url', url: 'response2.jpg' } }
+    ];
+    
+    const expected = [
+        { role: 'user', content: '' },
+        { role: 'assistant', content: { type: 'image_url', url: 'response1.jpg' } },
+        { role: 'user', content: { type: 'image_url', url: 'image2.jpg' } },
+        { role: 'assistant', content: { type: 'image_url', url: 'response2.jpg' } }
+    ];
+    
+    const result = removeOldImageAndFileContent(chatHistory);
+    t.deepEqual(result, expected);
+});
+
+test('removeOldImageAndFileContent should handle mixed content types', t => {
+    const chatHistory = [
+        { role: 'user', content: [{ type: 'image_url', url: 'image1.jpg' }, 'Text 1'] },
+        { role: 'assistant', content: 'I see image 1' },
+        { role: 'user', content: 'Just text' },
+        { role: 'assistant', content: 'I see text' },
+        { role: 'user', content: [{ type: 'file', url: 'document.pdf' }, 'Text 2'] },
+        { role: 'assistant', content: 'I see document' }
+    ];
+    
+    const expected = [
+        { role: 'user', content: ['Text 1'] },
+        { role: 'assistant', content: 'I see image 1' },
+        { role: 'user', content: 'Just text' },
+        { role: 'assistant', content: 'I see text' },
+        { role: 'user', content: [{ type: 'file', url: 'document.pdf' }, 'Text 2'] },
+        { role: 'assistant', content: 'I see document' }
+    ];
+    
+    const result = removeOldImageAndFileContent(chatHistory);
+    t.deepEqual(result, expected);
+});


### PR DESCRIPTION
This pull request introduces a new function to remove old image and file content from chat history and integrates this functionality into various parts of the system. The main changes involve the addition of helper functions to handle image and file content in messages and the modification of existing pathways to use these new functions.

### New Functionality for Handling Image and File Content:
* Added `removeOldImageAndFileContent`, `messageHasImageOrFile`, and `removeImageAndFileFromMessage` functions in `lib/util.js` to process and clean up chat history by removing old image and file content.
* Exported the new `removeOldImageAndFileContent` function from `lib/util.js`.

### Integration into Pathways:
* Updated `sys_entity_continue.js` to remove old image and file content from chat history and truncate the chat history before processing. [[1]](diffhunk://#diff-8ba73fc158d2b2bad10249a7c521fe7a967bbae1516205878243c50e1b05c8d3R4) [[2]](diffhunk://#diff-8ba73fc158d2b2bad10249a7c521fe7a967bbae1516205878243c50e1b05c8d3R47-R53) [[3]](diffhunk://#diff-8ba73fc158d2b2bad10249a7c521fe7a967bbae1516205878243c50e1b05c8d3L65-R77)
* Modified `sys_entity_start.js` to incorporate the new functions for cleaning up chat history and truncating it before various operations. [[1]](diffhunk://#diff-d1b38bbcc80b29c52567d12734c6da25eb46ea4df076c461d571c5749c597f8dL5-R5) [[2]](diffhunk://#diff-d1b38bbcc80b29c52567d12734c6da25eb46ea4df076c461d571c5749c597f8dL90-R99) [[3]](diffhunk://#diff-d1b38bbcc80b29c52567d12734c6da25eb46ea4df076c461d571c5749c597f8dL104-R108) [[4]](diffhunk://#diff-d1b38bbcc80b29c52567d12734c6da25eb46ea4df076c461d571c5749c597f8dL116-R132)

### Documentation Updates:
* Updated the description of the "Document" tool in `sys_router_tool.js` to clarify its use when the file is not visible in the context.
* Revised the description of the "Text" tool to include CSV file content.