### PR TITLE
Fix for no type in message case - Autogen

### DIFF
--- a/server/plugins/openAiVisionPlugin.js
+++ b/server/plugins/openAiVisionPlugin.js
@@ -51,8 +51,16 @@ class OpenAIVisionPlugin extends OpenAIChatPlugin {
                                     }
                                     return { type: 'text', text: typeof item === 'string' ? item : JSON.stringify(item) };
                                 }
+                                if (!parsedItem.type) {
+                                    const url = parsedItem.image_url?.url;
+                                    if (url && await this.validateImageUrl(url)) {
+                                        return { type: 'image_url', image_url: { url } };
+                                    }
+                                    const text = (typeof parsedItem.text === 'string') ? parsedItem.text : JSON.stringify(parsedItem);
+                                    return { type: 'text', text };
+                                }
+                                return parsedItem;
                             }
-                            
                             return parsedItem;
                         }))
                     };

--- a/tests/integration/graphql/features/openAi_missing_type.test.js
+++ b/tests/integration/graphql/features/openAi_missing_type.test.js
@@ -1,0 +1,132 @@
+// openaimissingtype.test.js
+import test from 'ava';
+import http from 'http';
+import serverFactory from '../../../../index.js';
+
+let testServer;
+let stub;
+const STUB_PORT = 18081;
+
+test.before(async () => {
+  // Start a stub HTTP server that mimics OpenAI's chat completions endpoint
+  stub = http.createServer((req, res) => {
+    if (req.method === 'POST' && req.url?.startsWith('/v1/chat/completions')) {
+      let body = '';
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', () => {
+        // Conditionally respond based on presence of typed content
+        try {
+          const parsed = JSON.parse(body || '{}');
+          const first = parsed?.messages?.[0]?.content?.[0];
+          const hasType = first && typeof first === 'object' && typeof first.type === 'string';
+
+          if (hasType) {
+            // Return a minimal success payload similar to OpenAI
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              id: 'chatcmpl-stub',
+              choices: [
+                {
+                  index: 0,
+                  message: { role: 'assistant', content: 'stub-ok' },
+                  finish_reason: 'stop'
+                }
+              ],
+              usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+            }));
+          } else {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: { message: "Missing required parameter: 'messages[0].content[0].type'." } }));
+          }
+        } catch (_e) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: { message: 'Bad Request' } }));
+        }
+      });
+    } else {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: { message: 'Not Found' } }));
+    }
+  });
+  await new Promise(resolve => stub.listen(STUB_PORT, resolve));
+
+  // Override models to point oai-gpt41 at the stub server
+  const modelsOverride = {
+    models: {
+      "oai-gpt41": {
+        name: "oai-gpt41",
+        type: "OPENAI-VISION",
+        endpoints: [
+          {
+            name: "stub",
+            url: `http://localhost:${STUB_PORT}/v1/chat/completions`,
+            headers: { "Content-Type": "application/json", "Authorization": "Bearer test" },
+            params: { model: "gpt-4.1" },
+            requestsPerSecond: 100,
+          }
+        ],
+        requestsPerSecond: 100,
+        maxTokenLength: 100000,
+        maxReturnTokens: 8192,
+        supportsStreaming: true
+      }
+    },
+    defaultModelName: 'oai-gpt41'
+  };
+
+  const { server, startServer } = await serverFactory(modelsOverride);
+  startServer && await startServer();
+  testServer = server;
+});
+
+test.after.always('cleanup', async () => {
+  if (testServer) {
+    await testServer.stop();
+  }
+  if (stub) {
+    await new Promise(resolve => stub.close(resolve));
+  }
+});
+
+// This test calls the GraphQL endpoint for the sys_openai_chat_gpt41 pathway
+// and passes message content array items that are JSON strings representing
+// objects WITHOUT the required `type` field. The plugin will parse these into
+// objects but not add a `type` (current bug), then send to our stub which
+// returns the target error.
+test('GraphQL sys_openai_chat_gpt41 normalizes untyped content and succeeds (stubbed)', async (t) => {
+  const query = `
+    query ($messages: [MultiMessage]) {
+      sys_openai_chat_gpt41(messages: $messages) {
+        result
+        errors
+        debug
+      }
+    }
+  `;
+
+  const variables = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          JSON.stringify({ text: "You are in a role play game. Respond with one word." })
+        ]
+      }
+    ]
+  };
+
+  const response = await testServer.executeOperation({ query, variables });
+
+  const data = response?.body?.singleResult?.data;
+  const gqlErrors = response?.body?.singleResult?.errors; // GraphQL-level errors (should be undefined)
+
+  // GraphQL call itself should succeed and pathway should NOT return missing type error
+  t.is(gqlErrors, undefined);
+  t.truthy(data?.sys_openai_chat_gpt41);
+
+  const pathwayErrors = data?.sys_openai_chat_gpt41?.errors || [];
+  const combinedErrors = pathwayErrors.join("\n");
+
+  t.false(combinedErrors.includes('Missing required parameter'));
+  t.is(data?.sys_openai_chat_gpt41?.result, 'stub-ok');
+});

