### PR TITLE
Update @aj-archipelago/subvibe to version 1.0.12 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.53",
       "license": "MIT",
       "dependencies": {
-        "@aj-archipelago/subvibe": "^1.0.10",
+        "@aj-archipelago/subvibe": "^1.0.12",
         "@apollo/server": "^4.7.3",
         "@apollo/server-plugin-response-cache": "^4.1.2",
         "@apollo/utils.keyvadapter": "^3.0.0",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@aj-archipelago/subvibe": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@aj-archipelago/subvibe/-/subvibe-1.0.10.tgz",
-      "integrity": "sha512-QnhDa/96fne67m4ilIVlmYWcd7WwEngXs5yvZiUBSLfFeyU7QQNeG9qSV3m2Rjuiei2FPFyUwNovEqCnSo0ZXA==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@aj-archipelago/subvibe/-/subvibe-1.0.12.tgz",
+      "integrity": "sha512-yx/LqBWBIYm4UDptnpC3DRSi/UivMlXxGyJ1AhGk1w0ZvoYGjTExVei/sD9UOn6u5X7hS4u3AjrtsHc3NalW2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "type": "module",
   "homepage": "https://github.com/aj-archipelago/cortex#readme",
   "dependencies": {
-    "@aj-archipelago/subvibe": "^1.0.10",
+    "@aj-archipelago/subvibe": "^1.0.12",
     "@apollo/server": "^4.7.3",
     "@apollo/server-plugin-response-cache": "^4.1.2",
     "@apollo/utils.keyvadapter": "^3.0.0",


### PR DESCRIPTION
This pull request updates the `@aj-archipelago/subvibe` dependency in the `package.json` file to a newer version, improving compatibility or addressing potential issues.

* Dependency update:
  * Updated `@aj-archipelago/subvibe` from version `^1.0.10` to `^1.0.12` in `package.json` to ensure the project uses the latest features or fixes provided by the library.