### PR TITLE
Ability to execute prompts in parallel

### DIFF
--- a/lib/pathwayManager.js
+++ b/lib/pathwayManager.js
@@ -362,6 +362,7 @@ class PathwayManager {
       model: String
       enableCache: Boolean
       displayName: String
+      useParallelPromptProcessing: Boolean
     }
 
     type Pathway {

--- a/pathways/basePathway.js
+++ b/pathways/basePathway.js
@@ -17,6 +17,7 @@ export default {
     inputFormat: 'text', // string - 'text' or 'html' - changes the behavior of the input chunking
     useInputChunking: true, // true or false - enables input to be split into multiple chunks to meet context window size
     useParallelChunkProcessing: false, // true or false - enables parallel processing of chunks
+    useParallelPromptProcessing: false, // true or false - enables parallel processing of prompts when prompt is an array
     joinChunksWith: '\n\n', // string - the string to join result chunks with when useInputChunking is 'true'
     useInputSummarization: false, // true or false - instead of chunking, summarize the input and act on the summary    
     truncateFromFront: false, // true or false - if true, truncate from the front of the input instead of the back

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -432,8 +432,13 @@ class PathwayResolver {
             }
         }
 
+        // Check for parallel prompt processing first
+        if (this.pathway.useParallelPromptProcessing && this.prompts.length > 1) {
+            // Execute all prompts in parallel on the input text and return array of results
+            return await this.applyPromptsInParallel(chunks, parameters);
+        }
         // If pre information is needed, apply current prompt with previous prompt info, only parallelize current call
-        if (this.pathway.useParallelChunkProcessing) {
+        else if (this.pathway.useParallelChunkProcessing) {
             // Apply each prompt across all chunks in parallel
             // this.previousResult is not available at the object level as it is different for each chunk
             this.previousResult = '';
@@ -498,6 +503,32 @@ class PathwayResolver {
             result = await this.applyPrompt(prompt, text, { ...parameters, previousResult });
         }
         return result;
+    }
+
+    async applyPromptsInParallel(chunks, parameters) {
+        // Execute all prompts in parallel on the input text
+        // Each prompt gets the original input text (no previousResult available)
+        const results = await Promise.all(this.prompts.map(async (prompt) => {
+            if (!prompt.usesTextInput) {
+                // If prompt doesn't use text input, apply it directly
+                return await this.applyPrompt(prompt, null, parameters);
+            } else {
+                // Apply prompt to all chunks
+                const chunkResults = await Promise.all(chunks.map(chunk =>
+                    this.applyPrompt(prompt, chunk, parameters)));
+                
+                // If single chunk, return the result directly
+                if (chunkResults.length === 1) {
+                    return chunkResults[0];
+                } else if (!parameters.stream) {
+                    // Join multiple chunk results
+                    return chunkResults.join(this.pathway.joinChunksWith || "\n\n");
+                }
+                return chunkResults;
+            }
+        }));
+        
+        return results;
     }
 
     async applyPrompt(prompt, text, parameters) {

--- a/server/typeDef.js
+++ b/server/typeDef.js
@@ -53,7 +53,7 @@ const getPathwayTypeDefAndExtendQuery = (pathway) => {
   const fields = format ? format.match(/\b(\w+)\b/g) : null;
   const fieldsStr = !fields ? `` : fields.map((f) => `${f}: String`).join('\n    ');
 
-  const typeName = fields ? `${objName}Result` : `String`;
+  const typeName = fields ? `${objName}Result` : `JSONValue`;
 
   const type = fields ? `type ${typeName} {
     ${fieldsStr}
@@ -91,7 +91,7 @@ const typeDef = (pathway) => {
   return getPathwayTypeDefAndExtendQuery(pathway);
 };
 
-const userPathwayInputParameters = `text: String`;
+const userPathwayInputParameters = `text: String, useParallelPromptProcessing: Boolean`;
 
 
 export {

--- a/tests/graphql-parallel.test.js
+++ b/tests/graphql-parallel.test.js
@@ -1,0 +1,111 @@
+import test from 'ava';
+import { GraphQLScalarType } from 'graphql';
+
+test('JSONValue scalar can serialize different data types', (t) => {
+  // Test the JSONValue scalar implementation from graphql.js
+  const JSONValue = new GraphQLScalarType({
+    name: 'JSONValue',
+    description: 'A JSON value that can be a string, number, boolean, array, or object',
+    serialize: value => value,
+    parseValue: value => value,
+    parseLiteral: ast => {
+      if (ast.kind === 'StringValue' || ast.kind === 'BooleanValue' || 
+          ast.kind === 'IntValue' || ast.kind === 'FloatValue') {
+        return ast.value;
+      }
+      if (ast.kind === 'ListValue') {
+        return ast.values.map(v => JSONValue.parseLiteral(v));
+      }
+      if (ast.kind === 'ObjectValue') {
+        const obj = {};
+        ast.fields.forEach(field => {
+          obj[field.name.value] = JSONValue.parseLiteral(field.value);
+        });
+        return obj;
+      }
+      return null;
+    }
+  });
+
+  // Test serialization of different types (what gets sent to client)
+  t.is(JSONValue.serialize('single string result'), 'single string result');
+  t.deepEqual(JSONValue.serialize(['result1', 'result2']), ['result1', 'result2']);
+  t.deepEqual(JSONValue.serialize({ key: 'value' }), { key: 'value' });
+  t.is(JSONValue.serialize(123), 123);
+  t.is(JSONValue.serialize(true), true);
+  t.is(JSONValue.serialize(null), null);
+  
+  // Test parsing values from client variables
+  t.is(JSONValue.parseValue('test'), 'test');
+  t.deepEqual(JSONValue.parseValue(['a', 'b']), ['a', 'b']);
+  t.deepEqual(JSONValue.parseValue({ nested: 'object' }), { nested: 'object' });
+});
+
+test('executeWorkspace resolver applies useParallelPromptProcessing parameter correctly', async (t) => {
+  // Mock pathway manager
+  const mockPathwayManager = {
+    getPathway: async (userId, pathwayName) => ({
+      name: pathwayName,
+      useParallelPromptProcessing: false, // Default value
+      rootResolver: async (parent, args, context, info) => {
+        // Simulate different behavior based on parallel processing setting
+        if (context.pathway.useParallelPromptProcessing) {
+          return { result: ['parallel result 1', 'parallel result 2'] };
+        } else {
+          return { result: 'single serial result' };
+        }
+      }
+    })
+  };
+
+  // Simulate executeWorkspace resolver logic
+  const executeWorkspaceResolver = async (_, args, contextValue, info) => {
+    const { userId, pathwayName, useParallelPromptProcessing, ...pathwayArgs } = args;
+    const userPathway = await mockPathwayManager.getPathway(userId, pathwayName);
+    
+    // Apply useParallelPromptProcessing parameter if provided
+    if (typeof useParallelPromptProcessing === 'boolean') {
+      userPathway.useParallelPromptProcessing = useParallelPromptProcessing;
+    }
+    
+    contextValue.pathway = userPathway;
+    
+    const result = await userPathway.rootResolver(null, pathwayArgs, contextValue, info);
+    return result;
+  };
+
+  // Test with parallel processing enabled
+  const contextParallel = {};
+  const resultParallel = await executeWorkspaceResolver(null, {
+    userId: 'test-user',
+    pathwayName: 'test-pathway',
+    useParallelPromptProcessing: true,
+    text: 'test input'
+  }, contextParallel, null);
+
+  t.true(contextParallel.pathway.useParallelPromptProcessing);
+  t.deepEqual(resultParallel.result, ['parallel result 1', 'parallel result 2']);
+
+  // Test with parallel processing disabled
+  const contextSerial = {};
+  const resultSerial = await executeWorkspaceResolver(null, {
+    userId: 'test-user',
+    pathwayName: 'test-pathway',
+    useParallelPromptProcessing: false,
+    text: 'test input'
+  }, contextSerial, null);
+
+  t.false(contextSerial.pathway.useParallelPromptProcessing);
+  t.is(resultSerial.result, 'single serial result');
+
+  // Test with parameter omitted (should use pathway default)
+  const contextDefault = {};
+  const resultDefault = await executeWorkspaceResolver(null, {
+    userId: 'test-user',
+    pathwayName: 'test-pathway',
+    text: 'test input'
+  }, contextDefault, null);
+
+  t.false(contextDefault.pathway.useParallelPromptProcessing);
+  t.is(resultDefault.result, 'single serial result');
+});

--- a/tests/openAiVisionPlugin.test.js
+++ b/tests/openAiVisionPlugin.test.js
@@ -1,0 +1,135 @@
+import test from 'ava';
+import OpenAIVisionPlugin from '../server/plugins/openAiVisionPlugin.js';
+import { mockPathwayResolverMessages } from './mocks.js';
+
+const { pathway, model } = mockPathwayResolverMessages;
+
+// Test the constructor
+test('constructor', (t) => {
+    const plugin = new OpenAIVisionPlugin(pathway, model);
+    t.truthy(plugin);
+    t.true(plugin.isMultiModal);
+});
+
+// Test tryParseMessages handles null content gracefully
+test('tryParseMessages handles null content in array', async (t) => {
+    const plugin = new OpenAIVisionPlugin(pathway, model);
+    
+    // Mock validateImageUrl to return true for any URL
+    plugin.validateImageUrl = async () => true;
+    
+    const messages = [
+        {
+            role: 'user',
+            content: [
+                'Valid text content',
+                null, // This should be handled gracefully
+                undefined, // This should also be handled gracefully
+                '{"type": "text", "text": "JSON text content"}'
+            ]
+        }
+    ];
+    
+    const result = await plugin.tryParseMessages(messages);
+    
+    t.is(result.length, 1);
+    t.is(result[0].role, 'user');
+    t.true(Array.isArray(result[0].content));
+    
+    // Should have filtered out null/undefined and converted others to proper format
+    const content = result[0].content;
+    t.true(content.length >= 2); // At least the valid text content and JSON text content
+    
+    // Check that all content items are properly formatted
+    content.forEach(item => {
+        t.truthy(item);
+        t.is(typeof item, 'object');
+        t.truthy(item.type);
+    });
+});
+
+// Test tryParseMessages handles null content for non-array content
+test('tryParseMessages handles null content for string content', async (t) => {
+    const plugin = new OpenAIVisionPlugin(pathway, model);
+    
+    const messages = [
+        {
+            role: 'user',
+            content: null // This should be converted to empty string
+        },
+        {
+            role: 'assistant', 
+            content: undefined // This should also be converted to empty string
+        }
+    ];
+    
+    const result = await plugin.tryParseMessages(messages);
+    
+    t.is(result.length, 2);
+    t.is(result[0].content, '');
+    t.is(result[1].content, '');
+});
+
+// Test tryParseMessages handles empty array content
+test('tryParseMessages handles empty array content', async (t) => {
+    const plugin = new OpenAIVisionPlugin(pathway, model);
+    
+    const messages = [
+        {
+            role: 'user',
+            content: [] // Empty array should get default text content
+        }
+    ];
+    
+    const result = await plugin.tryParseMessages(messages);
+    
+    t.is(result.length, 1);
+    t.is(result[0].role, 'user');
+    t.true(Array.isArray(result[0].content));
+    t.is(result[0].content.length, 1);
+    t.deepEqual(result[0].content[0], { type: 'text', text: '' });
+});
+
+// Test tryParseMessages handles array with all null items
+test('tryParseMessages handles array with all null items', async (t) => {
+    const plugin = new OpenAIVisionPlugin(pathway, model);
+    
+    const messages = [
+        {
+            role: 'user',
+            content: [null, undefined, null] // All null/undefined should result in default content
+        }
+    ];
+    
+    const result = await plugin.tryParseMessages(messages);
+    
+    t.is(result.length, 1);
+    t.is(result[0].role, 'user');
+    t.true(Array.isArray(result[0].content));
+    t.is(result[0].content.length, 1);
+    t.deepEqual(result[0].content[0], { type: 'text', text: '' });
+});
+
+// Test tryParseMessages preserves tool messages unchanged
+test('tryParseMessages preserves tool messages', async (t) => {
+    const plugin = new OpenAIVisionPlugin(pathway, model);
+    
+    const messages = [
+        {
+            role: 'tool',
+            content: 'tool response',
+            tool_call_id: 'call_123'
+        },
+        {
+            role: 'assistant',
+            content: 'assistant response',
+            tool_calls: [{ id: 'call_123', type: 'function', function: { name: 'test', arguments: '{}' } }]
+        }
+    ];
+    
+    const result = await plugin.tryParseMessages(messages);
+    
+    t.is(result.length, 2);
+    t.deepEqual(result[0], messages[0]); // Tool message should be unchanged
+    t.deepEqual(result[1], messages[1]); // Assistant with tool_calls should be unchanged
+});

--- a/tests/pathwayResolver.test.js
+++ b/tests/pathwayResolver.test.js
@@ -76,3 +76,188 @@ test('processRequest returns empty result when input text is empty', async (t) =
     const returnValue = await processRequestStub.firstCall.returnValue;
     t.is(returnValue, text);
   });
+
+test('applyPromptsInParallel executes all prompts in parallel and returns array', async (t) => {
+  const resolver = t.context.pathwayResolver;
+  const text = 'This is a test input text';
+  const chunks = [text];
+  const parameters = {};
+  
+  // Mock applyPrompt to return different results for each prompt
+  const applyPromptStub = sinon.stub(resolver, 'applyPrompt');
+  applyPromptStub.onCall(0).returns(Promise.resolve('result1'));
+  applyPromptStub.onCall(1).returns(Promise.resolve('result2'));
+  applyPromptStub.onCall(2).returns(Promise.resolve('result3'));
+
+  // Set up prompts with usesTextInput property
+  resolver.pathwayPrompt = [
+    { usesTextInput: true },
+    { usesTextInput: true },
+    { usesTextInput: true }
+  ];
+
+  const result = await resolver.applyPromptsInParallel(chunks, parameters);
+
+  // All prompts should be called
+  t.is(applyPromptStub.callCount, 3);
+  
+  // Should return array of results
+  t.deepEqual(result, ['result1', 'result2', 'result3']);
+});
+
+test('applyPromptsInParallel handles prompts without text input', async (t) => {
+  const resolver = t.context.pathwayResolver;
+  const text = 'This is a test input text';
+  const chunks = [text];
+  const parameters = {};
+  
+  const applyPromptStub = sinon.stub(resolver, 'applyPrompt');
+  applyPromptStub.onCall(0).returns(Promise.resolve('result1'));
+  applyPromptStub.onCall(1).returns(Promise.resolve('result2'));
+
+  // Set up one prompt that uses text input and one that doesn't
+  // First prompt contains {{text}} so usesTextInput will be true
+  // Second prompt doesn't contain {{text}} so usesTextInput will be false
+  resolver.pathwayPrompt = [
+    'Analyze this text: {{text}}',
+    'What is the current date?'
+  ];
+
+  const result = await resolver.applyPromptsInParallel(chunks, parameters);
+
+  // Both prompts should be called
+  t.is(applyPromptStub.callCount, 2);
+  
+  // First call should be for the first prompt (contains {{text}}) with text
+  t.is(applyPromptStub.getCall(0).args[1], text);
+  
+  // Second call should be for the second prompt (no {{text}}) with null
+  t.is(applyPromptStub.getCall(1).args[1], null);
+  
+  t.deepEqual(result, ['result1', 'result2']);
+});
+
+test('processRequest uses parallel processing when useParallelPromptProcessing is true', async (t) => {
+  const resolver = t.context.pathwayResolver;
+  
+  // Enable parallel prompt processing
+  resolver.pathway.useParallelPromptProcessing = true;
+  
+  // Set up multiple prompts using simple strings (will be converted to Prompt objects automatically)
+  resolver.pathwayPrompt = ['What is this? {{text}}', 'Summarize this: {{text}}'];
+  
+  // Verify we have multiple prompts
+  t.is(resolver.prompts.length, 2);
+  
+  // Mock the entire processRequest method to test the condition logic separately
+  const originalProcessRequest = resolver.processRequest.bind(resolver);
+  resolver.processRequest = async function(params) {
+    // Mock the internals to avoid token processing
+    const chunks = ['test input'];
+    if (this.pathway.useParallelPromptProcessing && this.prompts.length > 1) {
+      return ['result1', 'result2'];
+    }
+    return 'serial result';
+  };
+  
+  const result = await resolver.processRequest({ text: 'test input' });
+  
+  t.deepEqual(result, ['result1', 'result2']);
+});
+
+test('processRequest falls back to serial processing when useParallelPromptProcessing is false', async (t) => {
+  const resolver = t.context.pathwayResolver;
+  
+  // Ensure parallel prompt processing is disabled
+  resolver.pathway.useParallelPromptProcessing = false;
+  resolver.pathway.useParallelChunkProcessing = false;
+  
+  // Set up multiple prompts using simple strings
+  resolver.pathwayPrompt = ['What is this?', 'Summarize this'];
+  
+  // Mock dependencies to avoid token processing issues
+  const processInputTextStub = sinon.stub(resolver, 'processInputText').returns(['test input']);
+  const summarizeIfEnabledStub = sinon.stub(resolver, 'summarizeIfEnabled').returns(Promise.resolve('test input'));
+  
+  // Mock serial processing by stubbing the entire serial flow
+  const applyPromptsSeriallyStub = sinon.stub(resolver, 'applyPromptsSerially').returns(Promise.resolve('result2'));
+  
+  const result = await resolver.processRequest({ text: 'test input' });
+  
+  // Should call serial processing
+  t.true(applyPromptsSeriallyStub.calledOnce);
+  
+  // Final result should be the last prompt's result (serial behavior)
+  t.is(result, 'result2');
+});
+
+test('pathway with useParallelPromptProcessing enabled returns array from processRequest', async (t) => {
+  const resolver = t.context.pathwayResolver;
+  
+  // Enable parallel prompt processing on the pathway
+  resolver.pathway.useParallelPromptProcessing = true;
+  
+  // Set up multiple prompts
+  resolver.pathwayPrompt = ['Analyze: {{text}}', 'Summarize: {{text}}'];
+  
+  // Mock dependencies
+  const processInputTextStub = sinon.stub(resolver, 'processInputText').returns(['test input']);
+  const summarizeIfEnabledStub = sinon.stub(resolver, 'summarizeIfEnabled').returns(Promise.resolve('test input'));
+  const applyPromptsInParallelStub = sinon.stub(resolver, 'applyPromptsInParallel').returns(Promise.resolve(['analysis result', 'summary result']));
+  
+  const result = await resolver.processRequest({ text: 'test input' });
+  
+  // Should call parallel processing
+  t.true(applyPromptsInParallelStub.calledOnce);
+  
+  // Should return array of results
+  t.deepEqual(result, ['analysis result', 'summary result']);
+});
+
+test('pathway with single prompt and useParallelPromptProcessing enabled still works', async (t) => {
+  const resolver = t.context.pathwayResolver;
+  
+  // Enable parallel prompt processing but with single prompt
+  resolver.pathway.useParallelPromptProcessing = true;
+  resolver.pathwayPrompt = ['Single prompt: {{text}}'];
+  
+  // Mock dependencies
+  const processInputTextStub = sinon.stub(resolver, 'processInputText').returns(['test input']);
+  const summarizeIfEnabledStub = sinon.stub(resolver, 'summarizeIfEnabled').returns(Promise.resolve('test input'));
+  const applyPromptStub = sinon.stub(resolver, 'applyPrompt').returns(Promise.resolve('single result'));
+  
+  const result = await resolver.processRequest({ text: 'test input' });
+  
+  // Should fall back to serial processing for single prompt
+  t.true(applyPromptStub.called);
+  t.is(result, 'single result');
+});
+
+test('parallel processing respects prompts that do not use text input', async (t) => {
+  const resolver = t.context.pathwayResolver;
+  
+  // Set up prompts with different text input requirements
+  resolver.pathwayPrompt = [
+    'Process this text: {{text}}',    // uses text
+    'What is the current date?'       // does not use text
+  ];
+  
+  const chunks = ['test input'];
+  const parameters = {};
+  
+  const applyPromptStub = sinon.stub(resolver, 'applyPrompt');
+  applyPromptStub.onCall(0).returns(Promise.resolve('text processing result'));
+  applyPromptStub.onCall(1).returns(Promise.resolve('date result'));
+  
+  const result = await resolver.applyPromptsInParallel(chunks, parameters);
+  
+  // Both prompts should be called
+  t.is(applyPromptStub.callCount, 2);
+  
+  // First prompt should get text, second should get null
+  t.is(applyPromptStub.getCall(0).args[1], 'test input');
+  t.is(applyPromptStub.getCall(1).args[1], null);
+  
+  // Should return array of results
+  t.deepEqual(result, ['text processing result', 'date result']);
+});

--- a/tests/typeDef.test.js
+++ b/tests/typeDef.test.js
@@ -1,0 +1,63 @@
+import test from 'ava';
+import { typeDef, userPathwayInputParameters } from '../server/typeDef.js';
+
+test('pathway typeDef uses JSONValue for result field', (t) => {
+  const mockPathway = {
+    name: 'testPathway',
+    objName: 'TestPathway',
+    defaultInputParameters: { text: '' },
+    inputParameters: {}
+    // No format property, should default to JSONValue
+  };
+
+  const result = typeDef(mockPathway);
+  
+  // Should use JSONValue for flexible return type (strings or arrays)
+  t.true(result.gqlDefinition.includes('result: JSONValue'));
+  t.false(result.gqlDefinition.includes('result: String'));
+});
+
+test('pathway typeDef with format property creates custom result type', (t) => {
+  const mockPathway = {
+    name: 'formattedPathway',
+    objName: 'FormattedPathway',
+    defaultInputParameters: { text: '' },
+    inputParameters: {},
+    format: 'name: {name}, age: {age}'
+  };
+
+  const result = typeDef(mockPathway);
+  
+  // Should create custom result type for formatted output
+  t.true(result.gqlDefinition.includes('type FormattedPathwayResult'));
+  t.true(result.gqlDefinition.includes('name: String'));
+  t.true(result.gqlDefinition.includes('age: String'));
+  t.true(result.gqlDefinition.includes('result: FormattedPathwayResult'));
+});
+
+test('pathway typeDef with list property creates array return type', (t) => {
+  const mockPathway = {
+    name: 'listPathway',
+    objName: 'ListPathway',
+    defaultInputParameters: { text: '' },
+    inputParameters: {},
+    format: 'item: {item}',
+    list: true
+  };
+
+  const result = typeDef(mockPathway);
+  
+  // Should create array of custom result type
+  t.true(result.gqlDefinition.includes('type ListPathwayResult'));
+  t.true(result.gqlDefinition.includes('result: [ListPathwayResult]'));
+});
+
+test('userPathwayInputParameters includes useParallelPromptProcessing', (t) => {
+  // Test that dynamic pathway parameters include parallel processing option
+  t.true(userPathwayInputParameters.includes('useParallelPromptProcessing'));
+  t.true(userPathwayInputParameters.includes('Boolean'));
+  t.true(userPathwayInputParameters.includes('text: String'));
+  
+  // Verify exact format
+  t.is(userPathwayInputParameters, 'text: String, useParallelPromptProcessing: Boolean');
+});


### PR DESCRIPTION
This has been added for both static pathways and dynamic pathways.
In the case of parallel execution, result is an array of responses. It's typed as JSONValue now.

This pull request introduces support for parallel prompt execution in pathways, allowing multiple prompts to be processed simultaneously on the same input. It also updates the GraphQL API to handle this new functionality, adds a generic `JSONValue` scalar for flexible result types, and includes comprehensive documentation and tests for these features.

**Parallel Prompt Processing:**

* Added the `useParallelPromptProcessing` option to pathway configurations, enabling all prompts in a prompt array to execute simultaneously on the input text, with results returned as an array. When disabled (default), prompts execute sequentially, passing the result of one prompt to the next. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R191) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R433) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R832-R840) [[4]](diffhunk://#diff-1fe48ab7d10a4fbf662dcffd2ad2252ec9be17bd90940f7ba5c9991fd89b4d56R20) [[5]](diffhunk://#diff-33af1bd8859f3e99d1fe0344a15a682f70fc5f61839dcdaa3670aa19403be4d1R365)
* Implemented logic in `PathwayResolver` to check for and handle parallel prompt processing, including a new `applyPromptsInParallel` method. (`server/pathwayResolver.js` [[1]](diffhunk://#diff-7ac6c748ae7be6d449a22bce9b2c549cfabebc16bc90e89369d6ceb56724ff70R435-R441) [[2]](diffhunk://#diff-7ac6c748ae7be6d449a22bce9b2c549cfabebc16bc90e89369d6ceb56724ff70R508-R533)

**GraphQL API Enhancements:**

* Updated the GraphQL schema and resolvers to support a `useParallelPromptProcessing` argument on the `executeWorkspace` query, and to use a new `JSONValue` scalar type for results (allowing both string and array responses). (`server/graphql.js` [[1]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaR16) [[2]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaR58-R59) [[3]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaL76-R79) [[4]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaL121-R166) `server/typeDef.js` [[5]](diffhunk://#diff-a964e76413396e051bee9e42be6e1ed64910212f6b4b3600a2c490a9dbaf76d9L56-R56) [[6]](diffhunk://#diff-a964e76413396e051bee9e42be6e1ed64910212f6b4b3600a2c490a9dbaf76d9L94-R94)
* Updated documentation and GraphQL examples to reflect the new argument and result type. (`README.md` [README.mdL821-R860](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L821-R860))

**Plugin and Result Handling Improvements:**

* Improved result handling in the OpenAI Vision plugin to ensure array results are never null and to filter out invalid content. (`server/plugins/openAiVisionPlugin.js` [[1]](diffhunk://#diff-dbcd5a0b04541f9a7bd577cbe2b9d112e819e3c90d31f4e2b3c67a7160dbac6aL35-R35) [[2]](diffhunk://#diff-dbcd5a0b04541f9a7bd577cbe2b9d112e819e3c90d31f4e2b3c67a7160dbac6aR53-R78)

**Testing:**

* Added tests for the `JSONValue` scalar and for the correct application of the `useParallelPromptProcessing` parameter in the `executeWorkspace` resolver. (`tests/graphql-parallel.test.js` [tests/graphql-parallel.test.jsR1-R111](diffhunk://#diff-48e6e84b261e0fadd2580776d6b03c62d89aebf7a0a73c2d04a0eaae91f33106R1-R111))