--- a/tests/unit/plugins/openAiVision_normalize_untyped_content.test.js
+++ b/tests/unit/plugins/openAiVision_normalize_untyped_content.test.js
@@ -1,0 +1,51 @@
+import test from 'ava';
+import OpenAIVisionPlugin from '../../../server/plugins/openAiVisionPlugin.js';
+
+// Minimal mock pathway/model
+const mockPathway = { name: 'sys_openai_chat_gpt41', temperature: 0.7 };
+const mockModel = { name: 'oai-gpt41', type: 'OPENAI-VISION' };
+
+// This test reproduces a case where items inside messages[].content[]
+// are objects missing the required `type` field (e.g., { text: '...' } or { image_url: { url } }).
+// The OpenAI Chat Completions API requires content array items to include `type`.
+// Expected behavior: Plugin should normalize these to include `type`.
+// Current behavior: These objects are passed through unmodified, leading to errors like
+// "Missing required parameter: 'messages[N].content[i].type'".
+
+test('normalize untyped content items inside multimodal messages', async (t) => {
+  const plugin = new OpenAIVisionPlugin(mockPathway, mockModel);
+  // Avoid network calls in tests
+  plugin.validateImageUrl = async () => true;
+
+  const messages = [
+    {
+      role: 'user',
+      content: [
+        // Untyped text object -> should become { type: 'text', text: '...' }
+        { text: 'Hello, I am untyped text content' },
+        // Untyped image object -> should become { type: 'image_url', image_url: { url } }
+        { image_url: { url: 'https://example.com/image.jpg' } },
+        // Already typed should remain unchanged
+        { type: 'text', text: 'I am already typed' },
+        // Also verify plain strings are converted to typed text
+        'Plain string should become typed text'
+      ]
+    }
+  ];
+
+  const parsed = await plugin.tryParseMessages(messages);
+  const content = parsed[0].content;
+
+  // Assertions for expected normalized shapes
+  t.is(content[0].type, 'text');
+  t.is(content[0].text, 'Hello, I am untyped text content');
+
+  t.is(content[1].type, 'image_url');
+  t.is(content[1].image_url.url, 'https://example.com/image.jpg');
+
+  t.is(content[2].type, 'text');
+  t.is(content[2].text, 'I am already typed');
+
+  t.is(content[3].type, 'text');
+  t.is(content[3].text, 'Plain string should become typed text');
+});


### PR DESCRIPTION
This pull request addresses a bug where multimodal message content items without a required `type` field were not being normalized, causing errors in requests to the OpenAI Vision API. The main change ensures that such items are properly converted to the expected format before sending. The update is covered by new unit and integration tests to verify correct normalization and error handling.

**Bug fix: Content normalization in OpenAI Vision plugin**
- Updated `OpenAIVisionPlugin` to normalize content items inside message arrays that are missing the `type` field, converting them to the correct structure expected by the OpenAI API (e.g., untyped text becomes `{ type: 'text', text: ... }`, and valid image URLs become `{ type: 'image_url', image_url: { url } }`).

**Testing improvements**
- Added a unit test (`openAiVision_normalize_untyped_content.test.js`) to verify that the plugin correctly normalizes untyped content items in multimodal messages.
- Added an integration test (`openAi_missing_type.test.js`) using a stubbed OpenAI endpoint to ensure the GraphQL pathway (`sys_openai_chat_gpt41`) normalizes untyped content and avoids missing type errors.