### PR TITLE
Support chatId filtering on cognitive search over personal index

### DIFF
--- a/pathways/system/entity/sys_entity_agent.js
+++ b/pathways/system/entity/sys_entity_agent.js
@@ -16,11 +16,7 @@ export default {
         privateData: false,    
         chatHistory: [{role: '', content: []}],
         contextId: ``,
-        indexName: ``,
-        semanticConfiguration: ``,
-        roleInformation: ``,    
-        calculateEmbeddings: false,
-        dataSources: ["mydata", "aja", "aje", "wires", "bing"],
+        chatId: ``,
         language: "English",
         aiName: "Jarvis",
         aiMemorySelfModify: true,
@@ -186,7 +182,7 @@ export default {
         let pathwayResolver = resolver;
 
         // Load input parameters and information into args
-        const { entityId, voiceResponse, aiMemorySelfModify, stream } = { ...pathwayResolver.pathway.inputParameters, ...args };
+        const { entityId, voiceResponse, aiMemorySelfModify, chatId } = { ...pathwayResolver.pathway.inputParameters, ...args };
         
         const entityConfig = loadEntityConfig(entityId);
         const { entityTools, entityToolsOpenAiFormat } = getToolsForEntity(entityConfig);
@@ -205,7 +201,8 @@ export default {
             entityUseMemory,
             entityInstructions,
             voiceResponse,
-            aiMemorySelfModify
+            aiMemorySelfModify,
+            chatId
         };
 
         pathwayResolver.args = {...args};

--- a/pathways/system/entity/tools/sys_tool_cognitive_search.js
+++ b/pathways/system/entity/tools/sys_tool_cognitive_search.js
@@ -158,7 +158,7 @@ export default {
     ],
 
     executePathway: async ({args, runAllPrompts, resolver}) => {
-        const { text, filter, top, titleOnly, stream, dataSources, indexName, semanticConfiguration } = args;
+        const { text, filter, top, titleOnly, stream, chatId, indexName, semanticConfiguration } = args;
 
         // Map tool names to index names
         const toolToIndex = {
@@ -192,7 +192,8 @@ export default {
                 titleOnly: titleOnly || false,
                 indexName: toolIndexName,
                 semanticConfiguration,
-                stream: stream || false
+                stream: stream || false,
+                chatId
             });
 
             const parsedResponse = JSON.parse(response);


### PR DESCRIPTION
This pull request introduces changes to streamline the handling of `chatId` across multiple modules and removes unused properties related to data sources and configurations. The updates improve consistency in parameter usage and simplify the code by eliminating redundant fields.

### Updates to `sys_entity_agent.js`:

* Replaced several unused properties (`indexName`, `semanticConfiguration`, `roleInformation`, `calculateEmbeddings`, and `dataSources`) with the new `chatId` property in the default export object. (`[pathways/system/entity/sys_entity_agent.jsL19-R19](diffhunk://#diff-ba8390dc0ed151a2b26e69627a5fe50b0b6d18d6470f4cc3d05ffe105d865dfcL19-R19)`)
* Added `chatId` to the destructured arguments in the `pathwayResolver` logic to ensure it is passed correctly through the system. (`[pathways/system/entity/sys_entity_agent.jsL189-R185](diffhunk://#diff-ba8390dc0ed151a2b26e69627a5fe50b0b6d18d6470f4cc3d05ffe105d865dfcL189-R185)`)
* Included `chatId` in the `args` object to make it available for downstream processes. (`[pathways/system/entity/sys_entity_agent.jsL208-R205](diffhunk://#diff-ba8390dc0ed151a2b26e69627a5fe50b0b6d18d6470f4cc3d05ffe105d865dfcL208-R205)`)

### Updates to `sys_tool_cognitive_search.js`:

* Added `chatId` to the destructured arguments in the `executePathway` function, replacing the now-removed `dataSources` property. (`[pathways/system/entity/tools/sys_tool_cognitive_search.jsL161-R161](diffhunk://#diff-375c66b9e5b2736d9da4fe9cb91b1ef621deaad86355ba89f737d3a7ed3f27a3L161-R161)`)
* Passed `chatId` as part of the request payload to ensure it is included in the search tool's processing logic. (`[pathways/system/entity/tools/sys_tool_cognitive_search.jsL195-R196](diffhunk://#diff-375c66b9e5b2736d9da4fe9cb91b1ef621deaad86355ba89f737d3a7ed3f27a3L195-R196)`)