### PR TITLE
Enhance coding agent task with chat history

### DIFF
--- a/pathways/system/entity/tools/sys_tool_codingagent.js
+++ b/pathways/system/entity/tools/sys_tool_codingagent.js
@@ -79,10 +79,17 @@ export default {
             const { codingTask, userMessage, inputFiles, codingTaskKeywords } = args;
             const { contextId } = args;
 
-            let taskSuffix = "";
-            if (inputFiles) {
-                taskSuffix = `You must use the following files as input to complete the task: ${inputFiles}.`
+            let taskSuffix = `\n\n<EXTRA_INFO> Chat History with User (This chat triggered the coding task):\n${args?.chatHistory?.map(message => `${message?.role}: ${message?.content}`).join('\n')}\n\n</EXTRA_INFO>`;
+            const maxSuffixLength = 20000; // Maximum length for the task suffix
+            if(taskSuffix.length > maxSuffixLength) {
+                logger.warn(`Task suffix is too long (${taskSuffix.length} characters). Truncating to last ${maxSuffixLength} characters.`);
+                taskSuffix = taskSuffix.slice(-maxSuffixLength); // truncate to last characters to avoid exceeding 
             }
+            
+            // if (inputFiles) {
+            //     taskSuffix = `You must use the following files as input to complete the task: ${inputFiles}.`
+            // }
+
 
 
             // Send the task to the queue

--- a/pathways/system/entity/tools/sys_tool_codingagent.js
+++ b/pathways/system/entity/tools/sys_tool_codingagent.js
@@ -79,7 +79,7 @@ export default {
             const { codingTask, userMessage, inputFiles, codingTaskKeywords } = args;
             const { contextId } = args;
 
-            let taskSuffix = `\n\n<EXTRA_INFO> Chat History with User (This chat triggered the coding task):\n${args?.chatHistory?.map(message => `${message?.role}: ${message?.content}`).join('\n')}\n\n</EXTRA_INFO>`;
+            let taskSuffix = `\n\n<EXTRA_INFO> Chat History with User (This chat triggered the coding task):\n${(args.chatHistory || []).map(message => `${message?.role}: ${message?.content}`).join('\n')}\n\n</EXTRA_INFO>`;
             const maxSuffixLength = 20000; // Maximum length for the task suffix
             if(taskSuffix.length > maxSuffixLength) {
                 logger.warn(`Task suffix is too long (${taskSuffix.length} characters). Truncating to last ${maxSuffixLength} characters.`);


### PR DESCRIPTION
This pull request modifies the `taskSuffix` logic in the `sys_tool_codingagent.js` file to include user chat history as additional context for coding tasks. It also introduces truncation logic to ensure the `taskSuffix` does not exceed a specified length.

Key changes related to `taskSuffix`:

* [`pathways/system/entity/tools/sys_tool_codingagent.js`](diffhunk://#diff-a2fe2ad2cfe24c831158e55283f2ef720e3ec72a3a66da81b38bd324c052c7efL82-R93): Replaced the previous `taskSuffix` logic with a new format that includes user chat history for better context. Added truncation functionality to limit the `taskSuffix` length to a maximum of 20,000 characters, with a warning logged if truncation occurs.