### PR TITLE
feat: add geminiSafetySettings to multiple pathways

### DIFF
--- a/pathways/gemini_15_vision.js
+++ b/pathways/gemini_15_vision.js
@@ -17,4 +17,8 @@ export default {
     useInputChunking: false,
     enableDuplicateRequests: false,
     timeout: 600,
+    geminiSafetySettings: [{category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH'}],
 }

--- a/pathways/system/entity/tools/sys_tool_readfile.js
+++ b/pathways/system/entity/tools/sys_tool_readfile.js
@@ -22,6 +22,10 @@ export default {
     useInputChunking: false,
     enableDuplicateRequests: false,
     timeout: 600,
+    geminiSafetySettings: [{category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH'}],
     toolDefinition: [{
         type: "function",
         icon: "📄",

--- a/pathways/system/workspaces/workspace_applet_edit.js
+++ b/pathways/system/workspaces/workspace_applet_edit.js
@@ -182,6 +182,10 @@ export default {
     },
     // model: 'oai-gpt41',
     model: 'gemini-pro-25-vision',
+    geminiSafetySettings: [{category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH'},
+      {category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH'},
+      {category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH'},
+      {category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH'}],
     timeout: 600,
     stream: true,
 } 

--- a/pathways/transcribe_gemini.js
+++ b/pathways/transcribe_gemini.js
@@ -62,6 +62,10 @@ export default {
     },
     timeout: 3600, // in seconds
     enableDuplicateRequests: false,
+    geminiSafetySettings: [{category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH'},
+        {category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH'}],
 
     executePathway: async ({args, runAllPrompts, resolver}) => {
         let intervalId;

--- a/server/plugins/gemini15ChatPlugin.js
+++ b/server/plugins/gemini15ChatPlugin.js
@@ -124,9 +124,9 @@ class Gemini15ChatPlugin extends ModelPlugin {
             topP: parameters.topP || 0.95,
             topK: parameters.topK || 40,
         },
-        safety_settings: geminiSafetySettings || undefined,
-        systemInstruction: system,
-        tools: geminiTools || undefined
+        ...(geminiSafetySettings ? {safety_settings: geminiSafetySettings} : {}),
+        ...(system ? {systemInstruction: system} : {}),
+        ...(geminiTools ? {tools: geminiTools} : {})
         };
     
         return requestParameters;


### PR DESCRIPTION
This pull request introduces a standardized configuration for `geminiSafetySettings` across multiple files to enhance content moderation and improves the handling of optional parameters in the `Gemini15ChatPlugin`. Below are the key changes grouped by theme:

### Standardization of `geminiSafetySettings`
* Added `geminiSafetySettings` with specific categories (`HARM_CATEGORY_DANGEROUS_CONTENT`, `HARM_CATEGORY_SEXUALLY_EXPLICIT`, `HARM_CATEGORY_HARASSMENT`, `HARM_CATEGORY_HATE_SPEECH`) and a threshold of `BLOCK_ONLY_HIGH` to the configurations in the following files:
  - `pathways/gemini_15_vision.js`
  - `pathways/system/entity/tools/sys_tool_readfile.js`
  - `pathways/system/workspaces/workspace_applet_edit.js`
  - `pathways/transcribe_gemini.js`

### Improved Handling of Optional Parameters
* Refactored the `Gemini15ChatPlugin` class to use conditional spreads for optional parameters like `geminiSafetySettings`, `systemInstruction`, and `tools`, making the code more concise and robust. (`server/plugins/gemini15ChatPlugin.js`, [server/plugins/gemini15ChatPlugin.jsL127-R129](diffhunk://#diff-02c9e3aa329f46747bae92414ad005669447c1bbf39777dfaf61e0d80fcba8a9L127-R129))