### PR TITLE
HOTFIX - Support non-streaming agentic flow (for Digest page)

### DIFF
--- a/server/plugins/openAiVisionPlugin.js
+++ b/server/plugins/openAiVisionPlugin.js
@@ -266,7 +266,7 @@ class OpenAIVisionPlugin extends OpenAIChatPlugin {
                 switch (finishReason.toLowerCase()) {
                     case 'tool_calls':
                         // Process complete tool calls when we get the finish reason
-                        if (this.pathwayToolCallback && this.toolCallsBuffer.length > 0) {
+                        if (this.pathwayToolCallback && this.toolCallsBuffer.length > 0 && pathwayResolver) {
                             const toolMessage = {
                                 role: 'assistant',
                                 content: delta?.content || '', 


### PR DESCRIPTION
This pull request introduces several updates to improve the robustness of the `sys_entity_agent.js` and `openAiVisionPlugin.js` modules. The changes focus on enhancing error handling, refining asynchronous workflows, and improving the handling of tool calls in the system.

### Enhancements to error handling:
* Added a validation check in the `toolCallback` method to ensure `args`, `message`, and `resolver` are defined before proceeding, preventing potential runtime errors. (`pathways/system/entity/sys_entity_agent.js`, [pathways/system/entity/sys_entity_agent.jsR39-R42](diffhunk://#diff-ba8390dc0ed151a2b26e69627a5fe50b0b6d18d6470f4cc3d05ffe105d865dfcR39-R42))

### Improvements to asynchronous workflows:
* Updated the `promptAndParse` function to return its result directly, improving the clarity and consistency of the asynchronous flow. (`pathways/system/entity/sys_entity_agent.js`, [pathways/system/entity/sys_entity_agent.jsL173-L177](diffhunk://#diff-ba8390dc0ed151a2b26e69627a5fe50b0b6d18d6470f4cc3d05ffe105d865dfcL173-L177))
* Enhanced the parameter handling in the `pathwayResolver` setup by including the `stream` property, ensuring all necessary input parameters are properly loaded. (`pathways/system/entity/sys_entity_agent.js`, [pathways/system/entity/sys_entity_agent.jsL186-R189](diffhunk://#diff-ba8390dc0ed151a2b26e69627a5fe50b0b6d18d6470f4cc3d05ffe105d865dfcL186-R189))

### Refinements to tool call handling:
* Modified the `runAllPrompts` workflow to handle tool calls iteratively using the `toolCallback` function, allowing for dynamic and recursive processing of tool calls. (`pathways/system/entity/sys_entity_agent.js`, [pathways/system/entity/sys_entity_agent.jsL270-R283](diffhunk://#diff-ba8390dc0ed151a2b26e69627a5fe50b0b6d18d6470f4cc3d05ffe105d865dfcL270-R283))
* Added a check in the `OpenAIVisionPlugin` to ensure the `pathwayResolver` is defined before processing tool calls, preventing errors in scenarios where the resolver is unavailable. (`server/plugins/openAiVisionPlugin.js`, [server/plugins/openAiVisionPlugin.jsL269-R269](diffhunk://#diff-dbcd5a0b04541f9a7bd577cbe2b9d112e819e3c90d31f4e2b3c67a7160dbac6aL269-R269))