### PR TITLE
ARC-2602: Better retry handling, fixing null cases

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -138,8 +138,19 @@ function alignSubtitles(subtitles, format, offsets) {
         return resynced;
     }
 
+    //filter null subtitles
+    if(subtitles.some(subtitle => subtitle === null)){
+        logger.warn('Subtitles contains null values!');
+        subtitles = subtitles.filter(subtitle => subtitle !== null);
+    }
+
     for (let i = 0; i < subtitles.length; i++) {
-        result.push(...shiftSubtitles(subtitles[i], offsets[i]*1000)); // convert to milliseconds
+        try{
+            result.push(...shiftSubtitles(subtitles[i], offsets[i]*1000)); // convert to milliseconds
+        }catch(e){
+            logger.error(`Error aligning subtitles: ${e}`);
+            throw e;
+        }
     }
     
     


### PR DESCRIPTION
Enhance subtitle alignment and error handling in util.js; increase retry limit and improve error handling in OpenAIWhisperPlugin.js

This pull request introduces improvements to error handling, retry logic, and data validation in subtitle alignment and OpenAI Whisper plugin processing. Key changes include filtering null subtitles, enhancing retry mechanisms with rate-limit handling, and adding retry logic for processing URIs.

### Improvements to error handling and data validation:

* [`lib/util.js`](diffhunk://#diff-3fb720f70ea34fb2975fd6c38ac4b6b6131373be2abfa4760dfaae8a25daaee2R141-R153): Added a check to filter out null subtitles and log a warning if any are found. Enhanced error handling in the `alignSubtitles` function to log errors during subtitle alignment and rethrow them.

### Enhancements to retry mechanisms:

* [`server/plugins/openAiWhisperPlugin.js`](diffhunk://#diff-d1e1918f56df533caf95cc81e1dfa57a430bcd6a53fbabfb6dcc4045eacee07eL86-R86): Increased the maximum retry attempts for the OpenAI Whisper plugin from 3 to 5 and added logic to handle rate-limit errors (HTTP 429). Introduced exponential backoff for rate-limit retries and adjusted the retry counter accordingly. [[1]](diffhunk://#diff-d1e1918f56df533caf95cc81e1dfa57a430bcd6a53fbabfb6dcc4045eacee07eL86-R86) [[2]](diffhunk://#diff-d1e1918f56df533caf95cc81e1dfa57a430bcd6a53fbabfb6dcc4045eacee07eL102-R114)
* [`server/plugins/openAiWhisperPlugin.js`](diffhunk://#diff-d1e1918f56df533caf95cc81e1dfa57a430bcd6a53fbabfb6dcc4045eacee07eR168-R169): Added retry logic to the `processURI` function, allowing up to 3 retries with a 1-second delay between attempts. Errors now break out of the retry loop to ensure proper handling. [[1]](diffhunk://#diff-d1e1918f56df533caf95cc81e1dfa57a430bcd6a53fbabfb6dcc4045eacee07eR168-R169) [[2]](diffhunk://#diff-d1e1918f56df533caf95cc81e1dfa57a430bcd6a53fbabfb6dcc4045eacee07eR182-L177)