### PR TITLE
feat: swap Bing search to always use AF Agents

### DIFF
--- a/lib/entityConstants.js
+++ b/lib/entityConstants.js
@@ -89,20 +89,9 @@ Before you share online information with the user, you MUST complete all of the 
    - Never rely solely on snippets, headlines, or auto-generated summaries.
 `,
 
-    AI_SEARCH_SYNTAX: `# Bing Search Syntax
+    AI_SEARCH_SYNTAX: `# AI Search Syntax
 
-When creating a query string for your Bing internet search tool, you can use Bing's advanced search operators in your query. E.g. "+(\"exact phrase\") AND term1 -term2"
-
-token1 & token2        (AND operator - both tokens must appear)
-token1 | token2        (OR operator - either token may appear (also the default if no operator is specified))
--token                 (NOT operator - exclude results with token)
-+token                 (Require token)
-"term1 term2"          (Exact phrase match)
-(token1 + token2)      (Override precedence with parentheses)
-
-# AI Search Syntax
-
-When creating a query string for your non-Bing, index-based search tools, you can use the following AI Search syntax. Important: these tools do not support AND, OR, or NOT strings as operators - you MUST use the syntax below.  E.g. you cannot use "term1 AND term2", you must use "term1 + term2".
+When creating a query string for your index-based search tools, you can use the following AI Search syntax. Important: these tools do not support AND, OR, or NOT strings as operators - you MUST use the syntax below.  E.g. you cannot use "term1 AND term2", you must use "term1 + term2".
 
 token1 + token2        (AND operator - both tokens must appear)
 token1 | token2        (OR operator - either token may appear (also the default if no operator is specified))

--- a/pathways/system/entity/tools/sys_tool_bing_search.js
+++ b/pathways/system/entity/tools/sys_tool_bing_search.js
@@ -8,6 +8,7 @@ import { getSearchResultId } from '../../../../lib/util.js';
 export default {
     prompt: [],
     timeout: 300,
+    /* This tool is included for legacy reasons - as of August 2025, Azure has deprecated the Bing search API and replaced it with their Foundry Agents API.
     toolDefinition: { 
         type: "function",
         icon: "🌐",
@@ -42,6 +43,7 @@ export default {
             }
         }
     },
+    */
 
     executePathway: async ({args, runAllPrompts, resolver}) => {
 

--- a/pathways/system/entity/tools/sys_tool_bing_search_afagent.js
+++ b/pathways/system/entity/tools/sys_tool_bing_search_afagent.js
@@ -10,10 +10,10 @@ export default {
     timeout: 300,
     toolDefinition: { 
         type: "function",
-        icon: "🕸️",
+        icon: "🌐",
         function: {
-            name: "SearchInternetBackup",
-            description: "This tool allows you to search sources on the internet by calling another agent that has Bing search access. Use this for current events, news, fact-checking, and information requiring citation. This is a backup tool for when the other internet search tools fail - it is slower so try to use the other tools first and always call this tool in parallel if you have several searches to do.",
+            name: "SearchInternet",
+            description: "This tool allows you to search sources on the internet by calling another agent that has Bing search access. Use this for current events, news, fact-checking, and information requiring citation. Always call this tool in parallel rather than serially if you have several searches to do as it will be faster.",
             parameters: {
                 type: "object",
                 properties: {


### PR DESCRIPTION
- Revised AI search syntax instructions for clarity and consistency.
- Updated Bing search tool name to "SearchInternet" and modified its description for improved usability.
- Added a comment regarding the deprecation of the Bing search API for future reference.