### PR TITLE
Publish files with workspace

### DIFF
--- a/lib/pathwayManager.js
+++ b/lib/pathwayManager.js
@@ -338,36 +338,58 @@ class PathwayManager {
 
   /**
    * Creates a Prompt object from a prompt item and system prompt.
-   * @param {(string|Object)} promptItem - The prompt item (string or {name, prompt} object).
+   * @param {(string|Object)} promptItem - The prompt item (string or {name, prompt, files} object).
    * @param {string} systemPrompt - The system prompt to prepend.
    * @param {string} [defaultName] - Default name to use if promptItem is a string or if the object doesn't have a name.
    * @returns {Prompt} A new Prompt object.
    */
   _createPromptObject(promptItem, systemPrompt, defaultName = null) {
-    // Handle both old format (strings) and new format (objects with name and prompt)
+    // Handle both old format (strings) and new format (objects with name, prompt, and files)
     const promptText = typeof promptItem === 'string' ? promptItem : promptItem.prompt;
     const promptName = typeof promptItem === 'string' ? defaultName : (promptItem.name || defaultName);
+    const promptFiles = typeof promptItem === 'string' ? [] : (promptItem.files || []);
+    const cortexPathwayName = typeof promptItem === 'string' ? null : (promptItem.cortexPathwayName || null);
     
-    const messages = [
-      // Add the original prompt as a user message
-      { "role": "user", "content": `{{text}}\n\n${promptText}` },
-    ];
+    const messages = [];
 
     // Only include system message if systemPrompt has content
     if (systemPrompt && systemPrompt.trim() !== "") {
       messages.unshift({ "role": "system", "content": systemPrompt });
     }
 
-    return new Prompt({
+    // If there are files, include chatHistory to get the file content, then add user message
+    if (promptFiles.length > 0) {
+      // Add chatHistory which will contain the resolved file content
+      messages.push("{{chatHistory}}");
+      // Add the user text and prompt as a separate user message
+      messages.push({ "role": "user", "content": `{{text}}\n\n${promptText}` });
+    } else {
+      // No files, just add the user message with text and prompt
+      messages.push({ "role": "user", "content": `{{text}}\n\n${promptText}` });
+    }
+
+    const prompt = new Prompt({
       name: promptName,
       messages: messages
     });
+
+    // Store file hashes for later resolution
+    if (promptFiles.length > 0) {
+      prompt.fileHashes = promptFiles;
+    }
+
+    // Preserve cortexPathwayName if present
+    if (cortexPathwayName) {
+      prompt.cortexPathwayName = cortexPathwayName;
+    }
+
+    return prompt;
   }
 
   /**
    * Transforms the prompts in a pathway to include the system prompt.
    * @param {Object} pathway - The pathway object to transform.
-   * @param {(string[]|Object[])} pathway.prompt - Array of user prompts (strings) or prompt objects with {name, prompt} properties.
+   * @param {(string[]|Object[])} pathway.prompt - Array of user prompts (strings) or prompt objects with {name, prompt, files} properties.
    * @param {string} pathway.systemPrompt - The system prompt to prepend to each user prompt.
    * @returns {Object} A new pathway object with transformed prompts.
    */
@@ -378,6 +400,16 @@ class PathwayManager {
 
     // Transform each prompt in the array
     newPathway.prompt = prompt.map(p => this._createPromptObject(p, systemPrompt));
+
+    // Collect all file hashes from all prompts
+    const allFileHashes = newPathway.prompt
+      .filter(p => p.fileHashes && p.fileHashes.length > 0)
+      .flatMap(p => p.fileHashes);
+
+    // Store file hashes at pathway level for later resolution
+    if (allFileHashes.length > 0) {
+      newPathway.fileHashes = [...new Set(allFileHashes)]; // Remove duplicates
+    }
 
     return newPathway;
   }
@@ -426,6 +458,8 @@ class PathwayManager {
     input PromptInput {
       name: String!
       prompt: String!
+      files: [String!]
+      cortexPathwayName: String
     }
     
     input PathwayInput {

--- a/lib/util.js
+++ b/lib/util.js
@@ -412,6 +412,61 @@ function getAvailableFiles(chatHistory) {
     return availableFiles;
 }
 
+/**
+ * Convert file hashes to content format suitable for LLM processing
+ * @param {Array<string>} fileHashes - Array of file hashes to resolve
+ * @param {Object} config - Configuration object with file service endpoints
+ * @returns {Promise<Array<string>>} Array of stringified file content objects
+ */
+async function resolveFileHashesToContent(fileHashes, config) {
+    if (!fileHashes || fileHashes.length === 0) return [];
+
+    const fileContentPromises = fileHashes.map(async (hash) => {
+        try {
+            // Use the existing file handler (cortex-file-handler) to resolve file hashes
+            const fileHandlerUrl = config?.get?.('whisperMediaApiUrl');
+            
+            if (fileHandlerUrl && fileHandlerUrl !== 'null') {
+                // Make request to file handler to get file content by hash
+                const response = await axios.get(fileHandlerUrl, { 
+                    params: { hash: hash, checkHash: true } 
+                });
+                if (response.status === 200) {
+                    const fileData = response.data;
+                    const fileUrl = fileData.shortLivedUrl || fileData.url;
+                    const convertedUrl = fileData.converted?.url;
+                    const convertedGcsUrl = fileData.converted?.gcs;
+                    
+                    return JSON.stringify({
+                        type: "image_url",
+                        url: convertedUrl,
+                        image_url: { url: convertedUrl },
+                        gcs: convertedGcsUrl || fileData.gcs, // Add GCS URL for Gemini models
+                        originalFilename: fileData.filename,
+                        hash: hash
+                    });
+                }
+            }
+            
+            // Fallback: create a placeholder that indicates file resolution is needed
+            return JSON.stringify({
+                type: "file_hash",
+                hash: hash,
+                _cortex_needs_resolution: true
+            });
+        } catch (error) {
+            // Return error indicator
+            return JSON.stringify({
+                type: "file_error",
+                hash: hash,
+                error: error.message
+            });
+        }
+    });
+
+    return Promise.all(fileContentPromises);
+}
+
 export { 
     getUniqueId,
     getSearchResultId,
@@ -426,5 +481,6 @@ export {
     getMediaChunks,
     markCompletedForCleanUp,
     removeOldImageAndFileContent,
-    getAvailableFiles
+    getAvailableFiles,
+    resolveFileHashesToContent
 };

--- a/pathways/system/workspaces/run_workspace_prompt.js
+++ b/pathways/system/workspaces/run_workspace_prompt.js
@@ -79,9 +79,6 @@ export default {
         try {
             let currentMessages = JSON.parse(JSON.stringify(args.chatHistory));
 
-            console.log("currentMessages", currentMessages);
-            console.log("args", args);
-
             let response = await runAllPrompts({
                 ...args,
                 chatHistory: currentMessages,

--- a/tests/unit/core/parser.test.js
+++ b/tests/unit/core/parser.test.js
@@ -90,7 +90,6 @@ test('parseJson should attempt to repair invalid JSON', async t => {
     
     const result = await parser.parseJson(invalidJson);
     
-    console.log('parseJson result:', result);  // For debugging
     
     t.not(result, null);
     

--- a/tests/unit/core/pathwayManagerWithFiles.test.js
+++ b/tests/unit/core/pathwayManagerWithFiles.test.js
@@ -1,0 +1,230 @@
+import test from 'ava';
+import PathwayManager from '../../../lib/pathwayManager.js';
+
+// Mock config for PathwayManager
+const mockConfig = {
+    storageType: 'local',
+    filePath: './test-pathways.json',
+    publishKey: 'test-key'
+};
+
+// Mock base pathway
+const mockBasePathway = {
+    name: 'base',
+    prompt: '{{text}}',
+    systemPrompt: '',
+    inputParameters: {},
+    typeDef: 'type Test { test: String }',
+    rootResolver: () => {},
+    resolver: () => {}
+};
+
+// Mock storage strategy
+class MockStorageStrategy {
+    async load() {
+        return {};
+    }
+    
+    async save(data) {
+        // Do nothing
+    }
+    
+    async getLastModified() {
+        return Date.now();
+    }
+}
+
+test('pathwayManager handles prompt format with files correctly', async t => {
+    const pathwayManager = new PathwayManager(mockConfig, mockBasePathway);
+    
+    // Replace storage with mock
+    pathwayManager.storage = new MockStorageStrategy();
+    
+    // Test prompts with files
+    const pathwayWithFiles = {
+        prompt: [
+            {
+                name: 'Analyze Document',
+                prompt: 'Please analyze the provided document',
+                files: ['abc123def456', 'def456ghi789']
+            },
+            {
+                name: 'Summarize Text',
+                prompt: 'Please summarize the text',
+                files: []
+            },
+            {
+                name: 'Simple Task',
+                prompt: 'Perform a simple task'
+                // No files property
+            }
+        ],
+        systemPrompt: 'You are a helpful assistant'
+    };
+    
+    // Test transformPrompts method
+    const transformedPathway = await pathwayManager.transformPrompts(pathwayWithFiles);
+    
+    // Verify the transformed pathway structure
+    t.truthy(transformedPathway);
+    t.true(Array.isArray(transformedPathway.prompt));
+    t.is(transformedPathway.prompt.length, 3);
+    
+    // Verify first prompt with files
+    const firstPrompt = transformedPathway.prompt[0];
+    t.is(firstPrompt.name, 'Analyze Document');
+    t.truthy(firstPrompt.fileHashes);
+    t.deepEqual(firstPrompt.fileHashes, ['abc123def456', 'def456ghi789']);
+    
+    // Verify second prompt with empty files
+    const secondPrompt = transformedPathway.prompt[1];
+    t.is(secondPrompt.name, 'Summarize Text');
+    t.falsy(secondPrompt.fileHashes); // Empty array results in no fileHashes property
+    
+    // Verify third prompt without files property
+    const thirdPrompt = transformedPathway.prompt[2];
+    t.is(thirdPrompt.name, 'Simple Task');
+    t.falsy(thirdPrompt.fileHashes);
+    
+    // Verify pathway-level file hashes collection
+    t.truthy(transformedPathway.fileHashes);
+    t.deepEqual(transformedPathway.fileHashes, ['abc123def456', 'def456ghi789']);
+});
+
+test('pathwayManager handles legacy string prompts correctly', async t => {
+    const pathwayManager = new PathwayManager(mockConfig, mockBasePathway);
+    
+    // Replace storage with mock
+    pathwayManager.storage = new MockStorageStrategy();
+    
+    // Test legacy string prompts
+    const legacyPathway = {
+        prompt: [
+            'Please analyze the data',
+            'Summarize the findings'
+        ],
+        systemPrompt: 'You are a helpful assistant'
+    };
+    
+    // Test transformPrompts method
+    const transformedPathway = await pathwayManager.transformPrompts(legacyPathway);
+    
+    // Verify the transformed pathway structure
+    t.truthy(transformedPathway);
+    t.true(Array.isArray(transformedPathway.prompt));
+    t.is(transformedPathway.prompt.length, 2);
+    
+    // Verify prompts don't have file hashes
+    transformedPathway.prompt.forEach(prompt => {
+        t.falsy(prompt.fileHashes);
+    });
+    
+    // Verify no pathway-level file hashes
+    t.falsy(transformedPathway.fileHashes);
+});
+
+test('pathwayManager removes duplicate file hashes at pathway level', async t => {
+    const pathwayManager = new PathwayManager(mockConfig, mockBasePathway);
+    
+    // Replace storage with mock
+    pathwayManager.storage = new MockStorageStrategy();
+    
+    // Test prompts with duplicate file hashes
+    const pathwayWithDuplicateFiles = {
+        prompt: [
+            {
+                name: 'First Task',
+                prompt: 'Analyze document 1',
+                files: ['abc123def456', 'def456ghi789']
+            },
+            {
+                name: 'Second Task', 
+                prompt: 'Analyze document 2',
+                files: ['abc123def456', 'ghi789jkl012'] // abc123def456 is duplicate
+            }
+        ],
+        systemPrompt: 'You are a helpful assistant'
+    };
+    
+    // Test transformPrompts method
+    const transformedPathway = await pathwayManager.transformPrompts(pathwayWithDuplicateFiles);
+    
+    // Verify pathway-level file hashes are deduplicated
+    t.truthy(transformedPathway.fileHashes);
+    t.deepEqual(transformedPathway.fileHashes, ['abc123def456', 'def456ghi789', 'ghi789jkl012']);
+    t.is(transformedPathway.fileHashes.length, 3); // Should not have duplicates
+});
+
+test('pathwayManager handles null and undefined files gracefully', async t => {
+    const pathwayManager = new PathwayManager(mockConfig, mockBasePathway);
+    
+    // Replace storage with mock
+    pathwayManager.storage = new MockStorageStrategy();
+    
+    // Test prompts with null/undefined files
+    const pathwayWithNullFiles = {
+        prompt: [
+            {
+                name: 'Task with null files',
+                prompt: 'Do something', 
+                files: null
+            },
+            {
+                name: 'Task with undefined files',
+                prompt: 'Do something else'
+                // files property is undefined
+            }
+        ],
+        systemPrompt: 'You are a helpful assistant'
+    };
+    
+    // Test transformPrompts method
+    const transformedPathway = await pathwayManager.transformPrompts(pathwayWithNullFiles);
+    
+    // Verify the transformation handles null/undefined gracefully
+    t.truthy(transformedPathway);
+    t.true(Array.isArray(transformedPathway.prompt));
+    
+    // Both prompts should have empty or undefined fileHashes
+    transformedPathway.prompt.forEach(prompt => {
+        t.true(!prompt.fileHashes || prompt.fileHashes.length === 0);
+    });
+    
+    // No pathway-level file hashes should be set
+    t.falsy(transformedPathway.fileHashes);
+});
+
+test('pathwayManager _createPromptObject handles files correctly', t => {
+    const pathwayManager = new PathwayManager(mockConfig, mockBasePathway);
+    
+    // Test with object prompt containing files
+    const promptWithFiles = {
+        name: 'Test Prompt',
+        prompt: 'Analyze this document',
+        files: ['file1hash', 'file2hash']
+    };
+    
+    const createdPrompt = pathwayManager._createPromptObject(promptWithFiles, 'System prompt');
+    
+    t.is(createdPrompt.name, 'Test Prompt');
+    t.truthy(createdPrompt.fileHashes);
+    t.deepEqual(createdPrompt.fileHashes, ['file1hash', 'file2hash']);
+    
+    // Test with string prompt (no files)
+    const stringPrompt = 'Simple text prompt';
+    const createdStringPrompt = pathwayManager._createPromptObject(stringPrompt, 'System prompt', 'Default Name');
+    
+    t.is(createdStringPrompt.name, 'Default Name');
+    t.falsy(createdStringPrompt.fileHashes);
+    
+    // Test with object prompt without files
+    const promptWithoutFiles = {
+        name: 'No Files Prompt',
+        prompt: 'Simple task'
+    };
+    
+    const createdPromptNoFiles = pathwayManager._createPromptObject(promptWithoutFiles, 'System prompt');
+    
+    t.is(createdPromptNoFiles.name, 'No Files Prompt');
+    t.falsy(createdPromptNoFiles.fileHashes);
+});

--- a/tests/unit/graphql_executeWorkspace_transformation.test.js
+++ b/tests/unit/graphql_executeWorkspace_transformation.test.js
@@ -1,0 +1,218 @@
+import test from 'ava';
+
+// Test the transformation logic directly without mocking
+test('should format cortex pathway arguments correctly with existing chatHistory', (t) => {
+    // Mock the original prompt
+    const originalPrompt = {
+        name: 'summarize',
+        prompt: 'summarize this file',
+        cortexPathwayName: 'run_labeeb_agent'
+    };
+    
+    // Mock pathway data
+    const pathway = {
+        model: 'labeeb-agent',
+        systemPrompt: 'Test system prompt'
+    };
+    
+    // Mock incoming pathway args
+    const pathwayArgs = {
+        text: 'summarize the file',
+        chatHistory: [
+            {
+                role: 'user',
+                content: [
+                    '{"type":"image_url","url":"test-url","image_url":{"url":"test-url"},"gcs":"test-gcs","originalFilename":"test.jpg","hash":"test-hash"}'
+                ]
+            }
+        ]
+    };
+    
+    // Simulate the transformation logic from the executePathwayWithFallback function
+    const cortexArgs = {
+        model: pathway.model || pathwayArgs.model || "labeeb-agent",
+        chatHistory: [],
+        systemPrompt: pathway.systemPrompt
+    };
+    
+    // If we have existing chatHistory, use it as base
+    if (pathwayArgs.chatHistory && pathwayArgs.chatHistory.length > 0) {
+        cortexArgs.chatHistory = JSON.parse(JSON.stringify(pathwayArgs.chatHistory));
+    }
+    
+    // If we have text parameter, we need to add it to the chatHistory
+    if (pathwayArgs.text) {
+        // Find the last user message or create a new one
+        let lastUserMessage = null;
+        for (let i = cortexArgs.chatHistory.length - 1; i >= 0; i--) {
+            if (cortexArgs.chatHistory[i].role === 'user') {
+                lastUserMessage = cortexArgs.chatHistory[i];
+                break;
+            }
+        }
+        
+        if (lastUserMessage) {
+            // Ensure content is an array
+            if (!Array.isArray(lastUserMessage.content)) {
+                lastUserMessage.content = [JSON.stringify({
+                    type: "text",
+                    text: lastUserMessage.content || ""
+                })];
+            }
+            
+            // Add the text parameter as a text content item
+            const textFromPrompt = originalPrompt?.prompt || pathwayArgs.text;
+            lastUserMessage.content.unshift(JSON.stringify({
+                type: "text",
+                text: `${pathwayArgs.text}\n\n${textFromPrompt}`
+            }));
+        } else {
+            // Create new user message with text
+            const textFromPrompt = originalPrompt?.prompt || pathwayArgs.text;
+            cortexArgs.chatHistory.push({
+                role: 'user',
+                content: [JSON.stringify({
+                    type: "text",
+                    text: `${pathwayArgs.text}\n\n${textFromPrompt}`
+                })]
+            });
+        }
+    }
+    
+    // Verify the transformation
+    t.is(cortexArgs.model, 'labeeb-agent');
+    t.is(cortexArgs.systemPrompt, 'Test system prompt');
+    t.is(cortexArgs.chatHistory.length, 1);
+    
+    // Check that the user message has the correct structure
+    const userMessage = cortexArgs.chatHistory[0];
+    t.is(userMessage.role, 'user');
+    t.true(Array.isArray(userMessage.content));
+    t.is(userMessage.content.length, 2);
+    
+    // Check the text content was added first
+    const textContent = JSON.parse(userMessage.content[0]);
+    t.is(textContent.type, 'text');
+    t.is(textContent.text, 'summarize the file\n\nsummarize this file');
+    
+    // Check the image content is preserved second
+    const imageContent = JSON.parse(userMessage.content[1]);
+    t.is(imageContent.type, 'image_url');
+    t.is(imageContent.gcs, 'test-gcs');
+});
+
+test('should create new user message when no existing chatHistory', (t) => {
+    // Mock the original prompt
+    const originalPrompt = {
+        name: 'summarize',
+        prompt: 'summarize this file',
+        cortexPathwayName: 'run_labeeb_agent'
+    };
+    
+    // Mock pathway data
+    const pathway = {
+        model: 'labeeb-agent',
+        systemPrompt: 'Test system prompt'
+    };
+    
+    // Mock incoming pathway args with no chatHistory
+    const pathwayArgs = {
+        text: 'summarize the file'
+    };
+    
+    // Simulate the transformation logic from the executePathwayWithFallback function
+    const cortexArgs = {
+        model: pathway.model || pathwayArgs.model || "labeeb-agent",
+        chatHistory: [],
+        systemPrompt: pathway.systemPrompt
+    };
+    
+    // If we have existing chatHistory, use it as base
+    if (pathwayArgs.chatHistory && pathwayArgs.chatHistory.length > 0) {
+        cortexArgs.chatHistory = JSON.parse(JSON.stringify(pathwayArgs.chatHistory));
+    }
+    
+    // If we have text parameter, we need to add it to the chatHistory
+    if (pathwayArgs.text) {
+        // Find the last user message or create a new one
+        let lastUserMessage = null;
+        for (let i = cortexArgs.chatHistory.length - 1; i >= 0; i--) {
+            if (cortexArgs.chatHistory[i].role === 'user') {
+                lastUserMessage = cortexArgs.chatHistory[i];
+                break;
+            }
+        }
+        
+        if (lastUserMessage) {
+            // Ensure content is an array
+            if (!Array.isArray(lastUserMessage.content)) {
+                lastUserMessage.content = [JSON.stringify({
+                    type: "text",
+                    text: lastUserMessage.content || ""
+                })];
+            }
+            
+            // Add the text parameter as a text content item
+            const textFromPrompt = originalPrompt?.prompt || pathwayArgs.text;
+            lastUserMessage.content.unshift(JSON.stringify({
+                type: "text",
+                text: `${pathwayArgs.text}\n\n${textFromPrompt}`
+            }));
+        } else {
+            // Create new user message with text
+            const textFromPrompt = originalPrompt?.prompt || pathwayArgs.text;
+            cortexArgs.chatHistory.push({
+                role: 'user',
+                content: [JSON.stringify({
+                    type: "text",
+                    text: `${pathwayArgs.text}\n\n${textFromPrompt}`
+                })]
+            });
+        }
+    }
+    
+    // Verify the transformation
+    t.is(cortexArgs.model, 'labeeb-agent');
+    t.is(cortexArgs.systemPrompt, 'Test system prompt');
+    t.is(cortexArgs.chatHistory.length, 1);
+    
+    // Check that a new user message was created
+    const userMessage = cortexArgs.chatHistory[0];
+    t.is(userMessage.role, 'user');
+    t.true(Array.isArray(userMessage.content));
+    t.is(userMessage.content.length, 1);
+    
+    // Check the text content
+    const textContent = JSON.parse(userMessage.content[0]);
+    t.is(textContent.type, 'text');
+    t.is(textContent.text, 'summarize the file\n\nsummarize this file');
+});
+
+test('should use default model when pathway model is not specified', (t) => {
+    // Mock the original prompt
+    const originalPrompt = {
+        name: 'summarize',
+        prompt: 'summarize this file',
+        cortexPathwayName: 'run_labeeb_agent'
+    };
+    
+    // Mock pathway data without model
+    const pathway = {
+        systemPrompt: 'Test system prompt'
+    };
+    
+    // Mock incoming pathway args
+    const pathwayArgs = {
+        text: 'summarize the file'
+    };
+    
+    // Simulate the transformation logic
+    const cortexArgs = {
+        model: pathway.model || pathwayArgs.model || "labeeb-agent",
+        chatHistory: [],
+        systemPrompt: pathway.systemPrompt
+    };
+    
+    // Verify default model is used
+    t.is(cortexArgs.model, 'labeeb-agent');
+});


### PR DESCRIPTION
This pull request introduces support for attaching file references to prompts within pathways, enabling file content to be dynamically resolved and included in LLM processing. It also adds support for specifying a `cortexPathwayName` for prompts, allowing for dynamic routing to Cortex pathways. The changes include modifications to the pathway and prompt data structures, file resolution utilities, and GraphQL resolver logic to handle these new features.

**Enhancements to prompt and pathway structure:**

* Extended the prompt object format to support `files` (an array of file hashes) and `cortexPathwayName`, and updated the `_createPromptObject` method in `PathwayManager` to handle these fields. Prompts with files now include a `{{chatHistory}}` placeholder and store file hashes for later resolution.
* Updated the pathway transformation logic to collect all unique file hashes from prompts and store them at the pathway level for batch resolution.
* Updated the GraphQL input types to include `files` and `cortexPathwayName` fields for prompts.

**File resolution and LLM integration:**

* Added a utility function `resolveFileHashesToContent` in `lib/util.js` to resolve file hashes to content objects suitable for LLM input, including support for image URLs and error handling. [[1]](diffhunk://#diff-3fb720f70ea34fb2975fd6c38ac4b6b6131373be2abfa4760dfaae8a25daaee2R415-R469) [[2]](diffhunk://#diff-3fb720f70ea34fb2975fd6c38ac4b6b6131373be2abfa4760dfaae8a25daaee2L429-R485)
* Updated the GraphQL resolver logic to:
  - Resolve and inject file content into the chat history before executing pathways.
  - Support execution of prompts with `cortexPathwayName` by routing them to Cortex pathways and constructing chat history accordingly.
  - Apply these changes for both single and multi-prompt (parallel) pathway executions. [[1]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaR28) [[2]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaR134-R267) [[3]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaR314-L195) [[4]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaR362-L241) [[5]](diffhunk://#diff-a8ebf15b54106a1938838c088b2dfc4f6a0434e5f6b1f438603e848e7ae49aeaL269-R422)

**Minor cleanups:**

* Removed unnecessary debug logging from `run_workspace_prompt.js` and test files. [[1]](diffhunk://#diff-bd30169099b251595d7ebcf272e3326177dfce400a29166594dfc429d086b55fL82-L84) [[2]](diffhunk://#diff-527db78d1ec3f4f0355efda28cb4527dae9ae1f8fd17a990d7a74174a60ae069L93)