### PR TITLE
feat: enhance chat history management to support file attachments

### DIFF
--- a/pathways/system/entity/sys_entity_agent.js
+++ b/pathways/system/entity/sys_entity_agent.js
@@ -243,7 +243,7 @@ export default {
                     role: "user",
                     content: []
                 };
-                args.chatHistory.unshift(lastUserMessage);
+                args.chatHistory.push(lastUserMessage);
             }
 
             //if last user message content is not array then convert to array

--- a/pathways/system/entity/sys_entity_agent.js
+++ b/pathways/system/entity/sys_entity_agent.js
@@ -248,7 +248,7 @@ export default {
 
             //if last user message content is not array then convert to array
             if(!Array.isArray(lastUserMessage.content)) {
-                lastUserMessage.content = [lastUserMessage.content];
+                lastUserMessage.content = lastUserMessage.content ? [lastUserMessage.content] : [];
             }
 
             //add files to the last user message content

--- a/pathways/system/entity/sys_entity_agent.js
+++ b/pathways/system/entity/sys_entity_agent.js
@@ -237,7 +237,7 @@ export default {
 
         if(entityConfig?.files && entityConfig?.files.length > 0) {
             //get last user message if not create one to add files to
-            const lastUserMessage = args.chatHistory.filter(message => message.role === "user").slice(-1)[0];
+            let lastUserMessage = args.chatHistory.filter(message => message.role === "user").slice(-1)[0];
             if(!lastUserMessage) {
                 lastUserMessage = {
                     role: "user",
@@ -252,16 +252,14 @@ export default {
             }
 
             //add files to the last user message content
-            lastUserMessage.content.push(...entityConfig?.files.map(file => (
-                JSON.stringify({
+            lastUserMessage.content.push(...entityConfig?.files.map(file => ({
                     type: "image_url",
                     gcs: file?.gcs,
                     url: file?.url,
                     image_url: { url: file?.url },
                     originalFilename: file?.name
                 })
-            )));
-
+            ));
         }
 
         // Kick off the memory lookup required pathway in parallel - this takes like 500ms so we want to start it early

--- a/pathways/system/entity/sys_entity_agent.js
+++ b/pathways/system/entity/sys_entity_agent.js
@@ -235,6 +235,35 @@ export default {
             args.chatHistory = [];
         }
 
+        if(entityConfig?.files && entityConfig?.files.length > 0) {
+            //get last user message if not create one to add files to
+            const lastUserMessage = args.chatHistory.filter(message => message.role === "user").slice(-1)[0];
+            if(!lastUserMessage) {
+                lastUserMessage = {
+                    role: "user",
+                    content: []
+                };
+                args.chatHistory.unshift(lastUserMessage);
+            }
+
+            //if last user message content is not array then convert to array
+            if(!Array.isArray(lastUserMessage.content)) {
+                lastUserMessage.content = [lastUserMessage.content];
+            }
+
+            //add files to the last user message content
+            lastUserMessage.content.push(...entityConfig?.files.map(file => (
+                JSON.stringify({
+                    type: "image_url",
+                    gcs: file?.gcs,
+                    url: file?.url,
+                    image_url: { url: file?.url },
+                    originalFilename: file?.name
+                })
+            )));
+
+        }
+
         // Kick off the memory lookup required pathway in parallel - this takes like 500ms so we want to start it early
         let memoryLookupRequiredPromise = null;
         if (entityUseMemory) {


### PR DESCRIPTION
- Added functionality to append file information to the last user message in chat history.
- Ensured that the last user message is created if it does not exist and that its content is an array.
- Integrated file details including GCS, URL, and original filename into the chat history structure.

This pull request updates the way files are handled in the `chatHistory` within the `sys_entity_agent.js` file. Now, when files are present in the `entityConfig`, they are automatically attached to the most recent user message in the chat history, or a new user message is created if none exists.

Enhancements to file attachment in chat history:

* Automatically attaches files from `entityConfig.files` to the most recent user message in `args.chatHistory`. If no user message exists, a new one is created. Files are serialized as JSON objects with relevant metadata before being added.
* Ensures that the `content` property of the last user message is always an array before adding files, preventing type errors and maintaining consistent data structure.