### PR TITLE
Use new 'gemini-pro-25-vision' model

### DIFF
--- a/config/default.example.json
+++ b/config/default.example.json
@@ -46,6 +46,17 @@
             "maxReturnTokens": 2048,
             "supportsStreaming": true
         },
+        "gemini-pro-25-vision": {
+            "type": "GEMINI-VISION",
+            "url": "https://us-central1-aiplatform.googleapis.com/v1/projects/project-id/locations/us-central1/publishers/google/models/gemini-2.5-pro-exp-03-25:streamGenerateContent",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "requestsPerSecond": 10,
+            "maxTokenLength": 1048576,
+            "maxReturnTokens": 65536,
+            "supportsStreaming": true
+        },
         "claude-3-haiku-vertex": {
             "type": "CLAUDE-3-VERTEX",
             "url": "https://us-central1-aiplatform.googleapis.com/v1/projects/project-id/locations/us-central1/publishers/anthropic/models/claude-3-haiku@20240307",

--- a/pathways/transcribe_gemini.js
+++ b/pathways/transcribe_gemini.js
@@ -48,7 +48,7 @@ export default {
             "{{messages}}",
         ]}),
     ],
-    model: 'gemini-pro-20-vision',
+    model: 'gemini-pro-25-vision',
     inputParameters: {
         file: ``,
         language: ``,


### PR DESCRIPTION
This pull request includes updates to configuration and pathway files to integrate a new model and update its usage.

Integration of new model:

* [`config/default.example.json`](diffhunk://#diff-2b538994a18f0326f20bd22c72f60f8586d9d991a5e1f94f9341ab47481c6313R49-R59): Added a new model configuration for `gemini-pro-25-vision` with specific parameters including `type`, `url`, `headers`, `requestsPerSecond`, `maxTokenLength`, `maxReturnTokens`, and `supportsStreaming`.

Update to model usage:

* [`pathways/transcribe_gemini.js`](diffhunk://#diff-11836e8f37192542cfc25880a1db96a1b38f3c86b976af3bf78988724336de08L51-R51): Updated the model used in the transcribe pathway from `gemini-pro-20-vision` to `gemini-pro-25-vision`.