### PR TITLE
CFH: Put converted file in the same container as the original file

### DIFF
--- a/helper-apps/cortex-file-handler/src/blobHandler.js
+++ b/helper-apps/cortex-file-handler/src/blobHandler.js
@@ -659,6 +659,8 @@ function uploadBlob(
                       await conversionService._saveConvertedFile(
                         conversion.convertedPath,
                         requestId,
+                        null,
+                        containerName,
                       );
 
                     // Optionally save to GCS
@@ -960,6 +962,8 @@ async function uploadFile(
             await conversionService._saveConvertedFile(
               conversion.convertedPath,
               requestId,
+              null,
+              containerName,
             );
           context.log("Converted file saved to primary storage");
 

--- a/helper-apps/cortex-file-handler/src/index.js
+++ b/helper-apps/cortex-file-handler/src/index.js
@@ -479,6 +479,7 @@ async function CortexFileHandler(context, req) {
           hashResult = await conversionService.ensureConvertedVersion(
             hashResult,
             requestId,
+            container,
           );
         } catch (error) {
           context.log(`Error ensuring converted version: ${error}`);
@@ -593,6 +594,8 @@ async function CortexFileHandler(context, req) {
               await conversionService._saveConvertedFile(
                 conversion.convertedPath,
                 requestId,
+                null,
+                container,
               );
 
             // Return the converted file URL
@@ -608,6 +611,8 @@ async function CortexFileHandler(context, req) {
             const saveResult = await conversionService._saveConvertedFile(
               downloadedFile,
               requestId,
+              null,
+              container,
             );
 
             // Return the original file URL

--- a/helper-apps/cortex-file-handler/src/services/ConversionService.js
+++ b/helper-apps/cortex-file-handler/src/services/ConversionService.js
@@ -96,9 +96,10 @@ export class ConversionService {
    * Ensures a file has both original and converted versions
    * @param {Object} fileInfo - Information about the file
    * @param {string} requestId - Request ID for storage
+   * @param {string} containerName - Optional container name for storage
    * @returns {Promise<Object>} - Updated file info with conversion if needed
    */
-  async ensureConvertedVersion(fileInfo, requestId) {
+  async ensureConvertedVersion(fileInfo, requestId, containerName = null) {
     const { url, gcs } = fileInfo;
     // Remove any query parameters before extension check
     const extension = path.extname(url.split("?")[0]).toLowerCase();
@@ -158,6 +159,8 @@ export class ConversionService {
         const convertedSaveResult = await this._saveConvertedFile(
           conversion.convertedPath,
           requestId,
+          null,
+          containerName,
         );
         if (!convertedSaveResult) {
           throw new Error("Failed to save converted file to primary storage");
@@ -302,7 +305,7 @@ export class ConversionService {
     throw new Error("Method _downloadFile must be implemented");
   }
 
-  async _saveConvertedFile(filePath, requestId) {
+  async _saveConvertedFile(filePath, requestId, filename = null, containerName = null) {
     throw new Error("Method _saveConvertedFile must be implemented");
   }
 

--- a/helper-apps/cortex-file-handler/src/services/FileConversionService.js
+++ b/helper-apps/cortex-file-handler/src/services/FileConversionService.js
@@ -33,13 +33,13 @@ export class FileConversionService extends ConversionService {
     return downloadFile(url, destination);
   }
 
-  async _saveConvertedFile(filePath, requestId, filename = null) {
+  async _saveConvertedFile(filePath, requestId, filename = null, containerName = null) {
     // Generate a fallback requestId if none supplied (e.g. during checkHash calls)
     const reqId = requestId || uuidv4();
 
     let fileUrl;
     if (this.useAzure) {
-      const savedBlob = await saveFileToBlob(filePath, reqId, filename);
+      const savedBlob = await saveFileToBlob(filePath, reqId, filename, containerName);
       fileUrl = savedBlob.url;
     } else {
       fileUrl = await moveFileToPublicFolder(filePath, reqId);

--- a/helper-apps/cortex-file-handler/tests/FileConversionService.test.js
+++ b/helper-apps/cortex-file-handler/tests/FileConversionService.test.js
@@ -154,3 +154,45 @@ test("correctly detects file extensions", (t) => {
   t.false(service.needsConversion("test.txt"));
   t.false(service.needsConversion("test.json"));
 });
+
+// Test _saveConvertedFile method signature and container parameter handling
+test("_saveConvertedFile accepts container parameter", async (t) => {
+  const service = new FileConversionService(mockContext, false); // Use local storage for testing
+  
+  // Create a test file
+  const testFile = join(t.context.testDir, "container-param-test.txt");
+  await fs.writeFile(testFile, "Test content for container parameter");
+  
+  // Test that the method accepts all parameters without throwing
+  const result = await service._saveConvertedFile(
+    testFile,
+    "test-request-id",
+    "test-filename.txt",
+    "test-container"
+  );
+  
+  t.truthy(result);
+  t.truthy(result.url);
+  t.true(typeof result.url === 'string');
+});
+
+// Test ensureConvertedVersion method signature with container parameter
+test("ensureConvertedVersion accepts container parameter", async (t) => {
+  const service = new FileConversionService(mockContext, false);
+  
+  // Mock file info object
+  const fileInfo = {
+    url: "http://example.com/test.txt", // Non-convertible file
+    gcs: "gs://bucket/test.txt"
+  };
+  
+  // Test that the method accepts container parameter without throwing
+  const result = await service.ensureConvertedVersion(
+    fileInfo,
+    "test-request-id",
+    "test-container"
+  );
+  
+  t.truthy(result);
+  t.is(result.url, fileInfo.url); // Should return original for non-convertible file
+});

--- a/helper-apps/cortex-file-handler/tests/containerConversionFlow.test.js
+++ b/helper-apps/cortex-file-handler/tests/containerConversionFlow.test.js
@@ -1,0 +1,443 @@
+import test from "ava";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+import { v4 as uuidv4 } from "uuid";
+import axios from "axios";
+import FormData from "form-data";
+import XLSX from "xlsx";
+import { port } from "../src/start.js";
+import {
+  uploadBlob,
+  isValidContainerName,
+  AZURE_STORAGE_CONTAINER_NAMES,
+  saveFileToBlob,
+} from "../src/blobHandler.js";
+import { FileConversionService } from "../src/services/FileConversionService.js";
+import CortexFileHandler from "../src/index.js";
+import {
+  startTestServer,
+  stopTestServer,
+  setupTestDirectory,
+  cleanupHashAndFile,
+  getFolderNameFromUrl,
+} from "./testUtils.helper.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const baseUrl = `http://localhost:${port}/api/CortexFileHandler`;
+
+// Mock context for testing
+const mockContext = {
+  log: (message) => console.log(`[CONTAINER_CONVERSION_TEST] ${message}`),
+  res: null,
+};
+
+// Helper function to create test files
+async function createTestFile(content, extension, filename = null) {
+  const testDir = path.join(__dirname, "test-conversion-files");
+  if (!fs.existsSync(testDir)) {
+    fs.mkdirSync(testDir, { recursive: true });
+  }
+  const testFilename = filename || `${uuidv4()}.${extension}`;
+  const filePath = path.join(testDir, testFilename);
+  
+  if (extension === 'xlsx') {
+    // Create Excel file
+    const workbook = XLSX.utils.book_new();
+    const ws1 = XLSX.utils.aoa_to_sheet(content);
+    XLSX.utils.book_append_sheet(workbook, ws1, "Sheet1");
+    XLSX.writeFile(workbook, filePath);
+  } else {
+    fs.writeFileSync(filePath, content);
+  }
+  
+  return filePath;
+}
+
+// Helper function to check if URL belongs to specific container
+function getContainerFromUrl(url) {
+  try {
+    const urlObj = new URL(url);
+    const pathSegments = urlObj.pathname.split('/').filter(Boolean);
+    
+    // For Azure URLs, container is typically the first segment after the account
+    // Format: https://account.blob.core.windows.net/container/blob...
+    if (pathSegments.length > 0) {
+      return pathSegments[0];
+    }
+  } catch (error) {
+    console.log("Error parsing container from URL:", error);
+  }
+  return null;
+}
+
+// Setup: Create test directory and start server
+test.before(async (t) => {
+  await startTestServer();
+  await setupTestDirectory(t);
+});
+
+// Cleanup
+test.after.always(async (t) => {
+  await stopTestServer();
+
+  // Clean up test directory
+  if (t.context?.testDir) {
+    await fs.promises.rm(t.context.testDir, { recursive: true, force: true });
+  }
+
+  // Clean up any remaining files in the test-conversion-files directory
+  const testFilesDir = path.join(__dirname, "test-conversion-files");
+  if (fs.existsSync(testFilesDir)) {
+    try {
+      await fs.promises.rm(testFilesDir, { recursive: true, force: true });
+    } catch (error) {
+      console.log("Error cleaning test files:", error);
+    }
+  }
+});
+
+// Test that FileConversionService._saveConvertedFile respects container parameter
+test("FileConversionService._saveConvertedFile should use specified container", async (t) => {
+  if (!process.env.AZURE_STORAGE_CONNECTION_STRING) {
+    t.pass("Skipping test - Azure not configured");
+    return;
+  }
+
+  const originalEnv = process.env.AZURE_STORAGE_CONTAINER_NAME;
+  process.env.AZURE_STORAGE_CONTAINER_NAME = "test1,test2,test3";
+
+  try {
+    const service = new FileConversionService(mockContext, true); // useAzure = true
+    
+    // Create a test file to save
+    const testContent = "This is converted file content";
+    const testFile = await createTestFile(testContent, "txt", "converted-test.txt");
+    const requestId = uuidv4();
+    const targetContainer = "test2";
+
+    // Call _saveConvertedFile with container parameter
+    const result = await service._saveConvertedFile(
+      testFile,
+      requestId,
+      null, // filename
+      targetContainer
+    );
+
+    t.truthy(result);
+    t.truthy(result.url);
+
+    // Verify the URL indicates it was uploaded to the correct container
+    const containerFromUrl = getContainerFromUrl(result.url);
+    t.is(containerFromUrl, targetContainer, 
+      `File should be uploaded to container ${targetContainer}, but was uploaded to ${containerFromUrl}`);
+
+    // Cleanup
+    await cleanupHashAndFile(null, result.url, baseUrl);
+  } finally {
+    // Restore environment
+    if (originalEnv) {
+      process.env.AZURE_STORAGE_CONTAINER_NAME = originalEnv;
+    } else {
+      delete process.env.AZURE_STORAGE_CONTAINER_NAME;
+    }
+  }
+});
+
+// Test that file upload with conversion respects container parameter
+test("File upload with conversion should upload both original and converted files to specified container", async (t) => {
+  if (!process.env.AZURE_STORAGE_CONNECTION_STRING) {
+    t.pass("Skipping test - Azure not configured");
+    return;
+  }
+
+  const originalEnv = process.env.AZURE_STORAGE_CONTAINER_NAME;
+  process.env.AZURE_STORAGE_CONTAINER_NAME = "test1,test2,test3";
+
+  try {
+    // Create an Excel file that will need conversion
+    const excelData = [
+      ["Name", "Age", "City"],
+      ["John", 30, "New York"],
+      ["Jane", 25, "Boston"],
+    ];
+    const testFile = await createTestFile(excelData, "xlsx", "test-conversion.xlsx");
+    const targetContainer = "test3";
+
+    // Create form data with container parameter
+    const form = new FormData();
+    form.append("file", fs.createReadStream(testFile), "test-conversion.xlsx");
+    form.append("container", targetContainer);
+
+    const response = await axios.post(baseUrl, form, {
+      headers: {
+        ...form.getHeaders(),
+        "Content-Type": "multipart/form-data",
+      },
+      validateStatus: (status) => true,
+      timeout: 60000, // Longer timeout for conversion
+    });
+
+    t.is(response.status, 200);
+    t.truthy(response.data.url);
+
+    // Check that the main uploaded file is in the correct container
+    const mainContainerFromUrl = getContainerFromUrl(response.data.url);
+    t.is(mainContainerFromUrl, targetContainer,
+      `Original file should be in container ${targetContainer}, but was in ${mainContainerFromUrl}`);
+
+    // If there's a converted file mentioned in the response, check its container too
+    if (response.data.converted && response.data.converted.url) {
+      const convertedContainerFromUrl = getContainerFromUrl(response.data.converted.url);
+      t.is(convertedContainerFromUrl, targetContainer,
+        `Converted file should be in container ${targetContainer}, but was in ${convertedContainerFromUrl}`);
+    }
+
+    // Cleanup
+    await cleanupHashAndFile(null, response.data.url, baseUrl);
+    if (response.data.converted && response.data.converted.url) {
+      await cleanupHashAndFile(null, response.data.converted.url, baseUrl);
+    }
+  } finally {
+    // Restore environment
+    if (originalEnv) {
+      process.env.AZURE_STORAGE_CONTAINER_NAME = originalEnv;
+    } else {
+      delete process.env.AZURE_STORAGE_CONTAINER_NAME;
+    }
+  }
+});
+
+// Test document processing with save=true and container parameter
+test("Document processing with save=true should save converted file to specified container", async (t) => {
+  if (!process.env.AZURE_STORAGE_CONNECTION_STRING) {
+    t.pass("Skipping test - Azure not configured");
+    return;
+  }
+
+  const originalEnv = process.env.AZURE_STORAGE_CONTAINER_NAME;
+  process.env.AZURE_STORAGE_CONTAINER_NAME = "test1,test2,test3";
+
+  try {
+    // First upload a document file to get a URI
+    const docContent = "This is a test document content for processing.";
+    const testFile = await createTestFile(docContent, "txt", "test-doc.txt");
+    const targetContainer = "test1";
+
+    // Upload the file first
+    const uploadForm = new FormData();
+    uploadForm.append("file", fs.createReadStream(testFile), "test-doc.txt");
+    uploadForm.append("container", targetContainer);
+
+    const uploadResponse = await axios.post(baseUrl, uploadForm, {
+      headers: {
+        ...uploadForm.getHeaders(),
+        "Content-Type": "multipart/form-data",
+      },
+      validateStatus: (status) => true,
+      timeout: 30000,
+    });
+
+    t.is(uploadResponse.status, 200);
+    const documentUri = uploadResponse.data.url;
+
+    // Now process the document with save=true and container parameter
+    const processResponse = await axios.get(baseUrl, {
+      params: {
+        uri: documentUri,
+        requestId: uuidv4(),
+        save: true,
+        container: targetContainer,
+      },
+      validateStatus: (status) => true,
+      timeout: 60000,
+    });
+
+    t.is(processResponse.status, 200);
+    t.truthy(processResponse.data.url);
+
+    // Check that the saved file is in the correct container
+    const savedContainerFromUrl = getContainerFromUrl(processResponse.data.url);
+    t.is(savedContainerFromUrl, targetContainer,
+      `Saved processed file should be in container ${targetContainer}, but was in ${savedContainerFromUrl}`);
+
+    // Cleanup
+    await cleanupHashAndFile(null, documentUri, baseUrl);
+    await cleanupHashAndFile(null, processResponse.data.url, baseUrl);
+  } finally {
+    // Restore environment
+    if (originalEnv) {
+      process.env.AZURE_STORAGE_CONTAINER_NAME = originalEnv;
+    } else {
+      delete process.env.AZURE_STORAGE_CONTAINER_NAME;
+    }
+  }
+});
+
+// Test checkHash operation preserves container for converted files
+test("checkHash operation should respect container parameter for converted files", async (t) => {
+  if (!process.env.AZURE_STORAGE_CONNECTION_STRING) {
+    t.pass("Skipping test - Azure not configured");
+    return;
+  }
+
+  const originalEnv = process.env.AZURE_STORAGE_CONTAINER_NAME;
+  process.env.AZURE_STORAGE_CONTAINER_NAME = "test1,test2,test3";
+
+  try {
+    // Create an Excel file that will need conversion
+    const excelData = [
+      ["Product", "Price"],
+      ["Widget", 10.99],
+      ["Gadget", 15.50],
+    ];
+    const testFile = await createTestFile(excelData, "xlsx", "hash-test.xlsx");
+    const targetContainer = "test2";
+    const testHash = uuidv4();
+
+    // Upload the file with a hash and container parameter
+    const form = new FormData();
+    form.append("file", fs.createReadStream(testFile), "hash-test.xlsx");
+    form.append("hash", testHash);
+    form.append("container", targetContainer);
+
+    const uploadResponse = await axios.post(baseUrl, form, {
+      headers: {
+        ...form.getHeaders(),
+        "Content-Type": "multipart/form-data",
+      },
+      validateStatus: (status) => true,
+      timeout: 60000,
+    });
+
+    t.is(uploadResponse.status, 200);
+
+    // Now check the hash with container parameter
+    const checkResponse = await axios.get(baseUrl, {
+      params: {
+        hash: testHash,
+        checkHash: true,
+        container: targetContainer,
+      },
+      validateStatus: (status) => true,
+      timeout: 60000,
+    });
+
+    t.is(checkResponse.status, 200);
+    t.truthy(checkResponse.data.url);
+
+    // Check that the original file is in the correct container
+    const originalContainerFromUrl = getContainerFromUrl(checkResponse.data.url);
+    t.is(originalContainerFromUrl, targetContainer,
+      `Original file should be in container ${targetContainer}, but was in ${originalContainerFromUrl}`);
+
+    // If there's a converted file, check its container too
+    if (checkResponse.data.converted && checkResponse.data.converted.url) {
+      const convertedContainerFromUrl = getContainerFromUrl(checkResponse.data.converted.url);
+      t.is(convertedContainerFromUrl, targetContainer,
+        `Converted file should be in container ${targetContainer}, but was in ${convertedContainerFromUrl}`);
+    }
+
+    // Cleanup
+    await cleanupHashAndFile(testHash, checkResponse.data.url, baseUrl);
+    if (checkResponse.data.converted && checkResponse.data.converted.url) {
+      await cleanupHashAndFile(null, checkResponse.data.converted.url, baseUrl);
+    }
+  } finally {
+    // Restore environment
+    if (originalEnv) {
+      process.env.AZURE_STORAGE_CONTAINER_NAME = originalEnv;
+    } else {
+      delete process.env.AZURE_STORAGE_CONTAINER_NAME;
+    }
+  }
+});
+
+// Test that default container is used when no container specified for conversions
+test("Conversion should use default container when no container specified", async (t) => {
+  if (!process.env.AZURE_STORAGE_CONNECTION_STRING) {
+    t.pass("Skipping test - Azure not configured");
+    return;
+  }
+
+  const originalEnv = process.env.AZURE_STORAGE_CONTAINER_NAME;
+  process.env.AZURE_STORAGE_CONTAINER_NAME = "test1,test2,test3";
+
+  try {
+    const service = new FileConversionService(mockContext, true);
+    
+    // Create a test file to save
+    const testContent = "This is converted file content for default container test";
+    const testFile = await createTestFile(testContent, "txt", "default-container-test.txt");
+    const requestId = uuidv4();
+
+    // Call _saveConvertedFile without container parameter (should use default)
+    const result = await service._saveConvertedFile(
+      testFile,
+      requestId,
+      null, // filename
+      null  // container - should use default
+    );
+
+    t.truthy(result);
+    t.truthy(result.url);
+
+    // Verify the URL indicates it was uploaded to the default container
+    const containerFromUrl = getContainerFromUrl(result.url);
+    t.is(containerFromUrl, AZURE_STORAGE_CONTAINER_NAMES[0],
+      `File should be uploaded to default container ${AZURE_STORAGE_CONTAINER_NAMES[0]}, but was uploaded to ${containerFromUrl}`);
+
+    // Cleanup
+    await cleanupHashAndFile(null, result.url, baseUrl);
+  } finally {
+    // Restore environment
+    if (originalEnv) {
+      process.env.AZURE_STORAGE_CONTAINER_NAME = originalEnv;
+    } else {
+      delete process.env.AZURE_STORAGE_CONTAINER_NAME;
+    }
+  }
+});
+
+// Test saveFileToBlob function directly with container parameter
+test("saveFileToBlob should respect container parameter", async (t) => {
+  if (!process.env.AZURE_STORAGE_CONNECTION_STRING) {
+    t.pass("Skipping test - Azure not configured");
+    return;
+  }
+
+  const originalEnv = process.env.AZURE_STORAGE_CONTAINER_NAME;
+  process.env.AZURE_STORAGE_CONTAINER_NAME = "test1,test2,test3";
+
+  try {
+    // Create a test file
+    const testContent = "This is a test for saveFileToBlob with container parameter";
+    const testFile = await createTestFile(testContent, "txt", "save-blob-test.txt");
+    const requestId = uuidv4();
+    const targetContainer = "test3";
+
+    // Call saveFileToBlob directly with container parameter
+    const result = await saveFileToBlob(testFile, requestId, null, targetContainer);
+
+    t.truthy(result);
+    t.truthy(result.url);
+    t.truthy(result.blobName);
+
+    // Verify the URL indicates it was uploaded to the correct container
+    const containerFromUrl = getContainerFromUrl(result.url);
+    t.is(containerFromUrl, targetContainer,
+      `File should be uploaded to container ${targetContainer}, but was uploaded to ${containerFromUrl}`);
+
+    // Cleanup
+    await cleanupHashAndFile(null, result.url, baseUrl);
+  } finally {
+    // Restore environment
+    if (originalEnv) {
+      process.env.AZURE_STORAGE_CONTAINER_NAME = originalEnv;
+    } else {
+      delete process.env.AZURE_STORAGE_CONTAINER_NAME;
+    }
+  }
+});


### PR DESCRIPTION
This pull request updates the file conversion and storage logic to support passing a container name when saving converted files. This change enables more flexible storage handling, especially for cloud environments like Azure Blob Storage. The main updates are to the method signatures and their usage throughout the codebase, with corresponding tests added to verify the new functionality.

**Storage and Conversion Service Enhancements:**

* Updated the `_saveConvertedFile` method signature in `ConversionService.js` and `FileConversionService.js` to accept an optional `containerName` parameter, and ensured this parameter is passed through all relevant calls for saving converted files. [[1]](diffhunk://#diff-f74006a325eef0ca75a69bf2f961402b6d26b1de874f9f3f315fc8b755e1c2aaL305-R308) [[2]](diffhunk://#diff-5d06a365592893add0882ddee6b7acf184eb3dc542f8bdde880c916250fa6a61L36-R42)
* Modified the `ensureConvertedVersion` method in `ConversionService.js` to accept an optional `containerName` parameter, and updated all usages to include this argument. [[1]](diffhunk://#diff-f74006a325eef0ca75a69bf2f961402b6d26b1de874f9f3f315fc8b755e1c2aaR99-R102) [[2]](diffhunk://#diff-6ff3ecd4eb8ffdb22b965a5f17f4eb90ab283861b0c4cd0add840e2dccacc01fR482)
* Updated all calls to `_saveConvertedFile` in `blobHandler.js` and `index.js` to include the new `containerName` parameter, ensuring consistent behavior across the application. [[1]](diffhunk://#diff-8134933a5d9dd5748b0dd91a180ea5f1301273394d04657f3f02be37a65446caR662-R663) [[2]](diffhunk://#diff-8134933a5d9dd5748b0dd91a180ea5f1301273394d04657f3f02be37a65446caR965-R966) [[3]](diffhunk://#diff-6ff3ecd4eb8ffdb22b965a5f17f4eb90ab283861b0c4cd0add840e2dccacc01fR597-R598) [[4]](diffhunk://#diff-6ff3ecd4eb8ffdb22b965a5f17f4eb90ab283861b0c4cd0add840e2dccacc01fR614-R615) [[5]](diffhunk://#diff-f74006a325eef0ca75a69bf2f961402b6d26b1de874f9f3f315fc8b755e1c2aaR162-R163)

**Testing Improvements:**

* Added new tests in `FileConversionService.test.js` to verify that both `_saveConvertedFile` and `ensureConvertedVersion` correctly accept and handle the `containerName` parameter, ensuring robustness of the new functionality.