### PR TITLE
fix: increase maximum retry attempts and enhance error handling in requestExecutor

### DIFF
--- a/lib/requestExecutor.js
+++ b/lib/requestExecutor.js
@@ -214,7 +214,7 @@ const requestWithMonitor = async (endpoint, url, data, axiosConfigObj) => {
     return { response, duration };
 }
 
-const MAX_RETRY = 5; // retries for error handling
+const MAX_RETRY = 6; // retries for error handling
 const MAX_DUPLICATE_REQUESTS = 3; // duplicate requests to manage latency spikes
 const DUPLICATE_REQUEST_AFTER = 10; // 10 seconds
 
@@ -312,49 +312,54 @@ const makeRequest = async (cortexRequest) => {
             const { response, duration } = await Promise.race(promises);
 
             // if response status is 2xx
-            if (response.status >= 200 && response.status < 300) {
+            if (response?.status >= 200 && response?.status < 300) {
                 return { response, duration };
             } else {
-                throw new Error(`Received error response: ${response.status}`);
+                throw new Error({message: `Request failed with status ${response?.status}`, response: response, duration: duration});
             }
         } catch (error) {
-            const { response, duration, code } = error;
-            if (response || code === 'ECONNRESET') {
-                const status = response?.status || 502; // default to 502 if ECONNRESET
-                // if there is only one endpoint, only retry select error codes
-                if (cortexRequest.model.endpoints.length === 1) {
-                    if (status !== 429 &&
-                        status !== 408 &&
-                        status !== 500 &&
-                        status !== 502 &&
-                        status !== 503 &&
-                        status !== 504) {
-                        return { response, duration };
-                    }
-                    // set up for a retry by reinitializing the request
-                    cortexRequest.initRequest();
-                } else {
-                    // if there are multiple endpoints, retry everything by default
-                    // as it could be a temporary issue with one endpoint
-                    // certain errors (e.g. 400) are problems with the request itself
-                    // and should not be retried
-                    if (status == 400 || status == 413) {
-                        return { response, duration };
-                    }
-                    // set up for a retry by selecting a new endpoint, which will also reinitialize the request
-                    cortexRequest.selectNewEndpoint();
-                }
-
-                logger.info(`>>> [${requestId}] retrying request (${duration}ms) due to ${status} response. Retry count: ${i + 1}`);
-                if (i < MAX_RETRY - 1) {
-                    const backoffTime = 1000 * Math.pow(2, i);
-                    const jitter = backoffTime * 0.2 * Math.random();
-                    await new Promise(r => setTimeout(r, backoffTime + jitter));
-                } else {
+            // Handle both cases: error with response object and direct error object
+            const status = error?.response?.status || error?.status || 502; // default to 502 if no status
+            const duration = error?.duration;
+            const response = error?.response || {error: error};
+            
+            // Calculate backoff time - use Retry-After for 429s if available
+            let backoffTime = 1000 * Math.pow(2, i);
+            if (status === 429 && (response?.headers?.['retry-after'] || error?.headers?.['retry-after'])) {
+                backoffTime = parseInt(response?.headers?.['retry-after'] || error?.headers?.['retry-after']) * 1000;
+                logger.warn(`>>> [${requestId}] Rate limited (429). Retry-After: ${response?.headers?.['retry-after'] || error?.headers?.['retry-after']}s`);
+            }
+            const jitter = backoffTime * 0.2 * Math.random();
+            
+            // if there is only one endpoint, only retry select error codes
+            if (cortexRequest.model.endpoints.length === 1) {
+                if (status !== 429 &&
+                    status !== 408 &&
+                    status !== 500 &&
+                    status !== 502 &&
+                    status !== 503 &&
+                    status !== 504) {
                     return { response, duration };
                 }
+                // set up for a retry by reinitializing the request
+                cortexRequest.initRequest();
             } else {
-                throw error;
+                // if there are multiple endpoints, retry everything by default
+                // as it could be a temporary issue with one endpoint
+                // certain errors (e.g. 400) are problems with the request itself
+                // and should not be retried
+                if (status == 400 || status == 413) {
+                    return { response, duration };
+                }
+                // set up for a retry by selecting a new endpoint, which will also reinitialize the request
+                cortexRequest.selectNewEndpoint();
+            }
+
+            if (i < MAX_RETRY - 1) {
+                logger.info(`>>> [${requestId}] retrying request due to ${status} response. Retry count: ${i + 1}. Retrying in ${backoffTime + jitter}ms`);
+                await new Promise(r => setTimeout(r, backoffTime + jitter));
+            } else {
+                return { response, duration };
             }
         }
     }


### PR DESCRIPTION
- Updated MAX_RETRY from 5 to 6 to allow for additional retry attempts.
- Improved error handling to provide more detailed error messages and response information.
- Enhanced backoff strategy for rate-limited responses (status 429) to utilize Retry-After headers when available.