### PR TITLE
Add ephemeral flag to say() function for temporary messages

### DIFF
--- a/lib/pathwayTools.js
+++ b/lib/pathwayTools.js
@@ -54,11 +54,16 @@ const say = async (requestId, message, maxMessageLength = Infinity, voiceRespons
     try {
         const chunks = getSemanticChunks(message, maxMessageLength);
 
+        const info = JSON.stringify({
+            ephemeral: true,
+        });
+
         for (let chunk of chunks) {
             await publishRequestProgress({
                 requestId,
                 progress: 0.5,
-                data: JSON.stringify(chunk)
+                data: JSON.stringify(chunk),
+                info
             });
         }
 
@@ -66,14 +71,16 @@ const say = async (requestId, message, maxMessageLength = Infinity, voiceRespons
             await publishRequestProgress({
                 requestId,
                 progress: 0.5,
-                data: JSON.stringify(" ... ")
+                data: JSON.stringify(" ... "),
+                info
             });
         }
 
         await publishRequestProgress({
             requestId,
             progress: 0.5,
-            data: JSON.stringify("\n\n")
+            data: JSON.stringify("\n\n"),
+            info
         });
 
     } catch (error) {


### PR DESCRIPTION
This pull request includes an update to the `say` function in `lib/pathwayTools.js` to enhance the data being published during request progress updates. The most important change is the addition of an `info` object to the data payload.

Enhancements to data payload:

* [`lib/pathwayTools.js`](diffhunk://#diff-024e7e5ebbc75e94b187245e0463d17b39c273e7efe08ce3a0c9ae48459994a3R57-R83): Added an `info` object with `ephemeral: true` to the data payload in the `publishRequestProgress` calls. This ensures that additional context is provided during the request progress updates.