### PR TITLE
Port model adapter updates from aj-cortex

### DIFF
--- a/server/plugins/claude3VertexPlugin.js
+++ b/server/plugins/claude3VertexPlugin.js
@@ -1,10 +1,146 @@
 import OpenAIVisionPlugin from "./openAiVisionPlugin.js";
 import logger from "../../lib/logger.js";
-import { requestState } from '../requestState.js';
-import { addCitationsToResolver } from '../../lib/pathwayTools.js';
-import CortexResponse from '../../lib/cortexResponse.js';
-import axios from 'axios';
+import { requestState } from "../requestState.js";
+import { addCitationsToResolver } from "../../lib/pathwayTools.js";
+import CortexResponse from "../../lib/cortexResponse.js";
+import axios from "axios";
 import { sanitizeBase64 } from "../../lib/util.js";
+
+const SYNTHETIC_TOOL_RESULT_TEXT =
+  "Tool execution was interrupted or did not return a result. Continuing without tool output.";
+
+const normalizeContentArray = (content) => {
+  if (Array.isArray(content)) return content.slice();
+  if (content == null) return [];
+  return [content];
+};
+
+const isToolUse = (item) =>
+  item && typeof item === "object" && item.type === "tool_use";
+const isToolResult = (item) =>
+  item && typeof item === "object" && item.type === "tool_result";
+
+const sanitizeToolUseSequences = (messages) => {
+  const sanitized = [];
+  let syntheticCounter = 0;
+
+  const makeId = () => `tool_${Date.now()}_${syntheticCounter++}`;
+  const makeSyntheticResult = (toolUse) => ({
+    type: "tool_result",
+    tool_use_id: toolUse.id,
+    content: [{ type: "text", text: SYNTHETIC_TOOL_RESULT_TEXT }],
+  });
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = { ...messages[i] };
+    message.content = normalizeContentArray(message.content);
+
+    if (message.role === "assistant") {
+      const toolUses = message.content.filter(isToolUse);
+      toolUses.forEach((toolUse) => {
+        if (!toolUse.id) {
+          toolUse.id = makeId();
+          logger.warn(`Tool use missing id; generated ${toolUse.id}.`);
+        }
+      });
+
+      sanitized.push(message);
+
+      if (toolUses.length > 0) {
+        const next = messages[i + 1];
+        if (!next || next.role !== "user") {
+          logger.warn(
+            "Tool use missing immediate tool_result; inserting synthetic tool_result message.",
+          );
+          sanitized.push({
+            role: "user",
+            content: toolUses.map((toolUse) => makeSyntheticResult(toolUse)),
+          });
+          continue;
+        } else {
+          const nextContent = normalizeContentArray(next.content);
+          const validIds = new Set(toolUses.map((toolUse) => toolUse.id));
+          const existingIds = new Set();
+          const toolResultContent = [];
+          const preservedContent = [];
+
+          nextContent.forEach((item) => {
+            if (isToolResult(item)) {
+              if (validIds.has(item.tool_use_id)) {
+                toolResultContent.push(item);
+                existingIds.add(item.tool_use_id);
+              } else {
+                logger.warn(
+                  `Orphaned tool_result found for id ${item.tool_use_id || "unknown"}; removing from tool response payload.`,
+                );
+              }
+              return;
+            }
+            preservedContent.push(item);
+          });
+
+          const syntheticToolResults = [];
+          toolUses.forEach((toolUse) => {
+            if (!existingIds.has(toolUse.id)) {
+              logger.warn(
+                `Tool result missing for ${toolUse.id}; inserting synthetic tool_result.`,
+              );
+              syntheticToolResults.push(makeSyntheticResult(toolUse));
+            }
+          });
+
+          sanitized.push({
+            ...next,
+            role: "user",
+            content: [...syntheticToolResults, ...toolResultContent],
+          });
+          if (preservedContent.length > 0) {
+            logger.warn(
+              `Preserving ${preservedContent.length} non-tool_result item(s) from immediate user message after tool_use.`,
+            );
+            sanitized.push({
+              role: "user",
+              content: preservedContent,
+            });
+          }
+          i += 1;
+        }
+      }
+      continue;
+    }
+
+    if (message.role === "user") {
+      const prev = sanitized[sanitized.length - 1];
+      const validIds = new Set();
+
+      if (prev?.role === "assistant") {
+        const prevContent = normalizeContentArray(prev.content);
+        prevContent.forEach((item) => {
+          if (isToolUse(item)) validIds.add(item.id);
+        });
+      }
+
+      if (validIds.size === 0) {
+        message.content = message.content.map((item) => {
+          if (isToolResult(item)) {
+            logger.warn(
+              "Orphaned tool_result without preceding tool_use; converting to text.",
+            );
+            return {
+              type: "text",
+              text: `[orphaned tool_result ${item.tool_use_id || "unknown"} removed]`,
+            };
+          }
+          return item;
+        });
+      }
+    }
+
+    sanitized.push(message);
+  }
+
+  return sanitized;
+};
 
 async function convertContentItem(item, maxImageSize, plugin) {
   let imageUrl = "";
@@ -24,44 +160,64 @@ async function convertContentItem(item, maxImageSize, plugin) {
               type: "tool_use",
               id: item.id,
               name: item.name,
-              input: typeof item.input === 'string' ? { query: item.input } : item.input
+              input:
+                typeof item.input === "string"
+                  ? { query: item.input }
+                  : item.input,
             };
 
           case "tool_result":
             return {
               type: "tool_result",
               tool_use_id: item.tool_use_id,
-              content: item.content
+              content: item.content,
             };
+
+          // Pass through server-side tool blocks unchanged
+          case "server_tool_use":
+            return item;
+
+          case "web_search_tool_result":
+            return item;
 
           case "image_url":
             imageUrl = item.url || item.image_url?.url || item.image_url;
 
             if (!imageUrl) {
-              logger.warn("Could not parse image URL from content - skipping image content.");
+              logger.warn(
+                "Could not parse image URL from content - skipping image content.",
+              );
               return null;
             }
 
             try {
               // First validate the image URL
-              if (!await plugin.validateImageUrl(imageUrl)) {
+              if (!(await plugin.validateImageUrl(imageUrl))) {
                 return null;
               }
 
               // Then fetch and convert to base64 if needed
-              const urlData = imageUrl.startsWith("data:") ? imageUrl : await fetchImageAsDataURL(imageUrl);
-              if (!urlData) { return null; }
-              
-              const base64Image = urlData.split(",")[1];
-              // Calculate actual decoded size of base64 data
-              const base64Size = Buffer.from(base64Image, 'base64').length;
-              
-              if (base64Size > maxImageSize) {
-                logger.warn(`Image size ${base64Size} bytes exceeds maximum allowed size ${maxImageSize} - skipping image content.`);
+              const urlData = imageUrl.startsWith("data:")
+                ? imageUrl
+                : await fetchImageAsDataURL(imageUrl);
+              if (!urlData) {
                 return null;
               }
-              
-              const [, mimeType = "image/jpeg"] = urlData.match(/data:([a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+).*,.*/) || [];
+
+              const base64Image = urlData.split(",")[1];
+              // Calculate actual decoded size of base64 data
+              const base64Size = Buffer.from(base64Image, "base64").length;
+
+              if (base64Size > maxImageSize) {
+                logger.warn(
+                  `Image size ${base64Size} bytes exceeds maximum allowed size ${maxImageSize} - skipping image content.`,
+                );
+                return null;
+              }
+
+              const [, mimeType = "image/jpeg"] =
+                urlData.match(/data:([a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+).*,.*/) ||
+                [];
 
               return {
                 type: "image",
@@ -83,8 +239,7 @@ async function convertContentItem(item, maxImageSize, plugin) {
       default:
         return null;
     }
-  }
-  catch (e) {
+  } catch (e) {
     logger.warn(`Error converting content item: ${e}`);
     return null;
   }
@@ -96,184 +251,201 @@ async function fetchImageAsDataURL(imageUrl) {
     // Get the actual image data
     const dataResponse = await axios.get(imageUrl, {
       timeout: 30000,
-      responseType: 'arraybuffer',
-      maxRedirects: 5
+      responseType: "arraybuffer",
+      maxRedirects: 5,
     });
 
-    const contentType = dataResponse.headers['content-type'];
-    const base64Image = Buffer.from(dataResponse.data).toString('base64');
+    const contentType = dataResponse.headers["content-type"];
+    const base64Image = Buffer.from(dataResponse.data).toString("base64");
     return `data:${contentType};base64,${base64Image}`;
-  }
-  catch (e) {
+  } catch (e) {
     logger.error(`Failed to fetch image: ${imageUrl}. ${e}`);
     throw e;
   }
 }
 
 class Claude3VertexPlugin extends OpenAIVisionPlugin {
-  
   constructor(pathway, model) {
     super(pathway, model);
     this.isMultiModal = true;
     this.pathwayToolCallback = pathway.toolCallback;
     this.toolCallsBuffer = [];
-    this.contentBuffer = ''; // Initialize content buffer
+    this.contentBuffer = ""; // Initialize content buffer
     this.hadToolCalls = false; // Track if this stream had tool calls
   }
-  
+
   // Override tryParseMessages to add Claude-specific content types (tool_use, tool_result)
   async tryParseMessages(messages) {
     // Whitelist of content types we accept from parsed JSON strings
     // Only these types will be used if a JSON string parses to an object
     // Includes Claude-specific types: tool_use, tool_result
-    const WHITELISTED_CONTENT_TYPES = ['text', 'image', 'image_url', 'tool_use', 'tool_result'];
-    
+    const WHITELISTED_CONTENT_TYPES = [
+      "text",
+      "image",
+      "image_url",
+      "tool_use",
+      "tool_result",
+    ];
+
     // Helper to check if an object is a valid whitelisted content type
     const isValidContentObject = (obj) => {
       return (
-        typeof obj === 'object' && 
-        obj !== null && 
-        typeof obj.type === 'string' &&
+        typeof obj === "object" &&
+        obj !== null &&
+        typeof obj.type === "string" &&
         WHITELISTED_CONTENT_TYPES.includes(obj.type)
       );
     };
-    
+
     function safeJsonParse(content) {
       try {
         const parsedContent = JSON.parse(content);
-        return (typeof parsedContent === 'object' && parsedContent !== null) ? parsedContent : content;
+        return typeof parsedContent === "object" && parsedContent !== null
+          ? parsedContent
+          : content;
       } catch (e) {
         return content;
       }
     }
-    
-    return await Promise.all(messages.map(async message => {
-      try {
-        // Parse tool_calls from string array to object array if present
-        const parsedMessage = { ...message };
-        if (message.tool_calls && Array.isArray(message.tool_calls)) {
-          parsedMessage.tool_calls = message.tool_calls.map(tc => {
-            if (typeof tc === 'string') {
-              try {
-                return JSON.parse(tc);
-              } catch (e) {
-                logger.warn(`Failed to parse tool_call: ${tc}`);
-                return tc;
-              }
-            }
-            return tc;
-          });
-        }
-        
-        // Handle tool-related message types
-        // For tool messages, OpenAI supports content as either:
-        // 1. A string (text content)
-        // 2. An array of text content parts: [{ type: "text", text: "..." }]
-        if (message.role === "tool") {
-          // If content is already a string, keep it as-is
-          if (typeof parsedMessage.content === 'string') {
-            return parsedMessage;
-          }
-          
-          // If content is an array, process it
-          if (Array.isArray(parsedMessage.content)) {
-            // Check if array is already in the correct format (array of text content parts)
-            const isTextContentPartsArray = parsedMessage.content.every(item => 
-              typeof item === 'object' && 
-              item !== null && 
-              item.type === 'text' && 
-              typeof item.text === 'string'
-            );
-            
-            if (isTextContentPartsArray) {
-              // Already in correct format, keep as array
-              return parsedMessage;
-            }
-            
-            // Convert array to array of text content parts
-            parsedMessage.content = parsedMessage.content.map(item => {
-              if (typeof item === 'string') {
-                return { type: 'text', text: item };
-              }
-              if (typeof item === 'object' && item !== null && item.text) {
-                return { type: 'text', text: String(item.text) };
-              }
-              return { type: 'text', text: JSON.stringify(item) };
-            });
-            return parsedMessage;
-          }
-          
-          // If content is null/undefined, convert to empty string
-          if (parsedMessage.content == null) {
-            parsedMessage.content = '';
-          }
-          
-          return parsedMessage;
-        }
-        
-        // For assistant messages with tool_calls, return as-is (content can be null or string)
-        if (message.role === "assistant" && parsedMessage.tool_calls) {
-          return parsedMessage;
-        }
 
-        if (Array.isArray(message.content)) {
-          return {
-            ...parsedMessage,
-            content: await Promise.all(message.content.map(async item => {
-              // A content array item can be a plain string, a JSON string, or a valid content object
-              let itemToProcess, contentType;
-
-              // First try to parse it as a JSON string
-              const parsedItem = safeJsonParse(item);
-              
-              // Check if parsed item is a known content object
-              if (isValidContentObject(parsedItem)) {
-                itemToProcess = parsedItem;
-                contentType = parsedItem.type;
-              } 
-              // It's not, so check if original item is already a known content object
-              else if (isValidContentObject(item)) {
-                itemToProcess = item;
-                contentType = item.type;
-              } 
-              // It's not, so return it as a text object. This covers all unknown objects and strings.
-              else {
-                const textContent = typeof item === 'string' ? item : JSON.stringify(item);
-                return { type: 'text', text: textContent };
-              }
-              
-              // Process whitelisted content types (we know contentType is known and valid at this point)
-              if (contentType === 'text') {
-                return { type: 'text', text: itemToProcess.text || '' };
-              }
-              
-              if (contentType === 'image' || contentType === 'image_url') {
-                const url = itemToProcess.url || itemToProcess.image_url?.url;
-                if (url && await this.validateImageUrl(url)) {
-                  return { type: 'image_url', image_url: { url } };
+    return await Promise.all(
+      messages.map(async (message) => {
+        try {
+          // Parse tool_calls from string array to object array if present
+          const parsedMessage = { ...message };
+          if (message.tool_calls && Array.isArray(message.tool_calls)) {
+            parsedMessage.tool_calls = message.tool_calls.map((tc) => {
+              if (typeof tc === "string") {
+                try {
+                  return JSON.parse(tc);
+                } catch (e) {
+                  logger.warn(`Failed to parse tool_call: ${tc}`);
+                  return tc;
                 }
               }
+              return tc;
+            });
+          }
 
-              // Handle Claude-specific content types
-              if (contentType === 'tool_use' || contentType === 'tool_result') {
-                return itemToProcess;
+          // Handle tool-related message types
+          // For tool messages, OpenAI supports content as either:
+          // 1. A string (text content)
+          // 2. An array of text content parts: [{ type: "text", text: "..." }]
+          if (message.role === "tool") {
+            // If content is already a string, keep it as-is
+            if (typeof parsedMessage.content === "string") {
+              return parsedMessage;
+            }
+
+            // If content is an array, process it
+            if (Array.isArray(parsedMessage.content)) {
+              // Check if array is already in the correct format (array of text content parts)
+              const isTextContentPartsArray = parsedMessage.content.every(
+                (item) =>
+                  typeof item === "object" &&
+                  item !== null &&
+                  item.type === "text" &&
+                  typeof item.text === "string",
+              );
+
+              if (isTextContentPartsArray) {
+                // Already in correct format, keep as array
+                return parsedMessage;
               }
 
-              // If we got here, we failed to process something - likely the image - so we'll return it as a text object.
-              const textContent = typeof itemToProcess === 'string' 
-                ? itemToProcess 
-                : JSON.stringify(itemToProcess);
-              return { type: 'text', text: textContent };
-            }))
-          };
+              // Convert array to array of text content parts
+              parsedMessage.content = parsedMessage.content.map((item) => {
+                if (typeof item === "string") {
+                  return { type: "text", text: item };
+                }
+                if (typeof item === "object" && item !== null && item.text) {
+                  return { type: "text", text: String(item.text) };
+                }
+                return { type: "text", text: JSON.stringify(item) };
+              });
+              return parsedMessage;
+            }
+
+            // If content is null/undefined, convert to empty string
+            if (parsedMessage.content == null) {
+              parsedMessage.content = "";
+            }
+
+            return parsedMessage;
+          }
+
+          // For assistant messages with tool_calls, return as-is (content can be null or string)
+          if (message.role === "assistant" && parsedMessage.tool_calls) {
+            return parsedMessage;
+          }
+
+          if (Array.isArray(message.content)) {
+            return {
+              ...parsedMessage,
+              content: await Promise.all(
+                message.content.map(async (item) => {
+                  // A content array item can be a plain string, a JSON string, or a valid content object
+                  let itemToProcess, contentType;
+
+                  // First try to parse it as a JSON string
+                  const parsedItem = safeJsonParse(item);
+
+                  // Check if parsed item is a known content object
+                  if (isValidContentObject(parsedItem)) {
+                    itemToProcess = parsedItem;
+                    contentType = parsedItem.type;
+                  }
+                  // It's not, so check if original item is already a known content object
+                  else if (isValidContentObject(item)) {
+                    itemToProcess = item;
+                    contentType = item.type;
+                  }
+                  // It's not, so return it as a text object. This covers all unknown objects and strings.
+                  else {
+                    const textContent =
+                      typeof item === "string" ? item : JSON.stringify(item);
+                    return { type: "text", text: textContent };
+                  }
+
+                  // Process whitelisted content types (we know contentType is known and valid at this point)
+                  if (contentType === "text") {
+                    return { type: "text", text: itemToProcess.text || "" };
+                  }
+
+                  if (contentType === "image" || contentType === "image_url") {
+                    const url =
+                      itemToProcess.url || itemToProcess.image_url?.url;
+                    if (url && (await this.validateImageUrl(url))) {
+                      return { type: "image_url", image_url: { url } };
+                    }
+                  }
+
+                  // Handle Claude-specific content types
+                  if (
+                    contentType === "tool_use" ||
+                    contentType === "tool_result"
+                  ) {
+                    return itemToProcess;
+                  }
+
+                  // If we got here, we failed to process something - likely the image - so we'll return it as a text object.
+                  const textContent =
+                    typeof itemToProcess === "string"
+                      ? itemToProcess
+                      : JSON.stringify(itemToProcess);
+                  return { type: "text", text: textContent };
+                }),
+              ),
+            };
+          }
+        } catch (e) {
+          return message;
         }
-      } catch (e) {
         return message;
-      }
-      return message;
-    }));
+      }),
+    );
   }
-  
+
   parseResponse(data) {
     if (!data) {
       return data;
@@ -283,7 +455,7 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
 
     // Handle tool use responses from Claude
     if (content && Array.isArray(content)) {
-      const toolUses = content.filter(item => item.type === "tool_use");
+      const toolUses = content.filter((item) => item.type === "tool_use");
       if (toolUses.length > 0) {
         // Create standardized CortexResponse object for tool calls
         const cortexResponse = new CortexResponse({
@@ -291,25 +463,25 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
           finishReason: "tool_calls",
           usage: usage || null,
           metadata: {
-            model: this.modelName
-          }
+            model: this.modelName,
+          },
         });
 
         // Convert Claude tool uses to OpenAI format
-        cortexResponse.toolCalls = toolUses.map(toolUse => ({
+        cortexResponse.toolCalls = toolUses.map((toolUse) => ({
           id: toolUse.id,
           type: "function",
           function: {
             name: toolUse.name,
-            arguments: JSON.stringify(toolUse.input)
-          }
+            arguments: JSON.stringify(toolUse.input),
+          },
         }));
 
         return cortexResponse;
       }
 
       // Handle regular text responses
-      const textContent = content.find(item => item.type === "text");
+      const textContent = content.find((item) => item.type === "text");
       if (textContent) {
         // Create standardized CortexResponse object for text responses
         const cortexResponse = new CortexResponse({
@@ -317,11 +489,24 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
           finishReason: stop_reason === "tool_use" ? "tool_calls" : "stop",
           usage: usage || null,
           metadata: {
-            model: this.modelName
-          }
+            model: this.modelName,
+          },
         });
 
         return cortexResponse;
+      }
+
+      // Normalize empty-content responses so GraphQL callers still receive a
+      // scalar result instead of the raw provider envelope object.
+      if (content.length === 0) {
+        return new CortexResponse({
+          output_text: "",
+          finishReason: stop_reason === "tool_use" ? "tool_calls" : "stop",
+          usage: usage || null,
+          metadata: {
+            model: this.modelName,
+          },
+        });
       }
     }
 
@@ -332,61 +517,68 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
   async convertMessagesToClaudeVertex(messages) {
     // Create a deep copy of the input messages
     const messagesCopy = JSON.parse(JSON.stringify(messages));
-  
+
     let system = "";
     let imageCount = 0;
     const maxImages = 20; // Claude allows up to 20 images per request
-  
+
     // Extract system messages
-    const systemMessages = messagesCopy.filter(message => message.role === "system");
+    const systemMessages = messagesCopy.filter(
+      (message) => message.role === "system",
+    );
     if (systemMessages.length > 0) {
-      system = systemMessages.map(message => {
-        if (Array.isArray(message.content)) {
-          // For content arrays, extract text content and join
-          return message.content
-            .filter(item => item.type === 'text')
-            .map(item => item.text)
-            .join("\n");
-        }
-        return message.content;
-      }).join("\n");
+      system = systemMessages
+        .map((message) => {
+          if (Array.isArray(message.content)) {
+            // For content arrays, extract text content and join
+            return message.content
+              .filter((item) => item.type === "text")
+              .map((item) => item.text)
+              .join("\n");
+          }
+          return message.content;
+        })
+        .join("\n");
     }
-  
+
     // Filter out system messages and empty messages
     let modifiedMessages = messagesCopy
-      .filter(message => message.role !== "system")
-      .map(message => {
+      .filter((message) => message.role !== "system")
+      .map((message) => {
         // Handle OpenAI tool calls format conversion to Claude format
         if (message.tool_calls) {
           return {
             role: message.role,
-            content: message.tool_calls.map(toolCall => ({
+            content: message.tool_calls.map((toolCall) => ({
               type: "tool_use",
               id: toolCall.id,
               name: toolCall.function.name,
-              input: JSON.parse(toolCall.function.arguments)
-            }))
+              input: JSON.parse(toolCall.function.arguments),
+            })),
           };
         }
-        
+
         // Handle OpenAI tool response format conversion to Claude format
         if (message.role === "tool") {
           return {
             role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: message.tool_call_id,
-              content: message.content
-            }]
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: message.tool_call_id,
+                content: message.content,
+              },
+            ],
           };
         }
 
         return { ...message };
       })
-      .filter(message => {
+      .filter((message) => {
         // Filter out messages with empty content
         if (!message.content) return false;
-        if (Array.isArray(message.content) && message.content.length === 0) return false;
+        if (Array.isArray(message.content) && message.content.length === 0)
+          return false;
         return true;
       });
 
@@ -396,60 +588,80 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
         acc.push({ ...message });
       } else {
         const lastMessage = acc[acc.length - 1];
-        if (Array.isArray(lastMessage.content) && Array.isArray(message.content)) {
+        if (
+          Array.isArray(lastMessage.content) &&
+          Array.isArray(message.content)
+        ) {
           lastMessage.content = [...lastMessage.content, ...message.content];
         } else if (Array.isArray(lastMessage.content)) {
-          lastMessage.content.push({ type: 'text', text: message.content });
+          lastMessage.content.push({ type: "text", text: message.content });
         } else if (Array.isArray(message.content)) {
-          lastMessage.content = [{ type: 'text', text: lastMessage.content }, ...message.content];
+          lastMessage.content = [
+            { type: "text", text: lastMessage.content },
+            ...message.content,
+          ];
         } else {
           lastMessage.content += "\n" + message.content;
         }
       }
       return acc;
     }, []);
-  
+
+    const sanitizedMessages = sanitizeToolUseSequences(combinedMessages);
+
     // Ensure an odd number of messages
-    const finalMessages = combinedMessages.length % 2 === 0
-      ? combinedMessages.slice(1)
-      : combinedMessages;
-  
+    let finalMessages = sanitizedMessages;
+
+    if (combinedMessages.length % 2 === 0) {
+      finalMessages = sanitizedMessages.slice(1);
+    }
+
     // Convert content items
     const claude3Messages = await Promise.all(
       finalMessages.map(async (message) => {
-        const contentArray = Array.isArray(message.content) ? message.content : [message.content];
-        const claude3Content = await Promise.all(contentArray.map(async item => {
-          const convertedItem = await convertContentItem(item, this.getModelMaxImageSize(), this);
-          
-          // Track image count
-          if (convertedItem?.type === 'image') {
-            imageCount++;
-            if (imageCount > maxImages) {
-              logger.warn(`Maximum number of images (${maxImages}) exceeded - skipping additional images.`);
-              return null;
+        const contentArray = Array.isArray(message.content)
+          ? message.content
+          : [message.content];
+        const claude3Content = await Promise.all(
+          contentArray.map(async (item) => {
+            const convertedItem = await convertContentItem(
+              item,
+              this.getModelMaxImageSize(),
+              this,
+            );
+
+            // Track image count
+            if (convertedItem?.type === "image") {
+              imageCount++;
+              if (imageCount > maxImages) {
+                logger.warn(
+                  `Maximum number of images (${maxImages}) exceeded - skipping additional images.`,
+                );
+                return null;
+              }
             }
-          }
-          
-          return convertedItem;
-        }));
+
+            return convertedItem;
+          }),
+        );
         return {
           role: message.role,
           content: claude3Content.filter(Boolean),
         };
-      })
+      }),
     );
-  
+
     return {
       system,
       modifiedMessages: claude3Messages,
     };
   }
-  
+
   async getRequestParameters(text, parameters, prompt) {
     const requestParameters = await super.getRequestParameters(
       text,
       parameters,
-      prompt
+      prompt,
     );
 
     const { system, modifiedMessages } =
@@ -459,25 +671,25 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
 
     // Convert OpenAI tools format to Claude format if present
     let toolsArray = parameters.tools;
-    if (typeof toolsArray === 'string') {
+    if (typeof toolsArray === "string") {
       try {
         toolsArray = JSON.parse(toolsArray);
       } catch (e) {
         toolsArray = [];
       }
     }
-    
+
     if (toolsArray && Array.isArray(toolsArray) && toolsArray.length > 0) {
-      requestParameters.tools = toolsArray.map(tool => {
-        if (tool.type === 'function') {
+      requestParameters.tools = toolsArray.map((tool) => {
+        if (tool.type === "function") {
           return {
             name: tool.function.name,
             description: tool.function.description,
-                  input_schema: {
+            input_schema: {
               type: "object",
               properties: tool.function.parameters.properties,
-              required: tool.function.parameters.required || []
-            }
+              required: tool.function.parameters.required || [],
+            },
           };
         }
         return tool;
@@ -485,77 +697,111 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
     }
 
     // Handle tool_choice parameter conversion from OpenAI format to Claude format
-    if (parameters.tool_choice) {
-      let toolChoice = parameters.tool_choice;
-      
+    const rawToolChoice =
+      parameters.tool_choice ?? requestParameters.tool_choice;
+    if (rawToolChoice) {
+      let toolChoice = rawToolChoice;
+
       // Parse JSON string if needed
-      if (typeof toolChoice === 'string') {
+      if (typeof toolChoice === "string") {
         try {
           toolChoice = JSON.parse(toolChoice);
         } catch (e) {
           // If not JSON, handle as simple string values: auto, required, none
-          if (toolChoice === 'required') {
-            requestParameters.tool_choice = { type: 'any' }; // OpenAI's 'required' maps to Claude's 'any'
-          } else if (toolChoice === 'auto') {
-            requestParameters.tool_choice = { type: 'auto' };
-          } else if (toolChoice === 'none') {
-            requestParameters.tool_choice = { type: 'none' };
+          if (toolChoice === "required") {
+            requestParameters.tool_choice = { type: "any" }; // OpenAI's 'required' maps to Claude's 'any'
+          } else if (toolChoice === "auto") {
+            requestParameters.tool_choice = { type: "auto" };
+          } else if (toolChoice === "none") {
+            requestParameters.tool_choice = { type: "none" };
           }
           toolChoice = null; // Prevent further processing
         }
       }
-      
+
       // Handle parsed object
-      if (toolChoice && toolChoice.type === "function") {
-        // Handle function-specific tool choice
-        requestParameters.tool_choice = {
-          type: "tool",
-          name: toolChoice.function.name || toolChoice.function
-        };
+      if (toolChoice && typeof toolChoice === "object") {
+        if (toolChoice.type === "function") {
+          // OpenAI function selection maps to Claude tool selection
+          requestParameters.tool_choice = {
+            type: "tool",
+            name: toolChoice.function.name || toolChoice.function,
+          };
+        } else if (
+          toolChoice.type === "auto" ||
+          toolChoice.type === "any" ||
+          toolChoice.type === "none"
+        ) {
+          // Preserve Anthropic/OpenAI-compatible object forms when already normalized
+          requestParameters.tool_choice = { type: toolChoice.type };
+        } else if (toolChoice.type === "tool") {
+          // Preserve explicit Claude tool choice object
+          requestParameters.tool_choice = {
+            type: "tool",
+            name: toolChoice.name || toolChoice.function?.name || toolChoice.function,
+          };
+        }
       }
     }
 
     // If there are function calls in messages, generate tools block
-    if (modifiedMessages?.some(msg => 
-      Array.isArray(msg.content) && msg.content.some(item => item.type === 'tool_use')
-    )) {
+    if (
+      modifiedMessages?.some(
+        (msg) =>
+          Array.isArray(msg.content) &&
+          msg.content.some((item) => item.type === "tool_use"),
+      )
+    ) {
       const toolsMap = new Map();
-      
+
       // First add any existing tools from parameters to the map
       if (requestParameters.tools) {
-        requestParameters.tools.forEach(tool => {
+        requestParameters.tools.forEach((tool) => {
           toolsMap.set(tool.name, tool);
         });
       }
-      
+
       // Collect all unique tool uses from messages, only adding if not already present
-      modifiedMessages.forEach(msg => {
+      modifiedMessages.forEach((msg) => {
         if (Array.isArray(msg.content)) {
-          msg.content.forEach(item => {
-            if (item.type === 'tool_use' && !toolsMap.has(item.name)) {
+          msg.content.forEach((item) => {
+            if (item.type === "tool_use" && !toolsMap.has(item.name)) {
               toolsMap.set(item.name, {
                 name: item.name,
                 description: `Tool for ${item.name}`,
                 input_schema: {
                   type: "object",
-                  properties: item.input ? Object.keys(item.input).reduce((acc, key) => {
-                    acc[key] = {
-                      type: typeof item.input[key] === 'string' ? 'string' : 'object',
-                      description: `Parameter ${key} for ${item.name}`
-                    };
-                    return acc;
-                  }, {}) : {},
-                  required: item.input ? Object.keys(item.input) : []
-                }
+                  properties: item.input
+                    ? Object.keys(item.input).reduce((acc, key) => {
+                        acc[key] = {
+                          type:
+                            typeof item.input[key] === "string"
+                              ? "string"
+                              : "object",
+                          description: `Parameter ${key} for ${item.name}`,
+                        };
+                        return acc;
+                      }, {})
+                    : {},
+                  required: item.input ? Object.keys(item.input) : [],
+                },
               });
             }
           });
         }
       });
-      
+
       // Update the tools array with the combined unique tools
       requestParameters.tools = Array.from(toolsMap.values());
     }
+
+    // Note: Server-side tools (e.g., web_search_20250305) are handled via
+    // native passthrough in anthropicMessagesRoute.js, not through this plugin.
+
+    // Claude 3 models do not support Anthropic thinking/output_config controls.
+    delete requestParameters.reasoningEffort;
+    delete requestParameters.thinkingType;
+    delete requestParameters.thinkingBudgetTokens;
 
     requestParameters.max_tokens = this.getModelMaxReturnTokens();
     requestParameters.anthropic_version = "vertex-2023-10-16";
@@ -568,7 +814,6 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
     if (system) {
       const { length, units } = this.getLength(system);
       logger.info(`[system messages sent containing ${length} ${units}]`);
-      logger.verbose(`${this.shortenContent(system)}`);
     }
 
     if (messages && messages.length > 1) {
@@ -579,21 +824,18 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
         let content;
         if (Array.isArray(message.content)) {
           // Only stringify objects, not strings (which may already be JSON strings)
-          content = message.content.map((item) => {
-            const sanitized = sanitizeBase64(item);
-            return typeof sanitized === 'string' ? sanitized : JSON.stringify(sanitized);
-          }).join(", ");
+          content = message.content
+            .map((item) => {
+              const sanitized = sanitizeBase64(item);
+              return typeof sanitized === "string"
+                ? sanitized
+                : JSON.stringify(sanitized);
+            })
+            .join(", ");
         } else {
           content = message.content;
         }
         const { length, units } = this.getLength(content);
-        const preview = this.shortenContent(content);
-
-        logger.verbose(
-          `message ${index + 1}: role: ${
-            message.role
-          }, ${units}: ${length}, content: "${preview}"`
-        );
         totalLength += length;
         totalUnits = units;
       });
@@ -603,31 +845,28 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
       let content;
       if (Array.isArray(message.content)) {
         // Only stringify objects, not strings (which may already be JSON strings)
-        content = message.content.map((item) => {
-          return typeof item === 'string' ? item : JSON.stringify(item);
-        }).join(", ");
+        content = message.content
+          .map((item) => {
+            return typeof item === "string" ? item : JSON.stringify(item);
+          })
+          .join(", ");
       } else {
         content = message.content;
       }
       const { length, units } = this.getLength(content);
       logger.info(`[request sent containing ${length} ${units}]`);
-      logger.verbose(`${this.shortenContent(content)}`);
     }
 
-    if (stream) {
-      logger.info(`[response received as an SSE stream]`);
-    } else {
+    if (!stream) {
       const parsedResponse = this.parseResponse(responseData);
-      
-      if (typeof parsedResponse === 'string') {
-          const { length, units } = this.getLength(parsedResponse);
-          logger.info(`[response received containing ${length} ${units}]`);
-          logger.verbose(`${this.shortenContent(parsedResponse)}`);
+
+      if (typeof parsedResponse === "string") {
+        const { length, units } = this.getLength(parsedResponse);
+        logger.info(`[response received containing ${length} ${units}]`);
       } else {
-          logger.info(`[response received containing object]`);
-          logger.verbose(`${JSON.stringify(parsedResponse)}`);
+        logger.info(`[response received containing object]`);
       }
-  }
+    }
 
     prompt &&
       prompt.debugInfo &&
@@ -639,7 +878,7 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
       text,
       parameters,
       prompt,
-      cortexRequest
+      cortexRequest,
     );
     const { stream } = parameters;
 
@@ -662,7 +901,7 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
 
   convertClaudeSSEToOpenAI(event) {
     // Handle end of stream
-    if (event.data.trim() === '[DONE]') {
+    if (event.data.trim() === "[DONE]") {
       return event; // Pass through unchanged
     }
 
@@ -678,11 +917,13 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
       object: "chat.completion.chunk",
       created: Math.floor(Date.now() / 1000),
       model: this.modelName,
-      choices: [{
-        index: 0,
-        delta: {},
-        finish_reason: null
-      }]
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: null,
+        },
+      ],
     };
 
     let delta = {};
@@ -692,18 +933,18 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
     const streamError = eventData?.error?.message || eventData?.error;
     if (streamError) {
       delta = {
-        content: `\n\n*** ${streamError} ***`
+        content: `\n\n*** ${streamError} ***`,
       };
       finishReason = "error";
-      
+
       // Update the OpenAI response
       baseOpenAIResponse.choices[0].delta = delta;
       baseOpenAIResponse.choices[0].finish_reason = finishReason;
-      
+
       // Create new event with OpenAI format
       return {
         ...event,
-        data: JSON.stringify(baseOpenAIResponse)
+        data: JSON.stringify(baseOpenAIResponse),
       };
     }
 
@@ -711,8 +952,12 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
     switch (eventData.type) {
       case "message_start":
         delta = { role: "assistant", content: "" };
-        // Reset tool calls flag for new message
+        // Reset state for new message
         this.hadToolCalls = false;
+        // Forward initial usage (input_tokens) from Claude message_start
+        if (eventData.message?.usage) {
+          baseOpenAIResponse.usage = eventData.message.usage;
+        }
         break;
 
       case "content_block_delta":
@@ -721,61 +966,92 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
         } else if (eventData.delta.type === "input_json_delta") {
           // Handle tool call argument streaming
           const toolCallIndex = eventData.index || 0;
-          
+
           // Create OpenAI tool call delta - parent class will handle accumulation
           delta = {
-            tool_calls: [{
-              index: toolCallIndex,
-              id: eventData.id || `call_${toolCallIndex}_${Date.now()}`,
-              type: "function",
-              function: {
-                arguments: eventData.delta.partial_json || ""
-              }
-            }]
+            tool_calls: [
+              {
+                index: toolCallIndex,
+                id: eventData.id || `call_${toolCallIndex}_${Date.now()}`,
+                type: "function",
+                function: {
+                  arguments: eventData.delta.partial_json || "",
+                },
+              },
+            ],
           };
         } else if (eventData.delta.type === "name_delta") {
           // Handle tool call name streaming
           const toolCallIndex = eventData.index || 0;
-          
+
           // Create OpenAI tool call delta - parent class will handle accumulation
           delta = {
-            tool_calls: [{
-              index: toolCallIndex,
-              id: eventData.id || `call_${toolCallIndex}_${Date.now()}`,
-              type: "function",
-              function: {
-                name: eventData.delta.name || ""
-              }
-            }]
+            tool_calls: [
+              {
+                index: toolCallIndex,
+                id: eventData.id || `call_${toolCallIndex}_${Date.now()}`,
+                type: "function",
+                function: {
+                  name: eventData.delta.name || "",
+                },
+              },
+            ],
           };
         }
+        // Note: thinking_delta and server tool deltas are ignored here -
+        // Claude clients use native passthrough which handles these directly
         break;
 
       case "content_block_start":
         if (eventData.content_block.type === "tool_use") {
           // Mark that we have tool calls in this stream
           this.hadToolCalls = true;
-          
+
           // Create OpenAI tool call delta - parent class will handle buffer management
           const toolCallIndex = eventData.index || 0;
           delta = {
-            tool_calls: [{
-              index: toolCallIndex,
-              id: eventData.content_block.id || `call_${toolCallIndex}_${Date.now()}`,
-              type: "function",
-              function: {
-                name: eventData.content_block.name || ""
-              }
-            }]
+            tool_calls: [
+              {
+                index: toolCallIndex,
+                id:
+                  eventData.content_block.id ||
+                  `call_${toolCallIndex}_${Date.now()}`,
+                type: "function",
+                function: {
+                  name: eventData.content_block.name || "",
+                },
+              },
+            ],
           };
         }
+        // Note: thinking, server_tool_use, and web_search_tool_result blocks are ignored here -
+        // Claude clients use native passthrough which handles these directly
         break;
 
-      case "message_delta":
-        // Handle message delta events (like stop_reason)
-        // Don't set finish_reason here - let the stream continue until message_stop
+      case "message_delta": {
         delta = {};
+        const rawStopReason =
+          eventData?.delta?.stop_reason ??
+          eventData?.delta?.stopReason ??
+          eventData?.stop_reason ??
+          eventData?.stopReason;
+        if (rawStopReason && !this.pathwayToolCallback) {
+          const stopReason = String(rawStopReason).toLowerCase();
+          if (stopReason === "tool_use") {
+            finishReason = "tool_calls";
+          } else if (stopReason === "max_tokens") {
+            finishReason = "length";
+          } else if (stopReason === "stop_sequence") {
+            finishReason = "stop_sequence";
+          } else {
+            finishReason = "stop";
+          }
+        }
+        if (eventData.usage) {
+          baseOpenAIResponse.usage = eventData.usage;
+        }
         break;
+      }
 
       case "message_stop":
         delta = {};
@@ -789,14 +1065,16 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
 
       case "error":
         delta = {
-          content: `\n\n*** ${eventData.error.message || eventData.error} ***`
+          content: `\n\n*** ${eventData.error.message || eventData.error} ***`,
         };
         finishReason = "error";
         break;
 
-      // Ignore other event types as they don't map to OpenAI format
       case "content_block_stop":
-      case "message_delta":
+        // No action needed - block stops are implicit in OpenAI format
+        break;
+
+      // Ignore other event types as they don't map to OpenAI format
       case "ping":
         break;
     }
@@ -807,21 +1085,34 @@ class Claude3VertexPlugin extends OpenAIVisionPlugin {
       baseOpenAIResponse.choices[0].finish_reason = finishReason;
     }
 
-    // Create new event with OpenAI format
     return {
       ...event,
-      data: JSON.stringify(baseOpenAIResponse)
+      data: JSON.stringify(baseOpenAIResponse),
     };
   }
 
   processStreamEvent(event, requestProgress) {
+    let originalEventType = null;
+    try {
+      originalEventType = JSON.parse(event.data)?.type || null;
+    } catch {
+      // Let the delegated parser handle invalid event data consistently.
+    }
+
     // Convert Claude event to OpenAI format
     const openAIEvent = this.convertClaudeSSEToOpenAI(event);
-    
-    // Delegate to parent class for all the tool call logic
-    return super.processStreamEvent(openAIEvent, requestProgress);
-  }
 
+    // Delegate to parent class for all the tool call logic
+    const progress = super.processStreamEvent(openAIEvent, requestProgress);
+    if (
+      (originalEventType === "message_stop" || originalEventType === "error") &&
+      !progress.toolCallbackInvoked
+    ) {
+      progress.progress = 1;
+    }
+    return progress;
+  }
 }
 
 export default Claude3VertexPlugin;
+export { sanitizeToolUseSequences };

--- a/server/plugins/claude4VertexPlugin.js
+++ b/server/plugins/claude4VertexPlugin.js
@@ -1,6 +1,8 @@
-import Claude3VertexPlugin from "./claude3VertexPlugin.js";
+import Claude3VertexPlugin, {
+  sanitizeToolUseSequences,
+} from "./claude3VertexPlugin.js";
 import logger from "../../lib/logger.js";
-import axios from 'axios';
+import axios from "axios";
 import { sanitizeBase64 } from "../../lib/util.js";
 
 // Claude 4 default maximum file size limit (30MB) for both images and PDFs
@@ -9,30 +11,35 @@ const CLAUDE4_DEFAULT_MAX_FILE_SIZE = 30 * 1024 * 1024; // 30MB
 // Helper function to detect file type from URL or content
 function detectFileType(url, contentType) {
   const lowerUrl = url.toLowerCase();
-  
+
   // Check for data URLs first and extract media type
-  if (lowerUrl.startsWith('data:')) {
+  if (lowerUrl.startsWith("data:")) {
     const match = lowerUrl.match(/data:([^;,]+)/);
     if (match) {
       const mediaType = match[1];
-      if (mediaType.includes('pdf')) return 'pdf';
-      if (mediaType.includes('text') || mediaType.includes('markdown')) return 'text';
+      if (mediaType.includes("pdf")) return "pdf";
+      if (mediaType.includes("text") || mediaType.includes("markdown"))
+        return "text";
     }
   }
-  
+
   // Check URL extension - extract path before query string/fragment and check if it ends with extension
   // Remove query string and fragment for more accurate extension detection
-  const urlPath = lowerUrl.split('?')[0].split('#')[0];
-  if (urlPath.endsWith('.pdf')) return 'pdf';
-  if (urlPath.endsWith('.txt') || urlPath.endsWith('.text')) return 'text';
-  if (urlPath.endsWith('.md') || urlPath.endsWith('.markdown')) return 'text';
-  
+  const urlPath = lowerUrl.split("?")[0].split("#")[0];
+  if (urlPath.endsWith(".pdf")) return "pdf";
+  if (urlPath.endsWith(".txt") || urlPath.endsWith(".text")) return "text";
+  if (urlPath.endsWith(".md") || urlPath.endsWith(".markdown")) return "text";
+
   // Check content type parameter
   if (contentType) {
-    if (contentType.includes('pdf')) return 'pdf';
-    if (contentType.includes('text/plain') || contentType.includes('text/markdown')) return 'text';
+    if (contentType.includes("pdf")) return "pdf";
+    if (
+      contentType.includes("text/plain") ||
+      contentType.includes("text/markdown")
+    )
+      return "text";
   }
-  
+
   return null;
 }
 
@@ -41,12 +48,12 @@ async function fetchImageAsDataURL(imageUrl) {
   try {
     const dataResponse = await axios.get(imageUrl, {
       timeout: 30000,
-      responseType: 'arraybuffer',
-      maxRedirects: 5
+      responseType: "arraybuffer",
+      maxRedirects: 5,
     });
 
-    const contentType = dataResponse.headers['content-type'];
-    const base64Image = Buffer.from(dataResponse.data).toString('base64');
+    const contentType = dataResponse.headers["content-type"];
+    const base64Image = Buffer.from(dataResponse.data).toString("base64");
     return `data:${contentType};base64,${base64Image}`;
   } catch (e) {
     logger.error(`Failed to fetch image: ${imageUrl}. ${e}`);
@@ -59,20 +66,20 @@ async function fetchFileAsDataURL(fileUrl, fileType) {
   try {
     const dataResponse = await axios.get(fileUrl, {
       timeout: 30000,
-      responseType: 'arraybuffer',
-      maxRedirects: 5
+      responseType: "arraybuffer",
+      maxRedirects: 5,
     });
 
-    const contentType = dataResponse.headers['content-type'];
-    const base64Data = Buffer.from(dataResponse.data).toString('base64');
-    
+    const contentType = dataResponse.headers["content-type"];
+    const base64Data = Buffer.from(dataResponse.data).toString("base64");
+
     // Return appropriate data URL format
-    if (fileType === 'pdf') {
+    if (fileType === "pdf") {
       return `data:application/pdf;base64,${base64Data}`;
-    } else if (fileType === 'text') {
+    } else if (fileType === "text") {
       return `data:text/plain;base64,${base64Data}`;
     }
-    
+
     return `data:${contentType};base64,${base64Data}`;
   } catch (e) {
     logger.error(`Failed to fetch file: ${fileUrl}. ${e}`);
@@ -85,8 +92,8 @@ async function fetchTextFileAsString(fileUrl) {
   try {
     const dataResponse = await axios.get(fileUrl, {
       timeout: 30000,
-      responseType: 'text',
-      maxRedirects: 5
+      responseType: "text",
+      maxRedirects: 5,
     });
 
     return dataResponse.data;
@@ -108,23 +115,31 @@ async function convertContentItemClaude4(item, maxImageSize, plugin) {
           case "text":
             // Handle text content, but also check if it's stringified JSON containing documents
             if (!item.text) return null;
-            
+
             // Try to parse stringified JSON to check if it's actually a document
             let parsedText = item.text;
-            if (typeof item.text === 'string' && item.text.startsWith('{')) {
+            if (typeof item.text === "string" && item.text.startsWith("{")) {
               try {
                 const parsed = JSON.parse(item.text);
                 // If this is stringified JSON for an image_url or document, process it accordingly
-                if (parsed.type === 'image_url') {
-                  return await convertContentItemClaude4(parsed, maxImageSize, plugin);
-                } else if (parsed.type === 'document') {
-                  return await convertContentItemClaude4(parsed, maxImageSize, plugin);
+                if (parsed.type === "image_url") {
+                  return await convertContentItemClaude4(
+                    parsed,
+                    maxImageSize,
+                    plugin,
+                  );
+                } else if (parsed.type === "document") {
+                  return await convertContentItemClaude4(
+                    parsed,
+                    maxImageSize,
+                    plugin,
+                  );
                 }
               } catch (e) {
                 // Not valid JSON, treat as plain text
               }
             }
-            
+
             return { type: "text", text: parsedText };
 
           case "tool_use":
@@ -132,15 +147,25 @@ async function convertContentItemClaude4(item, maxImageSize, plugin) {
               type: "tool_use",
               id: item.id,
               name: item.name,
-              input: typeof item.input === 'string' ? { query: item.input } : item.input
+              input:
+                typeof item.input === "string"
+                  ? { query: item.input }
+                  : item.input,
             };
 
           case "tool_result":
             return {
               type: "tool_result",
               tool_use_id: item.tool_use_id,
-              content: item.content
+              content: item.content,
             };
+
+          // Pass through server-side tool blocks unchanged
+          case "server_tool_use":
+            return item;
+
+          case "web_search_tool_result":
+            return item;
 
           case "image_url":
             // Handle images and documents coming as image_url type
@@ -148,47 +173,55 @@ async function convertContentItemClaude4(item, maxImageSize, plugin) {
             // Note: gcs URLs are for Google models only, Claude uses the main url
             // Handle both: { image_url: "string" } and { image_url: { url: "string" } }
             let imageUrl = item.url || item.image_url?.url;
-            if (typeof item.image_url === 'string') {
+            if (typeof item.image_url === "string") {
               imageUrl = item.image_url;
             }
-            
-            const originalFilename = item.originalFilename || '';
-            
+
+            const originalFilename = item.originalFilename || "";
+
             if (!imageUrl) {
-              logger.warn("Could not parse image URL from content - skipping image content.");
+              logger.warn(
+                "Could not parse image URL from content - skipping image content.",
+              );
               return null;
             }
 
             // Check if this is actually a PDF document (by filename or URL extension)
             // Do this BEFORE image validation since PDFs are not images
-            const isPDF = originalFilename.toLowerCase().endsWith('.pdf') || 
-                          detectFileType(imageUrl) === 'pdf';
-            const isTxt = originalFilename.toLowerCase().endsWith('.txt') ||
-                          originalFilename.toLowerCase().endsWith('.md');
+            const isPDF =
+              originalFilename.toLowerCase().endsWith(".pdf") ||
+              detectFileType(imageUrl) === "pdf";
+            const isTxt =
+              originalFilename.toLowerCase().endsWith(".txt") ||
+              originalFilename.toLowerCase().endsWith(".md");
 
             // Handle PDF documents
             if (isPDF) {
               try {
                 // Fetch the PDF from the URL (Azure Blob Storage or http/https)
-                const pdfData = await fetchFileAsDataURL(imageUrl, 'pdf');
+                const pdfData = await fetchFileAsDataURL(imageUrl, "pdf");
                 const base64Pdf = pdfData.split(",")[1];
-                const pdfSize = Buffer.from(base64Pdf, 'base64').length;
-                
+                const pdfSize = Buffer.from(base64Pdf, "base64").length;
+
                 if (pdfSize > maxImageSize) {
-                  logger.warn(`PDF size ${pdfSize} bytes exceeds maximum allowed size ${maxImageSize} - skipping PDF content.`);
+                  logger.warn(
+                    `PDF size ${pdfSize} bytes exceeds maximum allowed size ${maxImageSize} - skipping PDF content.`,
+                  );
                   return null;
                 }
-                
+
                 return {
                   type: "document",
                   source: {
                     type: "base64",
                     media_type: "application/pdf",
-                    data: base64Pdf
-                  }
+                    data: base64Pdf,
+                  },
                 };
               } catch (error) {
-                logger.error(`Failed to fetch PDF from image_url field: ${error.message}`);
+                logger.error(
+                  `Failed to fetch PDF from image_url field: ${error.message}`,
+                );
                 return null;
               }
             }
@@ -199,32 +232,55 @@ async function convertContentItemClaude4(item, maxImageSize, plugin) {
                 const textContent = await fetchTextFileAsString(imageUrl);
                 return {
                   type: "text",
-                  text: textContent
+                  text: textContent,
                 };
               } catch (error) {
-                logger.error(`Failed to fetch text file from image_url field: ${error.message}`);
+                logger.error(
+                  `Failed to fetch text file from image_url field: ${error.message}`,
+                );
                 return null;
               }
             }
 
             // Only validate and handle as image if not a document
             try {
-              if (!await plugin.validateImageUrl(imageUrl)) {
+              // If the plugin supports image URLs and this is an HTTP/HTTPS URL,
+              // pass it directly to Claude (server-side fetch) — avoids base64 overhead
+              if (plugin.supportsImageUrls && !imageUrl.startsWith("data:")) {
+                return {
+                  type: "image",
+                  source: {
+                    type: "url",
+                    url: imageUrl,
+                  },
+                };
+              }
+
+              // Fallback: validate, fetch, and convert to base64
+              if (!(await plugin.validateImageUrl(imageUrl))) {
                 return null;
               }
 
-              const urlData = imageUrl.startsWith("data:") ? imageUrl : await fetchImageAsDataURL(imageUrl);
-              if (!urlData) { return null; }
-              
-              const base64Image = urlData.split(",")[1];
-              const base64Size = Buffer.from(base64Image, 'base64').length;
-              
-              if (base64Size > maxImageSize) {
-                logger.warn(`Image size ${base64Size} bytes exceeds maximum allowed size ${maxImageSize} - skipping image content.`);
+              const urlData = imageUrl.startsWith("data:")
+                ? imageUrl
+                : await fetchImageAsDataURL(imageUrl);
+              if (!urlData) {
                 return null;
               }
-              
-              const [, mimeType = "image/jpeg"] = urlData.match(/data:([a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+).*,.*/) || [];
+
+              const base64Image = urlData.split(",")[1];
+              const base64Size = Buffer.from(base64Image, "base64").length;
+
+              if (base64Size > maxImageSize) {
+                logger.warn(
+                  `Image size ${base64Size} bytes exceeds maximum allowed size ${maxImageSize} - skipping image content.`,
+                );
+                return null;
+              }
+
+              const [, mimeType = "image/jpeg"] =
+                urlData.match(/data:([a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+).*,.*/) ||
+                [];
 
               return {
                 type: "image",
@@ -244,82 +300,94 @@ async function convertContentItemClaude4(item, maxImageSize, plugin) {
             const documentUrl = item.url || item.source?.url;
             const documentData = item.data || item.source?.data;
             const documentFileId = item.file_id || item.source?.file_id;
-            
+
             if (documentFileId) {
               // Use file_id reference
               return {
                 type: "document",
                 source: {
                   type: "file",
-                  file_id: documentFileId
-                }
+                  file_id: documentFileId,
+                },
               };
             } else if (documentUrl) {
               // Determine file type
               const fileType = detectFileType(documentUrl);
-              
-              if (fileType === 'pdf') {
+
+              if (fileType === "pdf") {
                 // Fetch PDF and convert to base64
-                const pdfData = await fetchFileAsDataURL(documentUrl, 'pdf');
+                const pdfData = await fetchFileAsDataURL(documentUrl, "pdf");
                 const base64Pdf = pdfData.split(",")[1];
-                const pdfSize = Buffer.from(base64Pdf, 'base64').length;
-                
+                const pdfSize = Buffer.from(base64Pdf, "base64").length;
+
                 if (pdfSize > maxImageSize) {
-                  logger.warn(`PDF size ${pdfSize} bytes exceeds maximum allowed size ${maxImageSize} - skipping PDF content.`);
+                  logger.warn(
+                    `PDF size ${pdfSize} bytes exceeds maximum allowed size ${maxImageSize} - skipping PDF content.`,
+                  );
                   return null;
                 }
-                
+
                 return {
                   type: "document",
                   source: {
                     type: "base64",
                     media_type: "application/pdf",
-                    data: base64Pdf
-                  }
+                    data: base64Pdf,
+                  },
                 };
-              } else if (fileType === 'text') {
+              } else if (fileType === "text") {
                 // For text files, we can send as plain text or base64
                 // Using plain text is more efficient
                 const textContent = await fetchTextFileAsString(documentUrl);
                 return {
                   type: "text",
-                  text: textContent
+                  text: textContent,
                 };
               } else {
-                logger.warn(`Unsupported document type for URL: ${documentUrl}`);
+                logger.warn(
+                  `Unsupported document type for URL: ${documentUrl}`,
+                );
                 return null;
               }
             } else if (documentData) {
               // Already have base64 data
-              const mediaType = item.media_type || item.source?.media_type || "application/pdf";
-              
-              if (mediaType.includes('pdf')) {
-                const pdfSize = Buffer.from(documentData, 'base64').length;
-                
+              const mediaType =
+                item.media_type || item.source?.media_type || "application/pdf";
+
+              if (mediaType.includes("pdf")) {
+                const pdfSize = Buffer.from(documentData, "base64").length;
+
                 if (pdfSize > maxImageSize) {
-                  logger.warn(`PDF size ${pdfSize} bytes exceeds maximum allowed size ${maxImageSize} - skipping PDF content.`);
+                  logger.warn(
+                    `PDF size ${pdfSize} bytes exceeds maximum allowed size ${maxImageSize} - skipping PDF content.`,
+                  );
                   return null;
                 }
-                
+
                 return {
                   type: "document",
                   source: {
                     type: "base64",
                     media_type: "application/pdf",
-                    data: documentData
-                  }
+                    data: documentData,
+                  },
                 };
-              } else if (mediaType.includes('text')) {
+              } else if (mediaType.includes("text")) {
                 // Decode base64 text data
-                const textContent = Buffer.from(documentData, 'base64').toString('utf-8');
+                const textContent = Buffer.from(
+                  documentData,
+                  "base64",
+                ).toString("utf-8");
                 return {
                   type: "text",
-                  text: textContent
+                  text: textContent,
                 };
               }
             }
-            
-            logger.warn("Could not parse document content - skipping document.");
+
+            logger.warn(
+              "Could not parse document content - skipping document.",
+            );
             return null;
 
           default:
@@ -335,73 +403,110 @@ async function convertContentItemClaude4(item, maxImageSize, plugin) {
   }
 }
 
+const parseObjectParam = (value) => {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed
+        : null;
+    } catch (_error) {
+      return null;
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? value : null;
+};
+
+const normalizeOptionalString = (value) => {
+  if (value === undefined || value === null) return null;
+  const normalized = (typeof value === "string" ? value : String(value))
+    .trim()
+    .toLowerCase();
+  return normalized || null;
+};
+
 class Claude4VertexPlugin extends Claude3VertexPlugin {
-  
   constructor(pathway, model) {
     super(pathway, model);
     this.isMultiModal = true;
   }
-  
+
+  get supportsImageUrls() {
+    return this.model.supportsImageUrls ?? false;
+  }
+
   // Override to use 30MB default for Claude 4 (instead of 20MB)
   getModelMaxImageSize() {
-    return (this.promptParameters.maxImageSize ?? this.model.maxImageSize ?? CLAUDE4_DEFAULT_MAX_FILE_SIZE);
+    return (
+      this.promptParameters.maxImageSize ??
+      this.model.maxImageSize ??
+      CLAUDE4_DEFAULT_MAX_FILE_SIZE
+    );
   }
-  
+
   // Override convertMessagesToClaudeVertex to use the extended content conversion
   async convertMessagesToClaudeVertex(messages) {
     // Create a deep copy of the input messages
     const messagesCopy = JSON.parse(JSON.stringify(messages));
-  
+
     let system = "";
     let imageCount = 0;
     const maxImages = 20; // Claude allows up to 20 images per request
-  
+
     // Extract system messages
-    const systemMessages = messagesCopy.filter(message => message.role === "system");
+    const systemMessages = messagesCopy.filter(
+      (message) => message.role === "system",
+    );
     if (systemMessages.length > 0) {
-      system = systemMessages.map(message => {
-        if (Array.isArray(message.content)) {
-          return message.content
-            .filter(item => item.type === 'text')
-            .map(item => item.text)
-            .join("\n");
-        }
-        return message.content;
-      }).join("\n");
+      system = systemMessages
+        .map((message) => {
+          if (Array.isArray(message.content)) {
+            return message.content
+              .filter((item) => item.type === "text")
+              .map((item) => item.text)
+              .join("\n");
+          }
+          return message.content;
+        })
+        .join("\n");
     }
-  
+
     // Filter out system messages and empty messages
     let modifiedMessages = messagesCopy
-      .filter(message => message.role !== "system")
-      .map(message => {
+      .filter((message) => message.role !== "system")
+      .map((message) => {
         if (message.tool_calls) {
           return {
             role: message.role,
-            content: message.tool_calls.map(toolCall => ({
+            content: message.tool_calls.map((toolCall) => ({
               type: "tool_use",
               id: toolCall.id,
               name: toolCall.function.name,
-              input: JSON.parse(toolCall.function.arguments)
-            }))
+              input: JSON.parse(toolCall.function.arguments),
+            })),
           };
         }
-        
+
         if (message.role === "tool") {
           return {
             role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: message.tool_call_id,
-              content: message.content
-            }]
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: message.tool_call_id,
+                content: message.content,
+              },
+            ],
           };
         }
 
         return { ...message };
       })
-      .filter(message => {
+      .filter((message) => {
         if (!message.content) return false;
-        if (Array.isArray(message.content) && message.content.length === 0) return false;
+        if (Array.isArray(message.content) && message.content.length === 0)
+          return false;
         return true;
       });
 
@@ -411,53 +516,211 @@ class Claude4VertexPlugin extends Claude3VertexPlugin {
         acc.push({ ...message });
       } else {
         const lastMessage = acc[acc.length - 1];
-        if (Array.isArray(lastMessage.content) && Array.isArray(message.content)) {
+        if (
+          Array.isArray(lastMessage.content) &&
+          Array.isArray(message.content)
+        ) {
           lastMessage.content = [...lastMessage.content, ...message.content];
         } else if (Array.isArray(lastMessage.content)) {
-          lastMessage.content.push({ type: 'text', text: message.content });
+          lastMessage.content.push({ type: "text", text: message.content });
         } else if (Array.isArray(message.content)) {
-          lastMessage.content = [{ type: 'text', text: lastMessage.content }, ...message.content];
+          lastMessage.content = [
+            { type: "text", text: lastMessage.content },
+            ...message.content,
+          ];
         } else {
           lastMessage.content += "\n" + message.content;
         }
       }
       return acc;
     }, []);
-  
+
+    const sanitizedMessages = sanitizeToolUseSequences(combinedMessages);
+
     // Ensure an odd number of messages
-    const finalMessages = combinedMessages.length % 2 === 0
-      ? combinedMessages.slice(1)
-      : combinedMessages;
-  
+    let finalMessages = sanitizedMessages;
+
+    if (combinedMessages.length % 2 === 0) {
+      finalMessages = sanitizedMessages.slice(1);
+    }
+
     // Convert content items using the extended conversion function
     const claude4Messages = await Promise.all(
       finalMessages.map(async (message) => {
-        const contentArray = Array.isArray(message.content) ? message.content : [message.content];
-        const claude4Content = await Promise.all(contentArray.map(async item => {
-          const convertedItem = await convertContentItemClaude4(item, this.getModelMaxImageSize(), this);
-          
-          // Track image count
-          if (convertedItem?.type === 'image') {
-            imageCount++;
-            if (imageCount > maxImages) {
-              logger.warn(`Maximum number of images (${maxImages}) exceeded - skipping additional images.`);
-              return null;
+        const contentArray = Array.isArray(message.content)
+          ? message.content
+          : [message.content];
+        const claude4Content = await Promise.all(
+          contentArray.map(async (item) => {
+            const convertedItem = await convertContentItemClaude4(
+              item,
+              this.getModelMaxImageSize(),
+              this,
+            );
+
+            // Track image count
+            if (convertedItem?.type === "image") {
+              imageCount++;
+              if (imageCount > maxImages) {
+                logger.warn(
+                  `Maximum number of images (${maxImages}) exceeded - skipping additional images.`,
+                );
+                return null;
+              }
             }
-          }
-          
-          return convertedItem;
-        }));
+
+            return convertedItem;
+          }),
+        );
         return {
           role: message.role,
           content: claude4Content.filter(Boolean),
         };
-      })
+      }),
     );
-  
+
     return {
       system,
       modifiedMessages: claude4Messages,
     };
+  }
+
+  async getRequestParameters(text, parameters, prompt) {
+    const requestParameters = await super.getRequestParameters(
+      text,
+      parameters,
+      prompt,
+    );
+
+    // Normalize Anthropic thinking controls for Claude 4 family.
+    // - Legacy: thinking.type + thinking.budget_tokens
+    // - Newer (Opus 4.6+): output_config.effort with adaptive thinking
+    const incomingThinking = parseObjectParam(parameters.thinking);
+    const incomingOutputConfig = parseObjectParam(parameters.output_config);
+
+    const thinkingType = normalizeOptionalString(
+      parameters.thinkingType ?? incomingThinking?.type,
+    );
+    const thinkingBudgetTokensRaw =
+      parameters.thinkingBudgetTokens ??
+      incomingThinking?.budget_tokens ??
+      incomingThinking?.budgetTokens;
+    const thinkingBudgetTokensNumber = Number(thinkingBudgetTokensRaw);
+    const thinkingBudgetTokens =
+      Number.isFinite(thinkingBudgetTokensNumber) &&
+      thinkingBudgetTokensNumber > 0
+        ? Math.floor(thinkingBudgetTokensNumber)
+        : null;
+
+    const reasoningEffortRaw = normalizeOptionalString(
+      parameters.reasoningEffort ?? incomingOutputConfig?.effort,
+    );
+    const reasoningEffort =
+      reasoningEffortRaw === "xhigh" ? "max" : reasoningEffortRaw;
+    const validEffort = ["low", "medium", "high", "max"].includes(
+      reasoningEffort || "",
+    )
+      ? reasoningEffort
+      : null;
+
+    if (thinkingType === "disabled" || reasoningEffort === "none") {
+      requestParameters.thinking = { type: "disabled" };
+      delete requestParameters.output_config;
+    } else {
+      if (thinkingBudgetTokens) {
+        requestParameters.thinking = {
+          type: thinkingType === "adaptive" ? "adaptive" : "enabled",
+          budget_tokens: thinkingBudgetTokens,
+        };
+      } else if (thinkingType === "adaptive" || thinkingType === "enabled") {
+        requestParameters.thinking = { type: thinkingType };
+      }
+
+      const budgetTokensMap = this.model.budgetTokensMap;
+      if (budgetTokensMap && validEffort) {
+        // Pre-4.6 models: use budget_tokens instead of output_config.effort
+        const budgetKey = reasoningEffortRaw; // use original (before xhigh→max mapping)
+        const budgetTokens = budgetTokensMap[budgetKey];
+        if (budgetTokens) {
+          requestParameters.thinking = { type: "enabled", budget_tokens: budgetTokens };
+        }
+      } else if (validEffort) {
+        // 4.6+ models: use output_config.effort + adaptive thinking
+        requestParameters.output_config = {
+          ...(requestParameters.output_config &&
+          typeof requestParameters.output_config === "object"
+            ? requestParameters.output_config
+            : {}),
+          effort: validEffort,
+        };
+
+        // Effort without explicit thinking mode should enable adaptive thinking by default.
+        if (!requestParameters.thinking) {
+          requestParameters.thinking = { type: "adaptive" };
+        }
+      }
+    }
+
+    // Anthropic does not allow thinking when tool_choice forces tool use (type: "any" or "tool").
+    // Disable thinking in that case to avoid API errors.
+    const forcedToolChoice =
+      requestParameters.tool_choice &&
+      typeof requestParameters.tool_choice === "object" &&
+      (requestParameters.tool_choice.type === "any" ||
+        requestParameters.tool_choice.type === "tool");
+
+    if (forcedToolChoice && requestParameters.thinking) {
+      logger.info("Disabling thinking because tool_choice forces tool use");
+      requestParameters.thinking = { type: "disabled" };
+      delete requestParameters.output_config;
+    }
+
+    const thinkingConfig = requestParameters.thinking;
+    const hasThinkingEnabled =
+      thinkingConfig &&
+      typeof thinkingConfig === "object" &&
+      thinkingConfig.type !== "disabled";
+
+    // Anthropic does not allow thinking when tool_choice forces a specific tool.
+    // If tool_choice is set to anything other than "auto", disable thinking.
+    const tc = requestParameters.tool_choice;
+    if (hasThinkingEnabled && tc && typeof tc === "object" && tc.type !== "auto") {
+      requestParameters.thinking = { type: "disabled" };
+      delete requestParameters.output_config;
+    }
+
+    // Anthropic extended/adaptive thinking requires temperature to be exactly 1.
+    if (hasThinkingEnabled && requestParameters.thinking?.type !== "disabled") {
+      requestParameters.temperature = 1;
+    }
+
+    // Opus 4.7+ rejects temperature / top_p / top_k with non-default values (400).
+    // Models that opt out of sampling params get them stripped entirely.
+    if (this.model?.supportsSamplingParameters === false) {
+      delete requestParameters.temperature;
+      delete requestParameters.top_p;
+      delete requestParameters.top_k;
+    }
+
+    // Opus 4.7+ removed extended thinking budgets — { type: "enabled", budget_tokens }
+    // returns 400. Adaptive is the only thinking-on mode. Strip budget_tokens and
+    // promote "enabled" to "adaptive" for models that opt out.
+    if (
+      this.model?.supportsThinkingBudget === false &&
+      requestParameters.thinking &&
+      typeof requestParameters.thinking === "object"
+    ) {
+      delete requestParameters.thinking.budget_tokens;
+      if (requestParameters.thinking.type === "enabled") {
+        requestParameters.thinking.type = "adaptive";
+      }
+    }
+
+    delete requestParameters.reasoningEffort;
+    delete requestParameters.thinkingType;
+    delete requestParameters.thinkingBudgetTokens;
+
+    return requestParameters;
   }
 
   // Override logging to handle document blocks
@@ -466,7 +729,6 @@ class Claude4VertexPlugin extends Claude3VertexPlugin {
     if (system) {
       const { length, units } = this.getLength(system);
       logger.info(`[system messages sent containing ${length} ${units}]`);
-      logger.verbose(`${this.shortenContent(system)}`);
     }
 
     if (messages && messages.length > 1) {
@@ -477,24 +739,21 @@ class Claude4VertexPlugin extends Claude3VertexPlugin {
         let content;
         if (Array.isArray(message.content)) {
           // Only stringify objects, not strings (which may already be JSON strings)
-          content = message.content.map((item) => {
-            if (item.type === 'document') {
-              return `{type: document, source: ${JSON.stringify(sanitizeBase64(item.source))}}`;
-            }
-            const sanitized = sanitizeBase64(item);
-            return typeof sanitized === 'string' ? sanitized : JSON.stringify(sanitized);
-          }).join(", ");
+          content = message.content
+            .map((item) => {
+              if (item.type === "document") {
+                return `{type: document, source: ${JSON.stringify(sanitizeBase64(item.source))}}`;
+              }
+              const sanitized = sanitizeBase64(item);
+              return typeof sanitized === "string"
+                ? sanitized
+                : JSON.stringify(sanitized);
+            })
+            .join(", ");
         } else {
           content = message.content;
         }
         const { length, units } = this.getLength(content);
-        const preview = this.shortenContent(content);
-
-        logger.verbose(
-          `message ${index + 1}: role: ${
-            message.role
-          }, ${units}: ${length}, content: "${preview}"`
-        );
         totalLength += length;
         totalUnits = units;
       });
@@ -504,42 +763,39 @@ class Claude4VertexPlugin extends Claude3VertexPlugin {
       let content;
       if (Array.isArray(message.content)) {
         // Only stringify objects, not strings (which may already be JSON strings)
-        content = message.content.map((item) => {
-          if (item.type === 'document') {
-            return `{type: document, source: ${JSON.stringify(sanitizeBase64(item.source))}}`;
-          }
-          const sanitized = sanitizeBase64(item);
-          return typeof sanitized === 'string' ? sanitized : JSON.stringify(sanitized);
-        }).join(", ");
+        content = message.content
+          .map((item) => {
+            if (item.type === "document") {
+              return `{type: document, source: ${JSON.stringify(sanitizeBase64(item.source))}}`;
+            }
+            const sanitized = sanitizeBase64(item);
+            return typeof sanitized === "string"
+              ? sanitized
+              : JSON.stringify(sanitized);
+          })
+          .join(", ");
       } else {
         content = message.content;
       }
       const { length, units } = this.getLength(content);
       logger.info(`[request sent containing ${length} ${units}]`);
-      logger.verbose(`${this.shortenContent(content)}`);
     }
 
-    if (stream) {
-      logger.info(`[response received as an SSE stream]`);
-    } else {
+    if (!stream) {
       const parsedResponse = this.parseResponse(responseData);
-      
-      if (typeof parsedResponse === 'string') {
-          const { length, units } = this.getLength(parsedResponse);
-          logger.info(`[response received containing ${length} ${units}]`);
-          logger.verbose(`${this.shortenContent(parsedResponse)}`);
+
+      if (typeof parsedResponse === "string") {
+        const { length, units } = this.getLength(parsedResponse);
+        logger.info(`[response received containing ${length} ${units}]`);
       } else {
-          logger.info(`[response received containing object]`);
-          logger.verbose(`${JSON.stringify(parsedResponse)}`);
+        logger.info(`[response received containing object]`);
       }
-  }
+    }
 
     prompt &&
       prompt.debugInfo &&
       (prompt.debugInfo += `\n${JSON.stringify(data)}`);
   }
-
 }
 
 export default Claude4VertexPlugin;
-

--- a/server/plugins/claudeAnthropicPlugin.js
+++ b/server/plugins/claudeAnthropicPlugin.js
@@ -15,11 +15,15 @@ import Claude4VertexPlugin from "./claude4VertexPlugin.js";
  * - Streaming via stream:true in body, not URL suffix
  */
 class ClaudeAnthropicPlugin extends Claude4VertexPlugin {
-  
+
   constructor(pathway, model) {
     super(pathway, model);
   }
-  
+
+  get supportsImageUrls() {
+    return this.model.supportsImageUrls ?? true;
+  }
+
   async getRequestParameters(text, parameters, prompt) {
     // Get base request parameters from parent (includes message conversion)
     const requestParameters = await super.getRequestParameters(

--- a/server/plugins/gemini15ChatPlugin.js
+++ b/server/plugins/gemini15ChatPlugin.js
@@ -188,6 +188,11 @@ class Gemini15ChatPlugin extends ModelPlugin {
                 }
                 logger.warn(`Gemini returned MALFORMED_FUNCTION_CALL with no text content`);
                 return 'I encountered an issue processing that request. Please try rephrasing your question.';
+            } else if (finishReason === 'UNEXPECTED_TOOL_CALL') {
+                const textContent = content?.parts?.find(part => part?.text)?.text;
+                const finishMessage = data.candidates[0].finishMessage || 'Model tried to call an undeclared function';
+                logger.warn(`Gemini returned UNEXPECTED_TOOL_CALL: ${finishMessage}`);
+                return textContent || 'I encountered an issue processing that request. Please try rephrasing your question.';
             } else {
                 const returnString = `Response was not completed.  Finish reason: ${finishReason}, Safety ratings: ${JSON.stringify(safetyRatings, null, 2)}`;
                 throw new Error(returnString);
@@ -321,6 +326,8 @@ class Gemini15ChatPlugin extends ModelPlugin {
         
         if (messages && messages.length > 1) {
             logger.info(`[chat request contains ${messages.length} messages]`);
+            let totalLength = 0;
+            let totalUnits;
             messages.forEach((message, index) => {
                 const messageContent = message.parts.reduce((acc, part) => {
                     if (part.text) {
@@ -333,10 +340,10 @@ class Gemini15ChatPlugin extends ModelPlugin {
                     return acc;
                 } , '');
                 const { length, units } = this.getLength(messageContent);
-                const preview = this.shortenContent(messageContent);
-    
-                logger.verbose(`message ${index + 1}: role: ${message.role}, ${units}: ${length}, content: "${preview}"`);
+                totalLength += length;
+                totalUnits = units;
             });
+            logger.info(`[chat request contained ${totalLength} ${totalUnits}]`);
         } else if (messages && messages.length === 1) {
             const messageContent = messages[0].parts.reduce((acc, part) => {
                 if (part.text) {
@@ -348,23 +355,21 @@ class Gemini15ChatPlugin extends ModelPlugin {
                 }
                 return acc;
             } , '');
-            logger.verbose(`${this.shortenContent(messageContent)}`);
+            const { length, units } = this.getLength(messageContent);
+            logger.info(`[request sent containing ${length} ${units}]`);
         }
 
         // check if responseData is an array or string
         if (typeof responseData === 'string') {
             const { length, units } = this.getLength(responseData);
             logger.info(`[response received containing ${length} ${units}]`);
-            logger.verbose(`${this.shortenContent(responseData)}`);
         } else if (Array.isArray(responseData)) {
             const { mergedResult, safetyRatings } = mergeResults(responseData);
             if (safetyRatings?.length) {
                 logger.warn(`response was blocked because the input or response potentially violates policies`);
-                logger.verbose(`Safety Ratings: ${JSON.stringify(safetyRatings, null, 2)}`);
             }
             const { length, units } = this.getLength(mergedResult);
             logger.info(`[response received containing ${length} ${units}]`);
-            logger.verbose(`${this.shortenContent(mergedResult)}`);
         } else {
             logger.info(`[response received as an SSE stream]`);
         }

--- a/server/plugins/gemini15VisionPlugin.js
+++ b/server/plugins/gemini15VisionPlugin.js
@@ -5,6 +5,46 @@ import { addCitationsToResolver } from '../../lib/pathwayTools.js';
 import logger from '../../lib/logger.js';
 import mime from 'mime-types';
 
+function parseFunctionCallArgs(args) {
+    if (typeof args !== 'string') {
+        return args || {};
+    }
+
+    try {
+        const parsed = JSON.parse(args);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+            ? parsed
+            : { value: parsed };
+    } catch {
+        return {};
+    }
+}
+
+function normalizeGeminiFunctionCallArgs(messages) {
+    if (!Array.isArray(messages)) return messages;
+
+    return messages.map((message) => {
+        if (!Array.isArray(message?.parts)) return message;
+
+        let changed = false;
+        const parts = message.parts.map((part) => {
+            const functionCall = part?.functionCall || part?.function_call;
+            if (!functionCall || typeof functionCall.args !== 'string') return part;
+
+            changed = true;
+            const normalizedPart = { ...part };
+            const key = part.functionCall ? 'functionCall' : 'function_call';
+            normalizedPart[key] = {
+                ...functionCall,
+                args: parseFunctionCallArgs(functionCall.args),
+            };
+            return normalizedPart;
+        });
+
+        return changed ? { ...message, parts } : message;
+    });
+}
+
 class Gemini15VisionPlugin extends Gemini15ChatPlugin {
 
     constructor(pathway, model) {
@@ -14,6 +54,24 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
         this.toolCallsBuffer = [];
         this.contentBuffer = '';
         this.hadToolCalls = false;
+        this._currentResponseId = null;
+    }
+
+    resolveMimeType(fileUrl, explicitMimeType = null, fallback = 'image/jpeg') {
+        if (explicitMimeType) {
+            return explicitMimeType;
+        }
+
+        if (!fileUrl) {
+            return fallback;
+        }
+
+        try {
+            const parsed = new URL(fileUrl);
+            return mime.lookup(parsed.pathname) || mime.lookup(fileUrl) || fallback;
+        } catch (e) {
+            return mime.lookup(fileUrl) || fallback;
+        }
     }
 
     // Override the convertMessagesToGemini method to handle multimodal vision messages
@@ -26,11 +84,11 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
     
         // Check if the messages are already in the Gemini format
         if (messages[0] && Object.prototype.hasOwnProperty.call(messages[0], 'parts')) {
-            modifiedMessages = messages;
+            modifiedMessages = normalizeGeminiFunctionCallArgs(messages);
         } else {
             messages.forEach(message => {
                 const { role, author, content } = message;
-    
+
                 if (role === 'system') {
                     if (Array.isArray(content)) {
                         content.forEach(item => systemParts.push({ text: item }));
@@ -39,15 +97,57 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
                     }
                     return;
                 }
-    
+
+                // Handle assistant messages with tool_calls (OpenAI format → Gemini functionCall)
+                if (role === 'assistant' && message.tool_calls && message.tool_calls.length > 0) {
+                    const parts = [];
+                    // Add any text content first
+                    if (content && typeof content === 'string' && content.trim()) {
+                        parts.push({ text: content });
+                    }
+                    // Convert each tool_call to a Gemini functionCall part
+                    for (const tc of message.tool_calls) {
+                        if (tc?.function?.name) {
+                            let args;
+                            try {
+                                args = typeof tc.function.arguments === 'string'
+                                    ? JSON.parse(tc.function.arguments)
+                                    : (tc.function.arguments || {});
+                            } catch (e) {
+                                args = {};
+                            }
+                            const fcPart = {
+                                functionCall: {
+                                    name: tc.function.name,
+                                    args,
+                                }
+                            };
+                            // Preserve thoughtSignature for Gemini 3+ models
+                            if (tc.thoughtSignature) {
+                                fcPart.thoughtSignature = tc.thoughtSignature;
+                            }
+                            parts.push(fcPart);
+                        }
+                    }
+                    if (parts.length > 0) {
+                        modifiedMessages.push({ role: 'model', parts });
+                        lastAuthor = 'model';
+                    }
+                    return; // Skip normal content processing for this message
+                }
+
                 // Convert content to Gemini format, trying to maintain compatibility
                 const convertPartToGemini = (inputPart) => {
                     try {
                         // First try to parse as JSON if it's a string
                         const part = typeof inputPart === 'string' ? JSON.parse(inputPart) : inputPart;
-                        const {type, text, image_url, gcs, url} = part;
+                        const {type, text, image_url, gcs, url, mimeType, mime_type} = part;
                         // Check for URL in multiple places: gcs, image_url.url, or direct url property
                         let fileUrl = gcs || image_url?.url || url;
+                        const resolvedMimeType = this.resolveMimeType(
+                            fileUrl,
+                            mimeType || mime_type || image_url?.mimeType || image_url?.mime_type,
+                        );
 
                         if (typeof part === 'string') {
                             return { text: inputPart };
@@ -65,7 +165,7 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
                                 }
                                 return {
                                     fileData: {
-                                        mimeType: mime.lookup(fileUrl) || 'image/jpeg',
+                                        mimeType: resolvedMimeType,
                                         fileUri: fileUrl
                                     }
                                 };
@@ -95,7 +195,7 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
                                 // No need to fetch and convert to base64
                                 return {
                                     fileData: {
-                                        mimeType: mime.lookup(fileUrl) || 'image/jpeg',
+                                        mimeType: resolvedMimeType,
                                         fileUri: fileUrl
                                     }
                                 };
@@ -170,6 +270,8 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
             });
         }
     
+        modifiedMessages = normalizeGeminiFunctionCallArgs(modifiedMessages);
+
         // Gemini requires an odd number of messages
         if (modifiedMessages.length % 2 === 0) {
             modifiedMessages = modifiedMessages.slice(1);
@@ -229,6 +331,59 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
         return converted;
     }
 
+    // Strip/normalize JSON Schema fields not accepted by Gemini function declarations
+    sanitizeSchemaForGemini(schema) {
+        if (!schema || typeof schema !== 'object') {
+            return schema;
+        }
+
+        if (Array.isArray(schema)) {
+            return schema.map(item => this.sanitizeSchemaForGemini(item));
+        }
+
+        const cleaned = {};
+
+        for (const [key, value] of Object.entries(schema)) {
+            if (key === '$schema' || key === 'propertyNames') {
+                continue;
+            }
+
+            if (key === 'const') {
+                cleaned.enum = [value];
+                continue;
+            }
+
+            if (key === 'exclusiveMinimum') {
+                cleaned.minimum = value;
+                continue;
+            }
+
+            if (key === 'exclusiveMaximum') {
+                cleaned.maximum = value;
+                continue;
+            }
+
+            // Normalize JSON Schema type arrays into Gemini's Schema shape:
+            // nullable tuples become nullable, and multi-type unions become anyOf.
+            if (key === 'type' && Array.isArray(value)) {
+                const nonNull = value.filter(t => t !== 'null');
+                if (value.length !== nonNull.length) {
+                    cleaned.nullable = true;
+                }
+                if (nonNull.length === 1) {
+                    cleaned.type = nonNull[0];
+                } else if (nonNull.length > 1) {
+                    cleaned.anyOf = nonNull.map(type => ({ type }));
+                }
+                continue;
+            }
+
+            cleaned[key] = this.sanitizeSchemaForGemini(value);
+        }
+
+        return cleaned;
+    }
+
     // Convert OpenAI tools to Gemini format
     convertOpenAIToolsToGemini(openAITools) {
         if (!openAITools || !Array.isArray(openAITools)) {
@@ -245,7 +400,8 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
                 };
                 
                 // Convert numeric enums to string enums for Gemini compatibility
-                const convertedParameters = this.convertEnumToStrings(parameters);
+                const sanitizedParameters = this.sanitizeSchemaForGemini(parameters);
+                const convertedParameters = this.convertEnumToStrings(sanitizedParameters);
                 
                 return {
                     name: tool.function.name,
@@ -381,6 +537,18 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
                 return cortexResponse;
             }
 
+            if (finishReason === 'UNEXPECTED_TOOL_CALL') {
+                const textContent = content?.parts?.find(part => part?.text)?.text || '';
+                const finishMessage = candidate.finishMessage || 'Model tried to call an undeclared function';
+                logger.warn(`Gemini returned UNEXPECTED_TOOL_CALL: ${finishMessage}`);
+                return new CortexResponse({
+                    output_text: textContent || 'I encountered an issue processing that request. Please try rephrasing your question.',
+                    finishReason: "stop",
+                    usage: data.usageMetadata || null,
+                    metadata: { model: this.modelName }
+                });
+            }
+
             // Check for tool calls
             if (content?.parts) {
                 const toolCalls = [];
@@ -442,12 +610,17 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
         requestProgress = requestProgress || {};
         requestProgress.data = requestProgress.data || null;
         
-        // Reset tool calls flag for new stream
-        if (!requestProgress.started) {
+        // Reset state for a genuinely new stream (new responseId = new model response).
+        // Gemini includes a unique responseId in every SSE event of the same response.
+        // Only reset when a NEW responseId is seen, so tool calls accumulate across
+        // events within the same model response (e.g. Gemini 3 Flash sends each
+        // functionCall as a separate SSE event).
+        const responseId = eventData.responseId;
+        if (responseId && responseId !== this._currentResponseId) {
+            this._currentResponseId = responseId;
             this.hadToolCalls = false;
             this.toolCallsBuffer = [];
-            // Don't clear contentBuffer here - it should accumulate across all chunks
-            // this.contentBuffer = '';
+            this.contentBuffer = '';
         }
         
         // Create a helper function to generate message chunks
@@ -580,6 +753,20 @@ class Gemini15VisionPlugin extends Gemini15ChatPlugin {
             }, "stop"));
             requestProgress.progress = 1;
             // Clear buffers
+            this.toolCallsBuffer = [];
+            this.contentBuffer = '';
+            return requestProgress;
+        }
+
+        // Handle UNEXPECTED_TOOL_CALL - model tried to call a function not in the declared tools
+        if (eventData.candidates?.[0]?.finishReason === "UNEXPECTED_TOOL_CALL") {
+            const finishMessage = eventData.candidates[0].finishMessage || 'Model tried to call an undeclared function';
+            logger.warn(`Gemini streaming returned UNEXPECTED_TOOL_CALL: ${finishMessage}`);
+            requestProgress.data = JSON.stringify(createChunk({
+                content: '\n\nI encountered an issue processing that request. Please try rephrasing your question.'
+            }, "stop"));
+            requestProgress.progress = 1;
+            // Clear buffers - don't dispatch the invalid tool call
             this.toolCallsBuffer = [];
             this.contentBuffer = '';
             return requestProgress;

--- a/server/plugins/gemini25ImagePlugin.js
+++ b/server/plugins/gemini25ImagePlugin.js
@@ -49,15 +49,23 @@ class Gemini25ImagePlugin extends Gemini15VisionPlugin {
                 const parts = data.candidates[0].content.parts;
                 let imageContent = [];
 
+                let skippedThoughtImages = 0;
                 for (const part of parts) {
                     if (part.inlineData) {
-                        // Handle generated image content
+                        if (part.thought) {
+                            skippedThoughtImages++;
+                            continue;
+                        }
                         imageContent.push({
                             type: "image",
                             data: part.inlineData.data,
                             mimeType: part.inlineData.mimeType
                         });
                     }
+                }
+
+                if (skippedThoughtImages > 0) {
+                    logger.info(`[skipped ${skippedThoughtImages} image artifact(s) from thinking phase]`);
                 }
 
                 // If we have image artifacts, add them to the existing CortexResponse
@@ -75,9 +83,13 @@ class Gemini25ImagePlugin extends Gemini15VisionPlugin {
             let imageContent = [];
             let textContent = '';
 
+            let skippedThoughtImages = 0;
             for (const part of parts) {
                 if (part.inlineData) {
-                    // Handle generated image content
+                    if (part.thought) {
+                        skippedThoughtImages++;
+                        continue;
+                    }
                     imageContent.push({
                         type: "image",
                         data: part.inlineData.data,
@@ -86,6 +98,10 @@ class Gemini25ImagePlugin extends Gemini15VisionPlugin {
                 } else if (part.text) {
                     textContent += part.text;
                 }
+            }
+
+            if (skippedThoughtImages > 0) {
+                logger.info(`[skipped ${skippedThoughtImages} image artifact(s) from thinking phase]`);
             }
 
             // If we have image artifacts, create a new CortexResponse object
@@ -114,9 +130,10 @@ class Gemini25ImagePlugin extends Gemini15VisionPlugin {
             
             for (const part of parts) {
                 if (part.inlineData) {
-                    // Handle generated image content in streaming
-                    // For now, we'll accumulate images and send them at the end
-                    // This could be enhanced to stream image data if needed
+                    if (part.thought) {
+                        logger.info(`[skipped streaming image artifact from thinking phase]`);
+                        continue;
+                    }
                     if (!requestProgress.artifacts) {
                         requestProgress.artifacts = [];
                     }
@@ -142,7 +159,6 @@ class Gemini25ImagePlugin extends Gemini15VisionPlugin {
             if (responseData.artifacts && responseData.artifacts.length > 0) {
                 logger.info(`[response contains ${responseData.artifacts.length} image artifact(s)]`);
             }
-            logger.verbose(`${this.shortenContent(responseData.output_text || '')}`);
             return;
         }
 

--- a/server/plugins/gemini3ReasoningVisionPlugin.js
+++ b/server/plugins/gemini3ReasoningVisionPlugin.js
@@ -113,7 +113,11 @@ class Gemini3ReasoningVisionPlugin extends Gemini3ImagePlugin {
                     if (responseData?.content !== undefined) {
                         const contentStr = responseData.content;
                         try {
-                            responseData = JSON.parse(contentStr);
+                            const parsed = JSON.parse(contentStr);
+                            // Gemini 3 requires response to be a Struct (plain object), not an array, null, or primitive
+                            // Ref: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/Content
+                            responseData = (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
+                                ? { result: parsed } : parsed;
                         } catch (e) {
                             responseData = { output: contentStr };
                         }
@@ -141,18 +145,19 @@ class Gemini3ReasoningVisionPlugin extends Gemini3ImagePlugin {
         let thinkingLevel = parameters?.thinkingLevel ?? parameters?.thinking_level;
         let includeThoughts = parameters?.includeThoughts ?? parameters?.include_thoughts ?? false;
 
-        // Convert OpenAI reasoningEffort to Gemini 3 thinkingLevel
-        // OpenAI supports: 'high', 'medium', 'low', 'none'
-        // Gemini 3 supports: 'high' or 'low' (thinking cannot be disabled)
-        // Mapping: 'high' or 'medium' → 'high', 'low' or 'minimal' → 'low', 'none' → 'low'
+        // Convert reasoningEffort to Gemini 3 thinkingLevel using the model's
+        // reasoningEffortMap from config (same pattern as OpenAI reasoning plugins).
+        // Flash map: none→minimal, low→low, medium→medium, high→high
+        // Pro map:   none→low, low→low, medium→high, high→high (no minimal/medium support)
         const reasoningEffort = parameters?.reasoningEffort ?? this.promptParameters?.reasoningEffort;
         if (reasoningEffort && thinkingLevel === undefined) {
             const effort = typeof reasoningEffort === 'string' ? reasoningEffort.toLowerCase() : String(reasoningEffort).toLowerCase();
-            if (effort === 'high' || effort === 'medium') {
-                // High or medium reasoning effort → high thinking level
-                thinkingLevel = 'high';
+            const effortMap = this.model.reasoningEffortMap;
+            if (effortMap && effortMap[effort]) {
+                thinkingLevel = effortMap[effort];
+            } else if (['minimal', 'low', 'medium', 'high'].includes(effort)) {
+                thinkingLevel = effort;
             } else {
-                // Low, minimal, or none → low thinking level (Gemini 3 doesn't support disabling thinking)
                 thinkingLevel = 'low';
             }
         }
@@ -163,12 +168,14 @@ class Gemini3ReasoningVisionPlugin extends Gemini3ImagePlugin {
         } else if (thinkingLevel === undefined && cortexRequest?.pathway?.thinking_level !== undefined) {
             thinkingLevel = cortexRequest.pathway.thinking_level;
         } else if (thinkingLevel === undefined && cortexRequest?.pathway?.reasoningEffort !== undefined) {
-            // Also check pathway for reasoningEffort
-            const pathwayEffort = typeof cortexRequest.pathway.reasoningEffort === 'string' 
-                ? cortexRequest.pathway.reasoningEffort.toLowerCase() 
+            const pathwayEffort = typeof cortexRequest.pathway.reasoningEffort === 'string'
+                ? cortexRequest.pathway.reasoningEffort.toLowerCase()
                 : String(cortexRequest.pathway.reasoningEffort).toLowerCase();
-            if (pathwayEffort === 'high' || pathwayEffort === 'medium') {
-                thinkingLevel = 'high';
+            const effortMap = this.model.reasoningEffortMap;
+            if (effortMap && effortMap[pathwayEffort]) {
+                thinkingLevel = effortMap[pathwayEffort];
+            } else if (['minimal', 'low', 'medium', 'high'].includes(pathwayEffort)) {
+                thinkingLevel = pathwayEffort;
             } else {
                 thinkingLevel = 'low';
             }
@@ -186,16 +193,11 @@ class Gemini3ReasoningVisionPlugin extends Gemini3ImagePlugin {
                 baseParameters.generationConfig.thinkingConfig = {};
             }
             
-            // Gemini 3 uses thinkingLevel: 'low' or 'high'
+            // Set thinkingLevel — valid values depend on model (configured via reasoningEffortMap)
             if (thinkingLevel !== undefined) {
                 const level = typeof thinkingLevel === 'string' ? thinkingLevel.toLowerCase() : String(thinkingLevel).toLowerCase();
-                // Validate and set thinkingLevel (only 'low' or 'high' are valid)
-                if (level === 'low' || level === 'high') {
-                    baseParameters.generationConfig.thinkingConfig.thinkingLevel = level;
-                } else {
-                    // Default to 'low' if invalid value
-                    baseParameters.generationConfig.thinkingConfig.thinkingLevel = 'low';
-                }
+                const validLevels = ['minimal', 'low', 'medium', 'high'];
+                baseParameters.generationConfig.thinkingConfig.thinkingLevel = validLevels.includes(level) ? level : 'low';
             }
             
             // includeThoughts: true to get thought summaries
@@ -292,16 +294,12 @@ class Gemini3ReasoningVisionPlugin extends Gemini3ImagePlugin {
             
             if (responseData.thoughts && responseData.thoughts.length > 0) {
                 logger.info(`[response contains ${responseData.thoughts.length} thought summary(ies)]`);
-                responseData.thoughts.forEach((thought, index) => {
-                    logger.verbose(`[thought ${index + 1}]: ${this.shortenContent(thought)}`);
-                });
             }
             
             if (responseData.artifacts && responseData.artifacts.length > 0) {
                 logger.info(`[response contains ${responseData.artifacts.length} image artifact(s)]`);
             }
             
-            logger.verbose(`${this.shortenContent(responseData.output_text || '')}`);
             return;
         }
 
@@ -312,4 +310,3 @@ class Gemini3ReasoningVisionPlugin extends Gemini3ImagePlugin {
 }
 
 export default Gemini3ReasoningVisionPlugin;
-

--- a/server/plugins/geminiChatPlugin.js
+++ b/server/plugins/geminiChatPlugin.js
@@ -170,6 +170,8 @@ class GeminiChatPlugin extends ModelPlugin {
         
         if (messages && messages.length > 1) {
             logger.info(`[chat request contains ${messages.length} messages]`);
+            let totalLength = 0;
+            let totalUnits;
             messages.forEach((message, index) => {
                 const messageContent = message.parts.reduce((acc, part) => {
                     if (part.text) {
@@ -177,30 +179,28 @@ class GeminiChatPlugin extends ModelPlugin {
                     }
                     return acc;
                 } , '');
-                const words = messageContent.split(" ");
                 const { length, units } = this.getLength(messageContent);
-                const preview = words.length < 41 ? messageContent : words.slice(0, 20).join(" ") + " ... " + words.slice(-20).join(" ");
-    
-                logger.verbose(`message ${index + 1}: role: ${message.role}, ${units}: ${length}, content: "${preview}"`);
+                totalLength += length;
+                totalUnits = units;
             });
+            logger.info(`[chat request contained ${totalLength} ${totalUnits}]`);
         } else if (messages && messages.length === 1) {
-            logger.verbose(`${messages[0].parts[0].text}`);
+            const messageContent = messages[0].parts.reduce((acc, part) => part.text ? acc + part.text : acc, '');
+            const { length, units } = this.getLength(messageContent);
+            logger.info(`[request sent containing ${length} ${units}]`);
         }
 
         // check if responseData is an array or string
         if (typeof responseData === 'string') {
             const { length, units } = this.getLength(responseData);
             logger.info(`[response received containing ${length} ${units}]`);
-            logger.verbose(`${responseData}`);
         } else if (Array.isArray(responseData)) {
             const { mergedResult, safetyRatings } = mergeResults(responseData);
             if (safetyRatings?.length) {
                 logger.warn(`response was blocked because the input or response potentially violates policies`);
-                logger.verbose(`Safety Ratings: ${JSON.stringify(safetyRatings, null, 2)}`);
             }
             const { length, units } = this.getLength(mergedResult);
             logger.info(`[response received containing ${length} ${units}]`);
-            logger.verbose(`${mergedResult}`);
         } else {
             logger.info(`[response received as an SSE stream]`);
         }

--- a/server/plugins/geminiVisionPlugin.js
+++ b/server/plugins/geminiVisionPlugin.js
@@ -7,6 +7,23 @@ class GeminiVisionPlugin extends GeminiChatPlugin {
         super(pathway, model);
         this.isMultiModal = true;
     }
+
+    resolveMimeType(fileUrl, explicitMimeType = null, fallback = 'image/jpeg') {
+        if (explicitMimeType) {
+            return explicitMimeType;
+        }
+
+        if (!fileUrl) {
+            return fallback;
+        }
+
+        try {
+            const parsed = new URL(fileUrl);
+            return mime.lookup(parsed.pathname) || mime.lookup(fileUrl) || fallback;
+        } catch (e) {
+            return mime.lookup(fileUrl) || fallback;
+        }
+    }
     
     // Override the convertMessagesToGemini method to handle multimodal vision messages
     // This function can operate on messages in Gemini native format or in OpenAI's format
@@ -27,8 +44,12 @@ class GeminiVisionPlugin extends GeminiChatPlugin {
                 const convertPartToGemini = (inputPart) => {
                     try {
                         const part = typeof inputPart === 'string' ? JSON.parse(inputPart) : inputPart;
-                        const {type, text, image_url, gcs} = part;
-                        let fileUrl = gcs || image_url?.url;
+                        const {type, text, image_url, gcs, url, mimeType, mime_type} = part;
+                        let fileUrl = gcs || image_url?.url || url;
+                        const resolvedMimeType = this.resolveMimeType(
+                            fileUrl,
+                            mimeType || mime_type || image_url?.mimeType || image_url?.mime_type,
+                        );
 
                         if (typeof part === 'string') {
                             return { text: text };
@@ -38,7 +59,7 @@ class GeminiVisionPlugin extends GeminiChatPlugin {
                             if (fileUrl.startsWith('gs://')) {
                                 return {
                                     fileData: {
-                                        mimeType: mime.lookup(fileUrl) || 'image/jpeg',
+                                        mimeType: resolvedMimeType,
                                         fileUri: fileUrl
                                     }
                                 };

--- a/server/plugins/grokVisionPlugin.js
+++ b/server/plugins/grokVisionPlugin.js
@@ -42,16 +42,6 @@ class GrokVisionPlugin extends OpenAIVisionPlugin {
                     content = message.content;
                 }
                 const { length, units } = this.getLength(content);
-                const displayContent = this.shortenContent(content);
-
-                let logMessage = `message ${index + 1}: role: ${message.role}, ${units}: ${length}, content: "${displayContent}"`;
-                
-                // Add tool calls to log if they exist
-                if (message.role === 'assistant' && message.tool_calls) {
-                    logMessage += `, tool_calls: ${JSON.stringify(message.tool_calls)}`;
-                }
-                
-                logger.verbose(logMessage);
                 totalLength += length;
                 totalUnits = units;
             });
@@ -70,20 +60,15 @@ class GrokVisionPlugin extends OpenAIVisionPlugin {
             }
             const { length, units } = this.getLength(content);
             logger.info(`[grok request sent containing ${length} ${units}]`);
-            logger.verbose(`${this.shortenContent(content)}`);
         }
-        if (stream) {
-            logger.info(`[grok response received as an SSE stream]`);
-        } else {
+        if (!stream) {
             const parsedResponse = this.parseResponse(responseData);
             
             if (typeof parsedResponse === 'string') {
                 const { length, units } = this.getLength(parsedResponse);
                 logger.info(`[grok response received containing ${length} ${units}]`);
-                logger.verbose(`${this.shortenContent(parsedResponse)}`);
             } else {
                 logger.info(`[grok response received containing object]`);
-                logger.verbose(`${JSON.stringify(parsedResponse)}`);
             }
         }
 
@@ -235,6 +220,15 @@ class GrokVisionPlugin extends OpenAIVisionPlugin {
             requestParameters.search_parameters = search_parameters;
         }
 
+        const reasoningEffort = parameters.reasoningEffort || this.promptParameters.reasoningEffort;
+        if (reasoningEffort) {
+            const effort = String(reasoningEffort).toLowerCase();
+            const effortMap = this.model.reasoningEffortMap;
+            if (effortMap && effortMap[effort]) {
+                requestParameters.reasoning_effort = effortMap[effort];
+            }
+        }
+
         return requestParameters;
     }
 
@@ -367,4 +361,4 @@ class GrokVisionPlugin extends OpenAIVisionPlugin {
 
 }
 
-export default GrokVisionPlugin; 
+export default GrokVisionPlugin;

--- a/server/plugins/groqChatPlugin.js
+++ b/server/plugins/groqChatPlugin.js
@@ -96,8 +96,10 @@ class GroqChatPlugin extends ModelPlugin {
         const modelInput = userMessage ? userMessage.content : JSON.stringify(data.messages);
         const modelOutput = this.parseResponse(responseData);
         
-        logger.verbose(`Input: ${modelInput}`);
-        logger.verbose(`Output: ${modelOutput}`);
+        const requestLength = this.getLength(modelInput || '');
+        logger.info(`[Groq chat request sent containing ${requestLength.length} ${requestLength.units}]`);
+        const responseLength = this.getLength(modelOutput || '');
+        logger.info(`[Groq chat response received containing ${responseLength.length} ${responseLength.units}]`);
         
         if (prompt?.debugInfo) {
             prompt.debugInfo += `\nInput: ${modelInput}\nOutput: ${modelOutput}`;

--- a/server/plugins/localModelPlugin.js
+++ b/server/plugins/localModelPlugin.js
@@ -55,13 +55,12 @@ class LocalModelPlugin extends ModelPlugin {
         //args.push("--temperature", requestParameters.temperature);
 
         try {
-            logger.verbose(`Running local model: ${executablePath}, ${args}`);
+            logger.info(`[running local model: ${executablePath}]`);
             const result = execFileSync(executablePath, args, { encoding: 'utf8' });
             // Remove only the first occurrence of requestParameters.prompt from the result
             // Could have used regex here but then would need to escape the prompt
             const parts = result.split(requestParameters.prompt, 2);
             const modifiedResult = parts[0] + parts[1];
-            logger.verbose(`Result: ${modifiedResult}`);
             return this.filterFirstResponse(modifiedResult);
         } catch (error) {
             logger.error(`Error running local model: ${error}`);

--- a/server/plugins/ollamaChatPlugin.js
+++ b/server/plugins/ollamaChatPlugin.js
@@ -26,11 +26,7 @@ class OllamaChatPlugin extends ModelPlugin {
       messages.forEach((message, index) => {
         const content = message.content;
         const { length, units } = this.getLength(content);
-        const preview = this.shortenContent(content);
 
-        logger.verbose(
-          `message ${index + 1}: role: ${message.role}, ${units}: ${length}, content: "${preview}"`
-        );
         totalLength += length;
         totalUnits = units;
       });
@@ -43,7 +39,6 @@ class OllamaChatPlugin extends ModelPlugin {
       const responseText = this.parseResponse(responseData);
       const { length, units } = this.getLength(responseText);
       logger.info(`[response received containing ${length} ${units}]`);
-      logger.verbose(`${this.shortenContent(responseText)}`);
     }
 
     prompt &&

--- a/server/plugins/ollamaCompletionPlugin.js
+++ b/server/plugins/ollamaCompletionPlugin.js
@@ -21,8 +21,6 @@ class OllamaCompletionPlugin extends ModelPlugin {
     if (promptText) {
       logger.info(`[ollama completion request sent to model ${model}]`);
       const { length, units } = this.getLength(promptText);
-      const preview = this.shortenContent(promptText);
-      logger.verbose(`prompt ${units}: ${length}, content: "${preview}"`);
       logger.info(`[completion request contained ${length} ${units}]`);
     }
 
@@ -32,7 +30,6 @@ class OllamaCompletionPlugin extends ModelPlugin {
       const responseText = this.parseResponse(responseData);
       const { length, units } = this.getLength(responseText);
       logger.info(`[response received containing ${length} ${units}]`);
-      logger.verbose(`${this.shortenContent(responseText)}`);
     }
 
     prompt &&

--- a/server/plugins/openAiChatExtensionPlugin.js
+++ b/server/plugins/openAiChatExtensionPlugin.js
@@ -1,6 +1,16 @@
 // OpenAIChatPlugin.js
 import OpenAIChatPlugin from './openAiChatPlugin.js';
 
+const normalizeValue = (value) => {
+    if (!value || typeof value !== 'string') return '';
+    return value.trim().replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
+};
+
+const normalizeEndpoint = (value) => {
+    const normalized = normalizeValue(value);
+    return normalized ? normalized.replace(/\/+$/, '') : '';
+};
+
 class OpenAIChatExtensionPlugin extends OpenAIChatPlugin {
     constructor(pathway, model) {
         super(pathway, model);
@@ -43,6 +53,14 @@ class OpenAIChatExtensionPlugin extends OpenAIChatPlugin {
             indexName && (dataSource.parameters.indexName = indexName);
             semanticConfiguration && (dataSource.parameters.semanticConfiguration = semanticConfiguration);
             dataSource.parameters.queryType = semanticConfiguration ? 'semantic' : 'simple';
+
+            if (dataSource.type === 'AzureCognitiveSearch') {
+                const resolvedIndex = dataSource.parameters.indexName || indexName || '';
+                if (typeof resolvedIndex === 'string' && resolvedIndex.startsWith('idx-')) {
+                    dataSource.parameters.endpoint = normalizeEndpoint(process.env.AZURE_COGNITIVE_API_URL_QA);
+                    dataSource.parameters.key = normalizeValue(process.env.AZURE_COGNITIVE_API_KEY_QA);
+                }
+            }
         }
         return reqParams;
     }

--- a/server/plugins/openAiChatPlugin.js
+++ b/server/plugins/openAiChatPlugin.js
@@ -83,6 +83,22 @@ class OpenAIChatPlugin extends ModelPlugin {
         ...(tools && tools.length > 0 ? { tools, tool_choice: parameters.tool_choice || 'auto' } : {}),
         ...(functions && functions.length > 0 ? { functions } : {}),
         };
+
+        if (stream === true && [
+            'OPENAI-CHAT',
+            'OPENAI-CHAT-EXTENSION',
+            'OPENAI-VISION',
+            'OPENAI-REASONING',
+            'OPENAI-REASONING-VISION',
+        ].includes(this.model?.type)) {
+            requestParameters.stream_options = {
+                ...(this.promptParameters?.stream_options || {}),
+                ...(parameters.stream_options || {}),
+                include_usage: parameters.stream_options?.include_usage ?? this.promptParameters?.stream_options?.include_usage ?? true,
+            };
+        }
+
+        this.expectStreamUsage = Boolean(requestParameters.stream_options?.include_usage);
     
         return requestParameters;
     }
@@ -184,7 +200,6 @@ class OpenAIChatPlugin extends ModelPlugin {
                         requestProgress.progress = 1;
                         break;
                     default:
-                        requestProgress.progress = 1;
                         break;
                 }
             }
@@ -205,9 +220,7 @@ class OpenAIChatPlugin extends ModelPlugin {
                     return JSON.stringify(item);
                 }).join(', ') : message.content);
                 const { length, units } = this.getLength(content);
-                const displayContent = this.shortenContent(content);
 
-                logger.verbose(`message ${index + 1}: role: ${message.role}, ${units}: ${length}, content: "${displayContent}"`);
                 totalLength += length;
                 totalUnits = units;
             });
@@ -219,19 +232,14 @@ class OpenAIChatPlugin extends ModelPlugin {
             }).join(', ') : message.content;
             const { length, units } = this.getLength(content);
             logger.info(`[request sent containing ${length} ${units}]`);
-            logger.verbose(`${this.shortenContent(content)}`);
         }
     
-        if (stream) {
-            logger.info(`[response received as an SSE stream]`);
-        } else {           
+        if (!stream) {
             if (typeof responseData === 'string') {
                 const { length, units } = this.getLength(responseData);
                 logger.info(`[response received containing ${length} ${units}]`);
-                logger.verbose(`${this.shortenContent(responseData)}`);
             } else {
                 logger.info(`[response received containing object]`);
-                logger.verbose(`${JSON.stringify(responseData)}`);
             }
         }
 

--- a/server/plugins/openAiCompletionPlugin.js
+++ b/server/plugins/openAiCompletionPlugin.js
@@ -110,7 +110,6 @@ class OpenAICompletionPlugin extends ModelPlugin {
         const { length, units } = this.getLength(modelInput);
 
         logger.info(`[request sent containing ${length} ${units}]`);
-        logger.verbose(`${modelInput}`);
 
         if (stream) {
             logger.info(`[response received as an SSE stream]`);
@@ -118,7 +117,6 @@ class OpenAICompletionPlugin extends ModelPlugin {
             const responseText = this.parseResponse(responseData);
             const { length, units } = this.getLength(responseText);
             logger.info(`[response received containing ${length} ${units}]`);
-            logger.verbose(`${responseText}`);
         }
     
         prompt && prompt.debugInfo && (prompt.debugInfo += `\n${JSON.stringify(data)}`);
@@ -126,4 +124,3 @@ class OpenAICompletionPlugin extends ModelPlugin {
 }
 
 export default OpenAICompletionPlugin;
-

--- a/server/plugins/openAiDallE3Plugin.js
+++ b/server/plugins/openAiDallE3Plugin.js
@@ -1,8 +1,73 @@
 import RequestMonitor from '../../lib/requestMonitor.js';
 import ModelPlugin from './modelPlugin.js';
 import { publishRequestProgress } from '../../lib/redisSubscription.js';
+import FormData from 'form-data';
+import axios from 'axios';
+import logger from '../../lib/logger.js';
 
 const requestDurationEstimator = new RequestMonitor(10);
+
+// Azure /images/generations + /images/edits scalar body params we forward
+// when set. Single source of truth so the JSON and multipart paths stay aligned.
+const AZURE_IMAGE_BODY_PARAMS = [
+    'n', 'size', 'quality', 'output_format', 'output_compression',
+    'background', 'moderation', 'style', 'response_format', 'stream',
+    'partial_images',
+];
+
+// Field name for the Nth input image (i is 0-based). Matches the convention
+// the cortex media pathways use elsewhere (image_gemini_31, image_qwen, …).
+const inputImageKey = (i) => i === 0 ? 'input_image' : `input_image_${i + 1}`;
+
+// Collect non-empty input_image[, input_image_2, …, input_image_10] into an
+// ordered URL/data: URI list.
+function collectInputImages(parameters) {
+    return Array.from({ length: 10 }, (_, i) => parameters?.[inputImageKey(i)])
+        .filter(Boolean);
+}
+
+// Append every set scalar body param onto a target { append(k, v) } sink.
+// Works for both a plain object (JSON body) and a FormData instance.
+function appendScalarBodyParams(target, parameters) {
+    for (const key of AZURE_IMAGE_BODY_PARAMS) {
+        const v = parameters?.[key];
+        if (v === undefined || v === null || v === '') continue;
+        target.append
+            ? target.append(key, String(v))
+            : (target[key] = v);
+    }
+}
+
+// Fetch a URL or decode a data: URI into a { buffer, contentType, filename }.
+async function fetchImageAsPart(src, index) {
+    if (typeof src !== 'string' || !src) {
+        throw new Error('input image must be a non-empty string');
+    }
+    if (src.startsWith('data:')) {
+        // data:<mime>(;<param>=<value>)*;base64,<payload>
+        // — accept zero or more optional ;param= segments between mime and ;base64,
+        const m = src.match(/^data:([^;,]+)[^,]*;base64,(.*)$/);
+        if (!m) throw new Error('malformed data: URI for input image');
+        const contentType = m[1] || 'image/png';
+        return {
+            buffer: Buffer.from(m[2], 'base64'),
+            contentType,
+            filename: `input_${index}.${contentType.split('/')[1] || 'png'}`,
+        };
+    }
+    const resp = await axios.get(src, {
+        responseType: 'arraybuffer',
+        maxContentLength: 50 * 1024 * 1024, // Azure caps each input image at 50 MB
+        timeout: 30000,
+    });
+    const contentType = (resp.headers['content-type'] || 'image/png').split(';')[0];
+    const ext = contentType.split('/')[1] || 'png';
+    return {
+        buffer: Buffer.from(resp.data),
+        contentType,
+        filename: `input_${index}.${ext}`,
+    };
+}
 
 /**
  * @description This plugin is for the OpenAI DALL-E 3 model.
@@ -19,22 +84,76 @@ class OpenAIDallE3Plugin extends ModelPlugin {
      */
 
     async execute(text, parameters, _, cortexRequest) {
-        const { pathwayResolver } = cortexRequest;
-        cortexRequest.data = JSON.stringify({ prompt: text });
+        const inputImages = collectInputImages(parameters);
+        const isEdit = inputImages.length > 0;
 
-        const { requestId } = pathwayResolver;
+        // /images/generations JSON body. For the edit path the multipart
+        // body is built inside #executeEditRequest; we still set this for
+        // consistent request logging.
+        const body = { prompt: text };
+        if (!isEdit) appendScalarBodyParams(body, parameters);
+        cortexRequest.data = JSON.stringify(body);
 
-        const makeRequest = () => this.executeRequest(cortexRequest);
+        const makeRequest = () => isEdit
+            ? this.#executeEditRequest(text, parameters, cortexRequest, inputImages)
+            : this.executeRequest(cortexRequest);
 
-        if (!parameters.async) {
-            // synchronous request
-            return await makeRequest();
-        }
-        else {
-            // async request
-            const callid = requestDurationEstimator.startCall();
-            const requestPromise = makeRequest();
-            this.#sendRequestUpdates(requestId, requestPromise, callid);
+        if (!parameters.async) return await makeRequest();
+        // async — keep the request open and stream progress updates over the websocket
+        const callid = requestDurationEstimator.startCall();
+        this.#sendRequestUpdates(cortexRequest.pathwayResolver.requestId, makeRequest(), callid);
+    }
+
+    /**
+     * Issues a multipart/form-data POST to the Azure /images/edits endpoint.
+     * Bypasses the standard executeRequest pipeline because the framework's
+     * cortexRequest path locks Content-Type to application/json from the
+     * model config — multipart needs axios to set the boundary itself.
+     */
+    async #executeEditRequest(text, parameters, cortexRequest, inputImages) {
+        const generationsUrl = cortexRequest.url;
+        // The /images/edits endpoint requires api-version >= 2025-04-01-preview
+        // for the gpt-image-1 series (gpt-image-2 included). The /images/generations
+        // path can stay on the older 2024-02-01 (DALL-E 3 era) value.
+        const editsUrl = generationsUrl
+            .replace('/images/generations', '/images/edits')
+            .replace(/api-version=[^&]+/, 'api-version=2025-04-01-preview');
+
+        const headers = { ...cortexRequest.headers };
+        delete headers['Content-Type'];
+        delete headers['content-type'];
+
+        const form = new FormData();
+        form.append('prompt', text);
+
+        const appendImagePart = (field, src, idx) =>
+            fetchImageAsPart(src, idx).then((p) =>
+                form.append(field, p.buffer, { filename: p.filename, contentType: p.contentType }),
+            );
+
+        await Promise.all([
+            ...inputImages.map((src, i) => appendImagePart('image[]', src, i + 1)),
+            parameters?.mask ? appendImagePart('mask', parameters.mask, 'mask') : null,
+        ].filter(Boolean));
+
+        appendScalarBodyParams(form, parameters);
+
+        logger.info(`[${cortexRequest.requestId}: ${cortexRequest.pathway?.name}] image edit request to ${editsUrl} (${inputImages.length} input image(s))`);
+
+        try {
+            const response = await axios.post(editsUrl, form, {
+                headers: { ...headers, ...form.getHeaders() },
+                timeout: ((cortexRequest.pathway?.timeout) || 600) * 1000,
+                maxBodyLength: Infinity,
+                maxContentLength: Infinity,
+            });
+            return response.data;
+        } catch (error) {
+            const status = error?.response?.status;
+            const data = error?.response?.data;
+            const message = data?.error?.message || error.message;
+            logger.error(`Image edit request failed (${status || 'no status'}): ${message}`);
+            throw new Error(`Execution failed for ${cortexRequest.pathway?.name}: ${message}`);
         }
     }
 

--- a/server/plugins/openAiReasoningPlugin.js
+++ b/server/plugins/openAiReasoningPlugin.js
@@ -59,7 +59,10 @@ class OpenAIReasoningPlugin extends OpenAIChatPlugin {
         const reasoningEffort = parameters.reasoningEffort || this.promptParameters.reasoningEffort;
         if (reasoningEffort) {
             const effort = reasoningEffort.toLowerCase();
-            if (['high', 'medium', 'low'].includes(effort)) {
+            const effortMap = this.model.reasoningEffortMap;
+            if (effortMap && effortMap[effort]) {
+                requestParameters.reasoning_effort = effortMap[effort];
+            } else if (['low', 'medium', 'high'].includes(effort)) {
                 requestParameters.reasoning_effort = effort;
             } else {
                 requestParameters.reasoning_effort = 'low';

--- a/server/plugins/openAiReasoningVisionPlugin.js
+++ b/server/plugins/openAiReasoningVisionPlugin.js
@@ -32,7 +32,10 @@ class OpenAIReasoningVisionPlugin extends OpenAIVisionPlugin {
         const reasoningEffort = parameters.reasoningEffort || this.promptParameters.reasoningEffort;
         if (reasoningEffort) {
             const effort = reasoningEffort.toLowerCase();
-            if (['high', 'medium', 'low', 'none'].includes(effort)) {
+            const effortMap = this.model.reasoningEffortMap;
+            if (effortMap && effortMap[effort]) {
+                requestParameters.reasoning_effort = effortMap[effort];
+            } else if (['none', 'low', 'medium', 'high', 'xhigh'].includes(effort)) {
                 requestParameters.reasoning_effort = effort;
             } else {
                 requestParameters.reasoning_effort = 'low';

--- a/server/plugins/openAiVisionPlugin.js
+++ b/server/plugins/openAiVisionPlugin.js
@@ -172,16 +172,6 @@ class OpenAIVisionPlugin extends OpenAIChatPlugin {
                     content = message.content;
                 }
                 const { length, units } = this.getLength(content);
-                const displayContent = this.shortenContent(content);
-
-                let logMessage = `message ${index + 1}: role: ${message.role}, ${units}: ${length}, content: "${displayContent}"`;
-                
-                // Add tool calls to log if they exist
-                if (message.role === 'assistant' && message.tool_calls) {
-                    logMessage += `, tool_calls: ${JSON.stringify(message.tool_calls)}`;
-                }
-                
-                logger.verbose(logMessage);
                 totalLength += length;
                 totalUnits = units;
             });
@@ -200,18 +190,13 @@ class OpenAIVisionPlugin extends OpenAIChatPlugin {
             }
             const { length, units } = this.getLength(content);
             logger.info(`[request sent containing ${length} ${units}]`);
-            logger.verbose(`${this.shortenContent(content)}`);
         }
-        if (stream) {
-            logger.info(`[response received as an SSE stream]`);
-        } else {           
+        if (!stream) {
             if (typeof responseData === 'string') {
                 const { length, units } = this.getLength(responseData);
                 logger.info(`[response received containing ${length} ${units}]`);
-                logger.verbose(`${this.shortenContent(responseData)}`);
             } else {
                 logger.info(`[response received containing object]`);
-                logger.verbose(`${JSON.stringify(responseData)}`);
             }
         }
 
@@ -369,6 +354,7 @@ class OpenAIVisionPlugin extends OpenAIChatPlugin {
                 switch (finishReason.toLowerCase()) {
                     case 'tool_calls':
                         // Process complete tool calls when we get the finish reason
+                        let invokedToolCallback = false;
                         if (this.pathwayToolCallback && this.toolCallsBuffer.length > 0 && pathwayResolver) {
                             // Filter out undefined elements from the tool calls buffer
                             const validToolCalls = this.toolCallsBuffer.filter(tc => tc && tc.function && tc.function.name);
@@ -380,8 +366,12 @@ class OpenAIVisionPlugin extends OpenAIChatPlugin {
                             this.pathwayToolCallback(pathwayResolver?.args, toolMessage, pathwayResolver);
                             // Signal to pathwayResolver that tool callback was invoked - prevents [DONE] from ending stream
                             requestProgress.toolCallbackInvoked = true;
+                            invokedToolCallback = true;
                         }
-                        // Don't set progress to 1 for tool calls to keep stream open
+                        // If no server-side tool callback is handling this, close the stream
+                        if (!invokedToolCallback) {
+                            requestProgress.progress = 1;
+                        }
                         // Clear tool buffer after processing, but keep content buffer
                         this.toolCallsBuffer = [];
                         break;
@@ -397,7 +387,6 @@ class OpenAIVisionPlugin extends OpenAIChatPlugin {
                     default: // Includes 'stop' and other normal finish reasons
                         // Look to see if we need to add citations to the response
                         addCitationsToResolver(pathwayResolver, this.contentBuffer);
-                        requestProgress.progress = 1;
                         // Clear buffers on finish
                         this.toolCallsBuffer = [];
                         this.contentBuffer = '';

--- a/tests/unit/plugins.streaming/plugin_stream_events.test.js
+++ b/tests/unit/plugins.streaming/plugin_stream_events.test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { PathwayResolver } from '../../../server/pathwayResolver.js';
 import OpenAIChatPlugin from '../../../server/plugins/openAiChatPlugin.js';
+import OpenAIVisionPlugin from '../../../server/plugins/openAiVisionPlugin.js';
 import GeminiChatPlugin from '../../../server/plugins/geminiChatPlugin.js';
 import Gemini15ChatPlugin from '../../../server/plugins/gemini15ChatPlugin.js';
 import Claude3VertexPlugin from '../../../server/plugins/claude3VertexPlugin.js';
@@ -13,7 +14,8 @@ function createResolverWithPlugin(pluginClass, modelName = 'test-model') {
     OpenAIChatPlugin: 'OPENAI-VISION',
     GeminiChatPlugin: 'GEMINI-VISION',
     Gemini15ChatPlugin: 'GEMINI-1.5-VISION',
-    Claude3VertexPlugin: 'CLAUDE-3-VERTEX'
+    Claude3VertexPlugin: 'CLAUDE-3-VERTEX',
+    OpenAIVisionPlugin: 'OPENAI-VISION'
   };
 
   const modelType = pluginToModelType[pluginClass.name];
@@ -72,7 +74,26 @@ test('OpenAI Chat Plugin - processStreamEvent handles content chunks correctly',
   };
   
   progress = plugin.processStreamEvent(endEvent, {});
-  t.is(progress.progress, 1);
+  t.is(progress.progress, undefined);
+});
+
+test('OpenAI Vision Plugin - waits for DONE on stop finish reason', async t => {
+  const resolver = createResolverWithPlugin(OpenAIVisionPlugin);
+  const plugin = resolver.modelExecutor.plugin;
+
+  const endEvent = {
+    data: JSON.stringify({
+      id: 'test-id',
+      choices: [{
+        delta: {},
+        finish_reason: 'stop'
+      }]
+    })
+  };
+
+  const progress = plugin.processStreamEvent(endEvent, {});
+  t.is(progress.data, endEvent.data);
+  t.is(progress.progress, undefined);
 });
 
 test('Gemini Chat Plugin - processStreamEvent handles content chunks correctly', async t => {
@@ -154,5 +175,3 @@ test('Claude 3 Vertex Plugin - processStreamEvent handles message types', async 
   progress = plugin.processStreamEvent(stopEvent, {});
   t.is(progress.progress, 1);
 });
-
-

--- a/tests/unit/plugins/claude3VertexPlugin.test.js
+++ b/tests/unit/plugins/claude3VertexPlugin.test.js
@@ -4,6 +4,32 @@ import { mockPathwayResolverMessages } from '../../helpers/mocks.js';
 import { config } from '../../../config.js';
 import fs from 'fs';
 import path from 'path';
+import axios from 'axios';
+
+const originalAxiosHead = axios.head;
+const originalAxiosGet = axios.get;
+const sampleJpegBuffer = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.alloc(256, 0),
+  Buffer.from([0xff, 0xd9]),
+]);
+
+test.before(() => {
+  axios.head = async (url) => ({
+    headers: {
+      'content-type': String(url).endsWith('.pdf') ? 'application/pdf' : 'image/jpeg',
+    },
+  });
+  axios.get = async () => ({
+    headers: { 'content-type': 'image/jpeg' },
+    data: sampleJpegBuffer,
+  });
+});
+
+test.after.always(() => {
+  axios.head = originalAxiosHead;
+  axios.get = originalAxiosGet;
+});
 
 // Helper function to load test data from files
 function loadTestData(filename) {
@@ -182,6 +208,24 @@ test('parseResponse', (t) => {
     const dataNull = null;
     const resultNull = plugin.parseResponse(dataNull);
     t.is(resultNull, dataNull);
+});
+
+test('parseResponse normalizes empty content arrays to an empty CortexResponse', (t) => {
+    const plugin = new Claude3VertexPlugin(pathway, model);
+
+    const emptyContentResponse = {
+        content: [],
+        usage: { input_tokens: 42, output_tokens: 8 },
+        stop_reason: 'end_turn',
+    };
+
+    const result = plugin.parseResponse(emptyContentResponse);
+
+    t.truthy(result);
+    t.is(result.output_text, '');
+    t.is(result.finishReason, 'stop');
+    t.deepEqual(result.usage, emptyContentResponse.usage);
+    t.is(result.metadata.model, plugin.modelName);
 });
 
 test('convertMessagesToClaudeVertex text message', async (t) => {

--- a/tests/unit/plugins/claude3VertexToolConversion.test.js
+++ b/tests/unit/plugins/claude3VertexToolConversion.test.js
@@ -8,6 +8,25 @@ const { pathway, modelName, model } = mockPathwayResolverMessages;
 // Helper function to create a plugin instance
 const createPlugin = () => new Claude3VertexPlugin(pathway, model);
 
+test('Claude3 strips unsupported thinking controls', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoningEffort: 'high',
+        thinkingType: 'adaptive',
+        thinkingBudgetTokens: 3000
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    t.is(result.reasoningEffort, undefined);
+    t.is(result.thinkingType, undefined);
+    t.is(result.thinkingBudgetTokens, undefined);
+    t.is(result.thinking, undefined);
+    t.is(result.output_config, undefined);
+});
+
 // Test OpenAI tools block conversion
 test('OpenAI tools block conversion', async (t) => {
     const plugin = createPlugin();
@@ -473,7 +492,7 @@ test('Prevent duplicate tool definitions', async (t) => {
     
     // Verify the tool_use call is still properly converted
     t.truthy(result.messages, 'Messages should be defined');
-    t.is(result.messages.length, 1, 'Should have 1 message after conversion');
+    t.is(result.messages.length, 2, 'Should have 2 messages after conversion');
     
     // Check the converted message
     const message = result.messages[0];
@@ -486,4 +505,84 @@ test('Prevent duplicate tool definitions', async (t) => {
         name: 'memory_lookup',
         input: { query: 'search memory' }
     });
+
+    const toolResultMessage = result.messages[1];
+    t.is(toolResultMessage.role, 'user', 'Tool result should be from user');
+    const toolResult = toolResultMessage.content.find(item => item.type === 'tool_result');
+    t.truthy(toolResult, 'Should insert a tool_result');
+    t.is(toolResult.tool_use_id, 'tool_1', 'Tool result should match tool_use id');
+});
+
+test('Interrupted tool call preserves user interrupt text while inserting synthetic tool result', async (t) => {
+  const plugin = createPlugin();
+  const prompt = mockPathwayResolverMessages.pathway.prompt;
+  const interruptText = 'Request interrupted by user for tool use';
+
+  const messages = [
+    {
+      role: 'system',
+      content: 'You are a helpful assistant'
+    },
+    {
+      role: 'user',
+      content: 'Can you call memory_lookup?'
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'tool_1',
+          name: 'memory_lookup',
+          input: { query: 'what did you find?' }
+        }
+      ]
+    },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: interruptText
+        }
+      ]
+    }
+  ];
+
+  prompt.messages = messages;
+  const cortexRequest = { messages };
+  const result = await plugin.getRequestParameters('test', {}, prompt, cortexRequest);
+
+  t.is(result.messages.length, 4, 'Should include tool result and preserved interrupt text');
+  t.is(result.messages[1].role, 'assistant');
+  t.is(result.messages[2].role, 'user');
+  const toolResult = result.messages[2].content.find(item => item.type === 'tool_result');
+  t.truthy(toolResult, 'Should insert a synthetic tool result');
+  t.is(toolResult.tool_use_id, 'tool_1');
+
+  t.is(result.messages[3].role, 'user');
+  t.deepEqual(result.messages[3].content[0], {
+    type: 'text',
+    text: interruptText
+  });
+});
+
+test('Stream closes on message_delta stop_reason tool_use without message_stop', (t) => {
+  const plugin = createPlugin();
+  plugin.pathwayToolCallback = null;
+  plugin.requestId = 'test-request';
+
+  const requestProgress = { requestId: plugin.requestId };
+  const event = {
+    data: JSON.stringify({
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use' }
+    })
+  };
+
+  const result = plugin.processStreamEvent(event, requestProgress);
+
+  t.is(result.progress, 1);
+  const parsed = JSON.parse(result.data);
+  t.is(parsed.choices[0].finish_reason, 'tool_calls');
 });

--- a/tests/unit/plugins/claude4VertexPlugin.test.js
+++ b/tests/unit/plugins/claude4VertexPlugin.test.js
@@ -4,6 +4,40 @@ import { mockPathwayResolverMessages } from '../../helpers/mocks.js';
 import { config } from '../../../config.js';
 import fs from 'fs';
 import path from 'path';
+import axios from 'axios';
+
+const originalAxiosHead = axios.head;
+const originalAxiosGet = axios.get;
+const sampleJpegBuffer = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.alloc(256, 0),
+  Buffer.from([0xff, 0xd9]),
+]);
+const samplePdfBuffer = Buffer.concat([
+  Buffer.from('%PDF-1.4\n'),
+  Buffer.alloc(256, 65),
+  Buffer.from('\n%%EOF'),
+]);
+
+test.before(() => {
+  axios.head = async (url) => ({
+    headers: {
+      'content-type': String(url).endsWith('.pdf') ? 'application/pdf' : 'image/jpeg',
+    },
+  });
+  axios.get = async (url) => {
+    const isPdf = String(url).endsWith('.pdf');
+    return {
+      headers: { 'content-type': isPdf ? 'application/pdf' : 'image/jpeg' },
+      data: isPdf ? samplePdfBuffer : sampleJpegBuffer,
+    };
+  };
+});
+
+test.after.always(() => {
+  axios.head = originalAxiosHead;
+  axios.get = originalAxiosGet;
+});
 
 // Helper function to load test data from files
 function loadTestData(filename) {
@@ -17,6 +51,66 @@ function loadTestData(filename) {
 }
 
 const { pathway, model } = mockPathwayResolverMessages;
+
+// Model with budgetTokensMap for thinking tests (pre-4.6 style)
+const modelWithBudgetMap = {
+    ...model,
+    budgetTokensMap: { low: 1024, medium: 4096, high: 16384, xhigh: 65536 },
+};
+
+// --- Thinking + tool_choice interaction tests ---
+
+test('thinking is disabled when tool_choice forces a specific tool', async (t) => {
+    const plugin = new Claude4VertexPlugin(pathway, modelWithBudgetMap);
+    const params = await plugin.getRequestParameters('test', {
+        reasoningEffort: 'high',
+        tool_choice: JSON.stringify({ type: 'function', function: { name: 'store_memory' } }),
+        tools: JSON.stringify([{ type: 'function', function: { name: 'store_memory', parameters: {} } }]),
+    }, pathway.prompt);
+    t.is(params.thinking.type, 'disabled');
+    t.falsy(params.output_config);
+});
+
+test('thinking is disabled when tool_choice is "required"', async (t) => {
+    const plugin = new Claude4VertexPlugin(pathway, modelWithBudgetMap);
+    const params = await plugin.getRequestParameters('test', {
+        reasoningEffort: 'high',
+        tool_choice: 'required',
+        tools: JSON.stringify([{ type: 'function', function: { name: 'some_tool', parameters: {} } }]),
+    }, pathway.prompt);
+    t.is(params.thinking.type, 'disabled');
+});
+
+test('thinking is preserved when tool_choice is "auto"', async (t) => {
+    const plugin = new Claude4VertexPlugin(pathway, modelWithBudgetMap);
+    const params = await plugin.getRequestParameters('test', {
+        reasoningEffort: 'high',
+        tool_choice: 'auto',
+        tools: JSON.stringify([{ type: 'function', function: { name: 'some_tool', parameters: {} } }]),
+    }, pathway.prompt);
+    t.not(params.thinking.type, 'disabled');
+});
+
+test('thinking is disabled with forced tool_choice even with adaptive thinking', async (t) => {
+    const plugin = new Claude4VertexPlugin(pathway, model);
+    const params = await plugin.getRequestParameters('test', {
+        thinking: JSON.stringify({ type: 'adaptive' }),
+        tool_choice: JSON.stringify({ type: 'function', function: { name: 'recall_memory' } }),
+        tools: JSON.stringify([{ type: 'function', function: { name: 'recall_memory', parameters: {} } }]),
+    }, pathway.prompt);
+    t.is(params.thinking.type, 'disabled');
+});
+
+test('temperature is not forced to 1 when thinking is disabled by tool_choice', async (t) => {
+    const plugin = new Claude4VertexPlugin(pathway, modelWithBudgetMap);
+    const params = await plugin.getRequestParameters('test', {
+        reasoningEffort: 'high',
+        tool_choice: 'required',
+        tools: JSON.stringify([{ type: 'function', function: { name: 'some_tool', parameters: {} } }]),
+    }, pathway.prompt);
+    t.is(params.thinking.type, 'disabled');
+    t.not(params.temperature, 1);
+});
 
 test('constructor', (t) => {
     const plugin = new Claude4VertexPlugin(pathway, model);
@@ -459,4 +553,3 @@ test('convertMessagesToClaudeVertex with multi-part content array', async (t) =>
   t.true(base64Data.length > 100); // Check if the data is sufficiently long
   t.true(base64Regex.test(base64Data)); // Check if the data matches the base64 regex
 });
-

--- a/tests/unit/plugins/claude4VertexToolConversion.test.js
+++ b/tests/unit/plugins/claude4VertexToolConversion.test.js
@@ -7,6 +7,36 @@ const { pathway, modelName, model } = mockPathwayResolverMessages;
 // Helper function to create a plugin instance
 const createPlugin = () => new Claude4VertexPlugin(pathway, model);
 
+test('Claude4 maps reasoningEffort to adaptive output_config effort', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoningEffort: 'xhigh'
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    t.deepEqual(result.thinking, { type: 'adaptive' });
+    t.deepEqual(result.output_config, { effort: 'max' });
+    t.is(result.temperature, 1);
+});
+
+test('Claude4 maps thinkingType and budget tokens to anthropic thinking config', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        thinkingType: 'enabled',
+        thinkingBudgetTokens: 4096
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    t.deepEqual(result.thinking, { type: 'enabled', budget_tokens: 4096 });
+    t.is(result.temperature, 1);
+});
+
 // Test OpenAI tools block conversion
 test('OpenAI tools block conversion', async (t) => {
     const plugin = createPlugin();
@@ -318,8 +348,8 @@ test('Tool conversion with document content blocks', async (t) => {
     // System message should be extracted
     t.is(result.system, 'You are a helpful assistant');
     
-    // After filtering system messages and ensuring odd count, we have 3 messages
-    t.is(result.messages.length, 3);
+    // After sanitization, preserved interrupt-style text after tool_use is kept as a separate user message.
+    t.is(result.messages.length, 4);
     t.is(result.messages[0].role, 'user');
     t.is(result.messages[0].content.length, 2);
     t.is(result.messages[0].content[0].type, 'text');
@@ -327,6 +357,7 @@ test('Tool conversion with document content blocks', async (t) => {
     
     t.is(result.messages[1].role, 'assistant');
     t.is(result.messages[2].role, 'user');
+    t.is(result.messages[3].role, 'user');
     
     // Check tool was generated
     t.truthy(result.tools);
@@ -396,7 +427,7 @@ test('Prevent duplicate tool definitions', async (t) => {
     
     // Verify the tool_use call is still properly converted
     t.truthy(result.messages, 'Messages should be defined');
-    t.is(result.messages.length, 1, 'Should have 1 message after conversion');
+    t.is(result.messages.length, 2, 'Should have 2 messages after conversion');
     
     // Check the converted message
     const message = result.messages[0];
@@ -409,5 +440,157 @@ test('Prevent duplicate tool definitions', async (t) => {
         name: 'memory_lookup',
         input: { query: 'search memory' }
     });
+
+    const toolResultMessage = result.messages[1];
+    t.is(toolResultMessage.role, 'user', 'Tool result should be from user');
+    const toolResult = toolResultMessage.content.find(item => item.type === 'tool_result');
+    t.truthy(toolResult, 'Should insert a tool_result');
+    t.is(toolResult.tool_use_id, 'tool_1', 'Tool result should match tool_use id');
 });
 
+test('Interrupted tool call preserves user interrupt text while inserting synthetic tool result', async (t) => {
+  const plugin = createPlugin();
+  const prompt = mockPathwayResolverMessages.pathway.prompt;
+  const interruptText = 'Request interrupted by user for tool use';
+
+  const messages = [
+    {
+      role: 'system',
+      content: 'You are a helpful assistant'
+    },
+    {
+      role: 'user',
+      content: 'Can you call memory_lookup?'
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'tool_1',
+          name: 'memory_lookup',
+          input: { query: 'what did you find?' }
+        }
+      ]
+    },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: interruptText
+        }
+      ]
+    }
+  ];
+
+  prompt.messages = messages;
+  const cortexRequest = { messages };
+  const result = await plugin.getRequestParameters('test', {}, prompt, cortexRequest);
+
+  t.is(result.messages.length, 4, 'Should include tool result and preserved interrupt text');
+  t.is(result.messages[1].role, 'assistant');
+  t.is(result.messages[2].role, 'user');
+  const toolResult = result.messages[2].content.find(item => item.type === 'tool_result');
+  t.truthy(toolResult, 'Should insert a synthetic tool result');
+  t.is(toolResult.tool_use_id, 'tool_1');
+
+  t.is(result.messages[3].role, 'user');
+  t.deepEqual(result.messages[3].content[0], {
+    type: 'text',
+    text: interruptText
+  });
+});
+
+// ----- Forced tool choice + thinking disable tests -----
+
+test('Claude4 disables thinking when tool_choice type is "any"', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoningEffort: 'high',
+        tool_choice: { type: 'any' },
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    t.deepEqual(result.thinking, { type: 'disabled' });
+    t.is(result.output_config, undefined);
+});
+
+test('Claude4 disables thinking when tool_choice type is "tool"', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        thinkingType: 'enabled',
+        thinkingBudgetTokens: 8192,
+        tool_choice: { type: 'tool', name: 'search_web' },
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    t.deepEqual(result.thinking, { type: 'disabled' });
+    t.is(result.output_config, undefined);
+});
+
+test('Claude4 preserves thinking when tool_choice type is "auto"', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoningEffort: 'high',
+        tool_choice: { type: 'auto' },
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    // thinking should NOT be disabled
+    t.not(result.thinking?.type, 'disabled');
+});
+
+test('Claude4 preserves thinking when no tool_choice is set', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoningEffort: 'high',
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    // thinking should NOT be disabled
+    t.not(result.thinking?.type, 'disabled');
+});
+
+test('Claude4 preserves thinking when tool_choice is a string (not object)', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoningEffort: 'high',
+        tool_choice: 'auto',
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    // String tool_choice should not trigger thinking disable
+    t.not(result.thinking?.type, 'disabled');
+});
+
+test('Claude4 disables thinking for forced tool choice even with adaptive thinking', async (t) => {
+    const plugin = createPlugin();
+    const prompt = mockPathwayResolverMessages.pathway.prompt;
+    const parameters = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        thinking: JSON.stringify({ type: 'adaptive' }),
+        output_config: JSON.stringify({ effort: 'max' }),
+        tool_choice: { type: 'any' },
+    };
+
+    const result = await plugin.getRequestParameters('test', parameters, prompt);
+
+    t.deepEqual(result.thinking, { type: 'disabled' });
+    t.is(result.output_config, undefined);
+});

--- a/tests/unit/plugins/claudeAnthropicPlugin.test.js
+++ b/tests/unit/plugins/claudeAnthropicPlugin.test.js
@@ -97,6 +97,39 @@ test('getRequestParameters includes model in body', async (t) => {
     t.is(requestParams.anthropic_version, undefined);
 });
 
+test('getRequestParameters maps reasoningEffort to adaptive output_config effort', async (t) => {
+    const plugin = new ClaudeAnthropicPlugin(pathway, anthropicModel);
+
+    const messages = [
+        { role: 'user', content: 'Hello' }
+    ];
+
+    const parameters = { messages, reasoningEffort: 'xhigh' };
+    const requestParams = await plugin.getRequestParameters('', parameters, {});
+
+    t.deepEqual(requestParams.thinking, { type: 'adaptive' });
+    t.deepEqual(requestParams.output_config, { effort: 'max' });
+    t.is(requestParams.temperature, 1);
+});
+
+test('getRequestParameters maps thinkingType and budget tokens to anthropic thinking config', async (t) => {
+    const plugin = new ClaudeAnthropicPlugin(pathway, anthropicModel);
+
+    const messages = [
+        { role: 'user', content: 'Hello' }
+    ];
+
+    const parameters = {
+        messages,
+        thinkingType: 'enabled',
+        thinkingBudgetTokens: 4096
+    };
+    const requestParams = await plugin.getRequestParameters('', parameters, {});
+
+    t.deepEqual(requestParams.thinking, { type: 'enabled', budget_tokens: 4096 });
+    t.is(requestParams.temperature, 1);
+});
+
 test('convertMessagesToClaudeVertex preserves message conversion from parent', async (t) => {
     const plugin = new ClaudeAnthropicPlugin(pathway, anthropicModel);
     

--- a/tests/unit/plugins/gemini15VisionPlugin.test.js
+++ b/tests/unit/plugins/gemini15VisionPlugin.test.js
@@ -1,0 +1,537 @@
+import test from 'ava';
+import Gemini15VisionPlugin from '../../../server/plugins/gemini15VisionPlugin.js';
+import { requestState } from '../../../server/requestState.js';
+
+const createPlugin = () => {
+  const pathway = {
+    name: 'test-pathway',
+    model: 'gemini-flash-3-vision',
+    prompt: 'test prompt',
+    toolCallback: () => {}
+  };
+
+  const model = {
+    name: 'gemini-flash-3-vision',
+    type: 'GEMINI-3-VISION'
+  };
+
+  return new Gemini15VisionPlugin(pathway, model);
+};
+
+const findArrayTypePaths = (schema, path = '$') => {
+  if (!schema || typeof schema !== 'object') {
+    return [];
+  }
+
+  if (Array.isArray(schema)) {
+    return schema.flatMap((item, index) => findArrayTypePaths(item, `${path}[${index}]`));
+  }
+
+  const findings = [];
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === 'type' && Array.isArray(value)) {
+      findings.push(`${path}.type`);
+      continue;
+    }
+
+    findings.push(...findArrayTypePaths(value, `${path}.${key}`));
+  }
+
+  return findings;
+};
+
+test('Gemini15VisionPlugin - sanitizes tool schema fields for Gemini', t => {
+  const plugin = createPlugin();
+  const openAiTools = [
+    {
+      type: 'function',
+      function: {
+        name: 'doThing',
+        description: 'Test tool',
+        parameters: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          propertyNames: { pattern: '^[a-z]+$' },
+          properties: {
+            mode: { const: 'fast' },
+            count: { type: 'integer', exclusiveMinimum: 0 },
+            size: { type: 'integer', exclusiveMaximum: 10 },
+            level: { type: 'string', enum: [1, 'ok'] }
+          },
+          required: ['mode']
+        }
+      }
+    }
+  ];
+
+  const converted = plugin.convertOpenAIToolsToGemini(openAiTools);
+  t.is(converted.length, 1);
+  t.is(converted[0].functionDeclarations.length, 1);
+
+  const params = converted[0].functionDeclarations[0].parameters;
+  t.falsy(params.$schema);
+  t.falsy(params.propertyNames);
+  t.deepEqual(params.properties.mode.enum, ['fast']);
+  t.is(params.properties.count.minimum, 0);
+  t.falsy(params.properties.count.exclusiveMinimum);
+  t.is(params.properties.size.maximum, 10);
+  t.falsy(params.properties.size.exclusiveMaximum);
+  t.deepEqual(params.properties.level.enum, ['1', 'ok']);
+});
+
+test('Gemini15VisionPlugin - normalizes nullable type tuples to nullable flag', t => {
+  const plugin = createPlugin();
+  const openAiTools = [
+    {
+      type: 'function',
+      function: {
+        name: 'GetApplets',
+        description: 'Read applets',
+        parameters: {
+          type: 'object',
+          properties: {
+            appletId: { type: ['string', 'null'], description: 'optional id' },
+            version: { type: ['number', 'null'], description: 'optional version' },
+            tags: {
+              type: ['array', 'null'],
+              items: { type: 'string' }
+            },
+            name: { type: 'string' }
+          },
+          required: []
+        }
+      }
+    }
+  ];
+
+  const params = plugin.convertOpenAIToolsToGemini(openAiTools)[0]
+    .functionDeclarations[0].parameters;
+
+  t.is(params.properties.appletId.type, 'string');
+  t.true(params.properties.appletId.nullable);
+
+  t.is(params.properties.version.type, 'number');
+  t.true(params.properties.version.nullable);
+
+  t.is(params.properties.tags.type, 'array');
+  t.true(params.properties.tags.nullable);
+  t.is(params.properties.tags.items.type, 'string');
+
+  // Non-nullable strings should be untouched
+  t.is(params.properties.name.type, 'string');
+  t.falsy(params.properties.name.nullable);
+});
+
+test('Gemini15VisionPlugin - converts multi-type arrays to Gemini anyOf', t => {
+  const plugin = createPlugin();
+  const openAiTools = [
+    {
+      type: 'function',
+      function: {
+        name: 'CreateApplet',
+        description: 'Create an applet',
+        parameters: {
+          type: 'object',
+          properties: {
+            prompt: { type: 'string' },
+            createNew: {
+              type: ['boolean', 'string'],
+              description: 'Create a separate applet when true or createNew'
+            },
+            mode: {
+              type: ['string', 'boolean', 'null'],
+              description: 'Legacy multi-type nullable parameter'
+            }
+          },
+          required: ['prompt']
+        }
+      }
+    }
+  ];
+
+  const params = plugin.convertOpenAIToolsToGemini(openAiTools)[0]
+    .functionDeclarations[0].parameters;
+
+  t.falsy(params.properties.createNew.type);
+  t.deepEqual(params.properties.createNew.anyOf, [
+    { type: 'boolean' },
+    { type: 'string' }
+  ]);
+
+  t.falsy(params.properties.mode.type);
+  t.true(params.properties.mode.nullable);
+  t.deepEqual(params.properties.mode.anyOf, [
+    { type: 'string' },
+    { type: 'boolean' }
+  ]);
+
+  t.deepEqual(findArrayTypePaths(params), []);
+});
+
+test('convertMessagesToGemini converts assistant tool_calls to Gemini functionCall parts', t => {
+  const plugin = createPlugin();
+
+  const messages = [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'Find the cannes file' },
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [{
+        id: 'WorkspaceSSH_123',
+        type: 'function',
+        function: {
+          name: 'WorkspaceSSH',
+          arguments: JSON.stringify({ command: 'ls -R | grep -i cannes' })
+        }
+      }]
+    },
+    {
+      role: 'tool',
+      tool_call_id: 'WorkspaceSSH_123',
+      content: 'cannes_report.pdf'
+    },
+    { role: 'user', content: 'Open that file' },
+  ];
+
+  const { modifiedMessages, system } = plugin.convertMessagesToGemini(messages);
+
+  // System message should be extracted
+  t.truthy(system);
+  t.is(system.parts[0].text, 'You are a helpful assistant.');
+
+  // Find the model message with functionCall
+  const fcMessage = modifiedMessages.find(m =>
+    m.role === 'model' && m.parts.some(p => p.functionCall)
+  );
+  t.truthy(fcMessage, 'Should have a model message with functionCall');
+  t.is(fcMessage.parts[0].functionCall.name, 'WorkspaceSSH');
+  t.deepEqual(fcMessage.parts[0].functionCall.args, { command: 'ls -R | grep -i cannes' });
+
+  // Find the function response message
+  const frMessage = modifiedMessages.find(m =>
+    m.role === 'function' && m.parts.some(p => p.functionResponse)
+  );
+  t.truthy(frMessage, 'Should have a function response message');
+  t.is(frMessage.parts[0].functionResponse.name, 'WorkspaceSSH');
+  t.is(frMessage.parts[0].functionResponse.response.content, 'cannes_report.pdf');
+});
+
+test('convertMessagesToGemini handles tool_calls with text content', t => {
+  const plugin = createPlugin();
+
+  const messages = [
+    { role: 'user', content: 'Search for files' },
+    {
+      role: 'assistant',
+      content: 'Let me search for that.',
+      tool_calls: [{
+        id: 'Search_1',
+        type: 'function',
+        function: {
+          name: 'Search',
+          arguments: '{"query": "cannes"}'
+        }
+      }]
+    },
+    {
+      role: 'tool',
+      tool_call_id: 'Search_1',
+      content: 'Found 3 results'
+    },
+  ];
+
+  const { modifiedMessages } = plugin.convertMessagesToGemini(messages);
+
+  // The model message should have both text and functionCall parts
+  const fcMessage = modifiedMessages.find(m =>
+    m.role === 'model' && m.parts.some(p => p.functionCall)
+  );
+  t.truthy(fcMessage);
+  t.is(fcMessage.parts.length, 2, 'Should have text + functionCall parts');
+  t.is(fcMessage.parts[0].text, 'Let me search for that.');
+  t.is(fcMessage.parts[1].functionCall.name, 'Search');
+});
+
+test('convertMessagesToGemini preserves thoughtSignature on tool_calls', t => {
+  const plugin = createPlugin();
+
+  const messages = [
+    { role: 'user', content: 'Do something' },
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [{
+        id: 'Tool_1',
+        type: 'function',
+        function: { name: 'MyTool', arguments: '{}' },
+        thoughtSignature: 'abc123sig'
+      }]
+    },
+    { role: 'tool', tool_call_id: 'Tool_1', content: 'done' },
+  ];
+
+  const { modifiedMessages } = plugin.convertMessagesToGemini(messages);
+
+  const fcMessage = modifiedMessages.find(m =>
+    m.role === 'model' && m.parts.some(p => p.functionCall)
+  );
+  t.truthy(fcMessage);
+  t.is(fcMessage.parts[0].thoughtSignature, 'abc123sig');
+});
+
+test('convertMessagesToGemini parses native Gemini function_call args strings', t => {
+  const plugin = createPlugin();
+
+  const messages = [{
+    role: 'model',
+    parts: [{
+      function_call: {
+        name: 'SearchAvailableTools',
+        args: '{"query":"recently created issues"}',
+      },
+    }],
+  }];
+
+  const { modifiedMessages } = plugin.convertMessagesToGemini(messages);
+
+  t.deepEqual(modifiedMessages[0].parts[0].function_call.args, {
+    query: 'recently created issues',
+  });
+});
+
+test('parseResponse gracefully handles non-streaming UNEXPECTED_TOOL_CALL', t => {
+  const plugin = createPlugin();
+
+  const result = plugin.parseResponse({
+    candidates: [{
+      finishReason: 'UNEXPECTED_TOOL_CALL',
+      finishMessage: 'Model tried to call an undeclared function',
+      content: { parts: [] },
+    }],
+  });
+
+  t.is(result.finishReason, 'stop');
+  t.true(result.output_text.includes('try rephrasing'));
+});
+
+test('convertMessagesToGemini drops assistant with empty content and no tool_calls', t => {
+  const plugin = createPlugin();
+
+  // This is the old bug scenario: assistant with content="" and no tool_calls
+  // should be dropped (existing behavior, regression check)
+  const messages = [
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: '' },
+    { role: 'user', content: 'World' },
+  ];
+
+  const { modifiedMessages } = plugin.convertMessagesToGemini(messages);
+
+  // Should only have user messages (empty assistant dropped)
+  t.true(modifiedMessages.every(m => m.role === 'user'));
+});
+
+test('processStreamEvent accumulates tool calls across events and dispatches once on STOP', t => {
+  // Simulates Gemini 3 Flash pattern: 3 separate SSE events, each with a functionCall
+  // + usageMetadata, only the last has finishReason: "STOP".
+  // Verify: exactly ONE callback with ALL 3 tool calls.
+  const toolCallbackArgs = [];
+  const plugin = createPlugin();
+  plugin.pathwayToolCallback = (...args) => toolCallbackArgs.push(args);
+  plugin.requestId = 'test-req-123';
+
+  const mockResolver = { args: { text: 'test' } };
+  requestState['test-req-123'] = { pathwayResolver: mockResolver };
+
+  const responseId = 'resp-abc-123';
+
+  // Event 1: functionCall + usageMetadata, NO finishReason
+  plugin.processStreamEvent({
+    data: JSON.stringify({
+      candidates: [{
+        content: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'SearchInternet', args: { query: 'topic A' } } }]
+        }
+      }],
+      usageMetadata: { trafficType: 'ON_DEMAND' },
+      responseId
+    })
+  }, {});
+
+  t.is(toolCallbackArgs.length, 0, 'Should NOT dispatch after event 1');
+  t.is(plugin.toolCallsBuffer.length, 1, 'Should buffer 1 tool call');
+
+  // Event 2: another functionCall + usageMetadata, NO finishReason
+  plugin.processStreamEvent({
+    data: JSON.stringify({
+      candidates: [{
+        content: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'SearchInternet', args: { query: 'topic B' } } }]
+        }
+      }],
+      usageMetadata: { trafficType: 'ON_DEMAND' },
+      responseId
+    })
+  }, {});
+
+  t.is(toolCallbackArgs.length, 0, 'Should NOT dispatch after event 2');
+  t.is(plugin.toolCallsBuffer.length, 2, 'Should buffer 2 tool calls');
+
+  // Event 3: functionCall + usageMetadata + finishReason: "STOP"
+  const result = plugin.processStreamEvent({
+    data: JSON.stringify({
+      candidates: [{
+        content: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'SearchInternet', args: { query: 'topic C' } } }]
+        },
+        finishReason: 'STOP'
+      }],
+      usageMetadata: { trafficType: 'ON_DEMAND' },
+      responseId
+    })
+  }, {});
+
+  // Exactly ONE callback with ALL 3 tool calls
+  t.true(result.toolCallbackInvoked, 'Should set toolCallbackInvoked on STOP');
+  t.is(toolCallbackArgs.length, 1, 'Should invoke callback exactly once');
+
+  const toolMessage = toolCallbackArgs[0][1];
+  t.is(toolMessage.role, 'assistant');
+  t.is(toolMessage.tool_calls.length, 3, 'Should include all 3 accumulated tool calls');
+  t.is(toolMessage.tool_calls[0].function.name, 'SearchInternet');
+  t.is(toolMessage.tool_calls[1].function.name, 'SearchInternet');
+  t.is(toolMessage.tool_calls[2].function.name, 'SearchInternet');
+
+  t.is(plugin.toolCallsBuffer.length, 0, 'Tool buffer should be cleared');
+
+  delete requestState['test-req-123'];
+});
+
+test('processStreamEvent does NOT dispatch tool calls without finishReason STOP', t => {
+  const toolCallbackArgs = [];
+  const plugin = createPlugin();
+  plugin.pathwayToolCallback = (...args) => toolCallbackArgs.push(args);
+  plugin.requestId = 'test-req-456';
+
+  requestState['test-req-456'] = { pathwayResolver: { args: {} } };
+
+  // Intermediate event: functionCall + usageMetadata but no finishReason
+  const event = {
+    data: JSON.stringify({
+      candidates: [{
+        content: {
+          role: 'model',
+          parts: [{
+            functionCall: {
+              name: 'WorkspaceSSH',
+              args: { command: 'ls' }
+            }
+          }]
+        }
+      }],
+      usageMetadata: { trafficType: 'ON_DEMAND' },
+      modelVersion: 'gemini-3-flash-preview',
+      responseId: 'test-response-id'
+    })
+  };
+
+  const result = plugin.processStreamEvent(event, {});
+
+  // Should NOT dispatch — waiting for STOP event
+  t.falsy(result.toolCallbackInvoked, 'Should not dispatch without finishReason STOP');
+  t.is(toolCallbackArgs.length, 0, 'Should not invoke callback');
+  t.is(plugin.toolCallsBuffer.length, 1, 'Tool call should remain buffered');
+
+  delete requestState['test-req-456'];
+});
+
+test('processStreamEvent resets state only on new responseId', t => {
+  const plugin = createPlugin();
+  plugin.pathwayToolCallback = () => {};
+  plugin.requestId = 'test-req-reset';
+
+  requestState['test-req-reset'] = { pathwayResolver: { args: {} } };
+
+  // Event with responseId "A" — buffer a tool call
+  plugin.processStreamEvent({
+    data: JSON.stringify({
+      candidates: [{
+        content: { role: 'model', parts: [{ functionCall: { name: 'ToolA', args: {} } }] }
+      }],
+      responseId: 'response-A'
+    })
+  }, {});
+
+  t.is(plugin.toolCallsBuffer.length, 1);
+
+  // Another event with SAME responseId "A" — should accumulate, not reset
+  plugin.processStreamEvent({
+    data: JSON.stringify({
+      candidates: [{
+        content: { role: 'model', parts: [{ functionCall: { name: 'ToolB', args: {} } }] }
+      }],
+      responseId: 'response-A'
+    })
+  }, {});
+
+  t.is(plugin.toolCallsBuffer.length, 2, 'Should accumulate within same responseId');
+
+  // Event with NEW responseId "B" — should reset
+  plugin.processStreamEvent({
+    data: JSON.stringify({
+      candidates: [{
+        content: { role: 'model', parts: [{ functionCall: { name: 'ToolC', args: {} } }] }
+      }],
+      responseId: 'response-B'
+    })
+  }, {});
+
+  t.is(plugin.toolCallsBuffer.length, 1, 'Should reset on new responseId');
+  t.is(plugin.toolCallsBuffer[0].function.name, 'ToolC');
+
+  delete requestState['test-req-reset'];
+});
+
+test('processStreamEvent handles UNEXPECTED_TOOL_CALL by closing stream gracefully', t => {
+  const toolCallbackArgs = [];
+  const plugin = createPlugin();
+  plugin.pathwayToolCallback = (...args) => toolCallbackArgs.push(args);
+  plugin.requestId = 'test-req-789';
+
+  requestState['test-req-789'] = { pathwayResolver: { args: {} } };
+
+  // Gemini returns UNEXPECTED_TOOL_CALL when model calls an undeclared function
+  const event = {
+    data: JSON.stringify({
+      candidates: [{
+        content: {
+          role: 'model',
+          parts: [{
+            functionCall: {
+              name: 'SearchFileCollection',
+              args: { query: 'test.png' }
+            }
+          }]
+        },
+        finishReason: 'UNEXPECTED_TOOL_CALL',
+        finishMessage: 'Unexpected tool call: Model tried to call an undeclared function: SearchFileCollection'
+      }],
+      usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 10 },
+      responseId: 'test-response-id'
+    })
+  };
+
+  const result = plugin.processStreamEvent(event, {});
+
+  // Should close the stream gracefully, NOT dispatch the invalid tool call
+  t.is(result.progress, 1, 'Should close the stream');
+  t.falsy(result.toolCallbackInvoked, 'Should not invoke tool callback for undeclared function');
+  t.is(toolCallbackArgs.length, 0, 'Should not dispatch invalid tool call');
+  t.is(plugin.toolCallsBuffer.length, 0, 'Should clear tool buffer');
+
+  delete requestState['test-req-789'];
+});

--- a/tests/unit/plugins/gemini3ReasoningVisionPlugin.test.js
+++ b/tests/unit/plugins/gemini3ReasoningVisionPlugin.test.js
@@ -231,6 +231,187 @@ test('getRequestParameters - transforms function role to user role', t => {
     'Should not have any function role messages after transformation');
 });
 
+// ===== FunctionResponse.response must be a Struct (plain object) =====
+// Gemini API defines FunctionResponse.response as protobuf Struct (map<string, Value>).
+// Arrays, null, and primitives cannot be serialized as a Struct — they must be wrapped in an object.
+// Ref: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/Content
+
+test('getRequestParameters - wraps array tool responses in object for Struct compatibility', t => {
+  const resolver = createResolverWithPlugin(Gemini3ReasoningVisionPlugin);
+  const plugin = resolver.modelExecutor.plugin;
+
+  const originalGetCompiledPrompt = plugin.getCompiledPrompt.bind(plugin);
+  plugin.getCompiledPrompt = (text, parameters, prompt) => {
+    const result = originalGetCompiledPrompt(text, parameters, prompt);
+    result.modelPromptMessages = [
+      { role: 'user', content: 'Search for cards' },
+      {
+        role: 'assistant', content: '',
+        tool_calls: [{
+          id: 'call_1',
+          function: { name: 'AssetLibrary', arguments: '{"resource":"cards","action":"search"}' },
+          thoughtSignature: 'test_sig'
+        }]
+      },
+      // Tool returns a stringified array, such as asset-library search results
+      { role: 'tool', tool_call_id: 'AssetLibrary_call_1',
+        content: JSON.stringify([{id: 'VX-1', title: 'Card A'}, {id: 'VX-2', title: 'Card B'}]) }
+    ];
+    return result;
+  };
+
+  const params = plugin.getRequestParameters('test', {}, { prompt: 'test' }, { pathway: {} });
+
+  // Find the functionResponse in transformed contents
+  let functionResponseData = null;
+  for (const content of params.contents) {
+    for (const part of (content.parts || [])) {
+      if (part.functionResponse) {
+        functionResponseData = part.functionResponse.response;
+      }
+    }
+  }
+
+  t.truthy(functionResponseData, 'Should have a functionResponse');
+  t.false(Array.isArray(functionResponseData),
+    'response must not be an array — Gemini Struct requires an object');
+  t.true(typeof functionResponseData === 'object' && functionResponseData !== null,
+    'response must be an object (Struct)');
+  t.true(Array.isArray(functionResponseData.result),
+    'Original array should be preserved under "result" key');
+  t.is(functionResponseData.result.length, 2);
+  t.is(functionResponseData.result[0].id, 'VX-1');
+});
+
+test('getRequestParameters - passes object tool responses through unchanged', t => {
+  const resolver = createResolverWithPlugin(Gemini3ReasoningVisionPlugin);
+  const plugin = resolver.modelExecutor.plugin;
+
+  const originalGetCompiledPrompt = plugin.getCompiledPrompt.bind(plugin);
+  plugin.getCompiledPrompt = (text, parameters, prompt) => {
+    const result = originalGetCompiledPrompt(text, parameters, prompt);
+    result.modelPromptMessages = [
+      { role: 'user', content: 'Get card details' },
+      {
+        role: 'assistant', content: '',
+        tool_calls: [{
+          id: 'call_1',
+          function: { name: 'AssetLibrary', arguments: '{"resource":"cards","action":"get"}' },
+          thoughtSignature: 'test_sig'
+        }]
+      },
+      // Tool returns a stringified object — should pass through as-is
+      { role: 'tool', tool_call_id: 'AssetLibrary_call_1',
+        content: JSON.stringify({id: 'VX-1', title: 'Card A', status: 'active'}) }
+    ];
+    return result;
+  };
+
+  const params = plugin.getRequestParameters('test', {}, { prompt: 'test' }, { pathway: {} });
+
+  let functionResponseData = null;
+  for (const content of params.contents) {
+    for (const part of (content.parts || [])) {
+      if (part.functionResponse) {
+        functionResponseData = part.functionResponse.response;
+      }
+    }
+  }
+
+  t.truthy(functionResponseData, 'Should have a functionResponse');
+  t.false(Array.isArray(functionResponseData),
+    'response should not be an array');
+  t.is(functionResponseData.id, 'VX-1',
+    'Object properties should pass through directly');
+  t.is(functionResponseData.title, 'Card A');
+  t.is(functionResponseData.result, undefined,
+    'Should not wrap objects in a result key');
+});
+
+test('getRequestParameters - wraps null tool responses in object for Struct compatibility', t => {
+  const resolver = createResolverWithPlugin(Gemini3ReasoningVisionPlugin);
+  const plugin = resolver.modelExecutor.plugin;
+
+  const originalGetCompiledPrompt = plugin.getCompiledPrompt.bind(plugin);
+  plugin.getCompiledPrompt = (text, parameters, prompt) => {
+    const result = originalGetCompiledPrompt(text, parameters, prompt);
+    result.modelPromptMessages = [
+      { role: 'user', content: 'Delete card' },
+      {
+        role: 'assistant', content: '',
+        tool_calls: [{
+          id: 'call_1',
+          function: { name: 'AssetLibrary', arguments: '{"resource":"cards","action":"delete"}' },
+          thoughtSignature: 'test_sig'
+        }]
+      },
+      // Tool returns null
+      { role: 'tool', tool_call_id: 'AssetLibrary_call_1', content: 'null' }
+    ];
+    return result;
+  };
+
+  const params = plugin.getRequestParameters('test', {}, { prompt: 'test' }, { pathway: {} });
+
+  let functionResponseData = null;
+  let found = false;
+  for (const content of params.contents) {
+    for (const part of (content.parts || [])) {
+      if (part.functionResponse) {
+        functionResponseData = part.functionResponse.response;
+        found = true;
+      }
+    }
+  }
+
+  t.true(found, 'Should have a functionResponse');
+  t.true(typeof functionResponseData === 'object' && functionResponseData !== null,
+    'null must be wrapped in an object (Struct)');
+  t.is(functionResponseData.result, null,
+    'Original null should be preserved under "result" key');
+});
+
+test('getRequestParameters - wraps primitive tool responses in object for Struct compatibility', t => {
+  const resolver = createResolverWithPlugin(Gemini3ReasoningVisionPlugin);
+  const plugin = resolver.modelExecutor.plugin;
+
+  const originalGetCompiledPrompt = plugin.getCompiledPrompt.bind(plugin);
+  plugin.getCompiledPrompt = (text, parameters, prompt) => {
+    const result = originalGetCompiledPrompt(text, parameters, prompt);
+    result.modelPromptMessages = [
+      { role: 'user', content: 'Check existence' },
+      {
+        role: 'assistant', content: '',
+        tool_calls: [{
+          id: 'call_1',
+          function: { name: 'AssetLibrary', arguments: '{"resource":"cards","action":"exists"}' },
+          thoughtSignature: 'test_sig'
+        }]
+      },
+      // Tool returns a primitive (boolean)
+      { role: 'tool', tool_call_id: 'AssetLibrary_call_1', content: 'true' }
+    ];
+    return result;
+  };
+
+  const params = plugin.getRequestParameters('test', {}, { prompt: 'test' }, { pathway: {} });
+
+  let functionResponseData = null;
+  for (const content of params.contents) {
+    for (const part of (content.parts || [])) {
+      if (part.functionResponse) {
+        functionResponseData = part.functionResponse.response;
+      }
+    }
+  }
+
+  t.truthy(functionResponseData, 'Should have a functionResponse');
+  t.true(typeof functionResponseData === 'object' && functionResponseData !== null,
+    'Primitive must be wrapped in an object (Struct)');
+  t.is(functionResponseData.result, true,
+    'Original primitive should be preserved under "result" key');
+});
+
 test('Gemini3ReasoningVisionPlugin - inherits from Gemini3ImagePlugin', t => {
   const resolver = createResolverWithPlugin(Gemini3ReasoningVisionPlugin);
   const plugin = resolver.modelExecutor.plugin;
@@ -245,4 +426,3 @@ test('Gemini3ReasoningVisionPlugin - inherits from Gemini3ImagePlugin', t => {
   t.true(typeof plugin.buildToolCallFromFunctionCall === 'function',
     'Should have buildToolCallFromFunctionCall method');
 });
-

--- a/tests/unit/plugins/grokResponsesPlugin.test.js
+++ b/tests/unit/plugins/grokResponsesPlugin.test.js
@@ -1,0 +1,508 @@
+// grokResponsesPlugin.test.js
+// Unit tests for Grok Responses API plugin (xAI Responses API)
+
+import test from 'ava';
+
+// Import the plugin class
+import GrokResponsesPlugin, { safeJsonParse, convertMessagesToResponsesInput } from '../../../server/plugins/grokResponsesPlugin.js';
+import { Prompt } from '../../../server/prompt.js';
+
+// Create a minimal mock pathway and model for testing
+const createMockPlugin = () => {
+    const mockPathway = {
+        name: 'test_pathway',
+        model: {
+            name: 'grok-4'
+        }
+    };
+    const mockModel = {
+        name: 'grok-4',
+        url: 'https://api.x.ai/v1/responses'
+    };
+    return new GrokResponsesPlugin(mockPathway, mockModel);
+};
+
+// ============================================================================
+// Helper Function Tests
+// ============================================================================
+
+test('convertMessagesToResponsesInput leaves string content alone', t => {
+    const messages = [
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'user', content: 'Hello' },
+    ];
+    t.deepEqual(convertMessagesToResponsesInput(messages), messages);
+});
+
+test('convertMessagesToResponsesInput rewrites user text parts to input_text', t => {
+    const out = convertMessagesToResponsesInput([
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }, { type: 'text', text: 'there' }] },
+    ]);
+    t.deepEqual(out, [
+        { role: 'user', content: [{ type: 'input_text', text: 'Hi' }, { type: 'input_text', text: 'there' }] },
+    ]);
+});
+
+test('convertMessagesToResponsesInput rewrites assistant text parts to output_text', t => {
+    const out = convertMessagesToResponsesInput([
+        { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+    ]);
+    t.deepEqual(out, [
+        { role: 'assistant', content: [{ type: 'output_text', text: 'Hi' }] },
+    ]);
+});
+
+test('convertMessagesToResponsesInput rewrites image_url parts to flat input_image', t => {
+    const out = convertMessagesToResponsesInput([
+        {
+            role: 'user',
+            content: [
+                { type: 'text', text: 'What is this?' },
+                { type: 'image_url', image_url: { url: 'https://example.com/cat.jpg', detail: 'high' } },
+            ],
+        },
+    ]);
+    t.deepEqual(out, [
+        {
+            role: 'user',
+            content: [
+                { type: 'input_text', text: 'What is this?' },
+                { type: 'input_image', image_url: 'https://example.com/cat.jpg', detail: 'high' },
+            ],
+        },
+    ]);
+});
+
+test('convertMessagesToResponsesInput accepts already-flat image_url string', t => {
+    const out = convertMessagesToResponsesInput([
+        { role: 'user', content: [{ type: 'image_url', image_url: 'https://example.com/cat.jpg' }] },
+    ]);
+    t.deepEqual(out, [
+        { role: 'user', content: [{ type: 'input_image', image_url: 'https://example.com/cat.jpg' }] },
+    ]);
+});
+
+test('convertMessagesToResponsesInput wraps bare strings in an array', t => {
+    const out = convertMessagesToResponsesInput([
+        { role: 'user', content: ['raw'] },
+        { role: 'assistant', content: ['reply'] },
+    ]);
+    t.deepEqual(out, [
+        { role: 'user', content: [{ type: 'input_text', text: 'raw' }] },
+        { role: 'assistant', content: [{ type: 'output_text', text: 'reply' }] },
+    ]);
+});
+
+test('convertMessagesToResponsesInput passes through unknown part types', t => {
+    const out = convertMessagesToResponsesInput([
+        { role: 'user', content: [{ type: 'custom_thing', payload: { x: 1 } }] },
+    ]);
+    t.deepEqual(out, [
+        { role: 'user', content: [{ type: 'custom_thing', payload: { x: 1 } }] },
+    ]);
+});
+
+test('safeJsonParse should parse valid JSON', t => {
+    const result = safeJsonParse('{"key": "value"}');
+    t.deepEqual(result, { key: 'value' });
+});
+
+test('safeJsonParse should return original string for invalid JSON', t => {
+    const result = safeJsonParse('not valid json');
+    t.is(result, 'not valid json');
+});
+
+test('safeJsonParse should return original for primitive JSON values', t => {
+    // safeJsonParse only returns objects, primitives are returned as-is (original string)
+    t.is(safeJsonParse('"string"'), '"string"');
+    t.is(safeJsonParse('123'), '123');
+});
+
+// ============================================================================
+// Tools Validation and Transformation Tests
+// ============================================================================
+
+test('validateAndTransformTools should handle web_search tool', t => {
+    const plugin = createMockPlugin();
+    const tools = {
+        web_search: true
+    };
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 1);
+    t.is(result[0].type, 'web_search');
+});
+
+test('validateAndTransformTools should handle x_search tool', t => {
+    const plugin = createMockPlugin();
+    const tools = {
+        x_search: true
+    };
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 1);
+    t.is(result[0].type, 'x_search');
+});
+
+test('validateAndTransformTools should handle web_search with domain filters', t => {
+    const plugin = createMockPlugin();
+    const tools = {
+        web_search: {
+            allowed_domain: ['example.com', 'test.org'],
+            excluded_domain: ['spam.com']
+        }
+    };
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 1);
+    t.is(result[0].type, 'web_search');
+    t.deepEqual(result[0].filters.allowed_domains, ['example.com', 'test.org']);
+    t.deepEqual(result[0].filters.excluded_domains, ['spam.com']);
+});
+
+test('validateAndTransformTools should handle x_search with handles', t => {
+    const plugin = createMockPlugin();
+    const tools = {
+        x_search: {
+            allowed_x_handles: ['OpenAI', 'xai'],
+            excluded_x_handles: ['spam_bot']
+        }
+    };
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 1);
+    t.is(result[0].type, 'x_search');
+    t.deepEqual(result[0].allowed_x_handles, ['OpenAI', 'xai']);
+    t.deepEqual(result[0].excluded_x_handles, ['spam_bot']);
+});
+
+test('validateAndTransformTools should handle x_search with date range', t => {
+    const plugin = createMockPlugin();
+    const tools = {
+        x_search: {
+            from_date: '2025-01-01',
+            to_date: '2025-01-31'
+        }
+    };
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 1);
+    t.is(result[0].type, 'x_search');
+    t.is(result[0].from_date, '2025-01-01');
+    t.is(result[0].to_date, '2025-01-31');
+});
+
+test('validateAndTransformTools should handle both web_search and x_search', t => {
+    const plugin = createMockPlugin();
+    const tools = {
+        web_search: true,
+        x_search: true
+    };
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 2);
+
+    const types = result.map(tool => tool.type);
+    t.true(types.includes('web_search'));
+    t.true(types.includes('x_search'));
+});
+
+test('validateAndTransformTools should pass through array format', t => {
+    const plugin = createMockPlugin();
+    const tools = [
+        { type: 'web_search' },
+        { type: 'x_search', allowed_x_handles: ['test'] }
+    ];
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.deepEqual(result, tools);
+});
+
+// ============================================================================
+// Legacy search_parameters Conversion Tests
+// ============================================================================
+
+test('convertSearchParametersToTools should convert web source', t => {
+    const plugin = createMockPlugin();
+    const searchParams = {
+        sources: [{ type: 'web' }]
+    };
+
+    const result = plugin.convertSearchParametersToTools(searchParams);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 1);
+    t.is(result[0].type, 'web_search');
+});
+
+test('convertSearchParametersToTools should convert x source', t => {
+    const plugin = createMockPlugin();
+    const searchParams = {
+        sources: [{ type: 'x' }]
+    };
+
+    const result = plugin.convertSearchParametersToTools(searchParams);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 1);
+    t.is(result[0].type, 'x_search');
+});
+
+test('convertSearchParametersToTools should convert both sources', t => {
+    const plugin = createMockPlugin();
+    const searchParams = {
+        sources: [{ type: 'web' }, { type: 'x' }]
+    };
+
+    const result = plugin.convertSearchParametersToTools(searchParams);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 2);
+
+    const types = result.map(tool => tool.type);
+    t.true(types.includes('web_search'));
+    t.true(types.includes('x_search'));
+});
+
+test('convertSearchParametersToTools should add default tools when no sources specified', t => {
+    const plugin = createMockPlugin();
+    const searchParams = {
+        mode: 'auto'
+    };
+
+    const result = plugin.convertSearchParametersToTools(searchParams);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 2);
+
+    const types = result.map(tool => tool.type);
+    t.true(types.includes('web_search'));
+    t.true(types.includes('x_search'));
+});
+
+test('convertSearchParametersToTools should return null for mode: off', t => {
+    const plugin = createMockPlugin();
+    const searchParams = {
+        mode: 'off',
+        sources: []
+    };
+
+    const result = plugin.convertSearchParametersToTools(searchParams);
+
+    t.is(result, null);
+});
+
+test('convertSearchParametersToTools should handle x handles', t => {
+    const plugin = createMockPlugin();
+    const searchParams = {
+        sources: [{
+            type: 'x',
+            included_x_handles: ['OpenAI', 'xai'],
+            excluded_x_handles: ['spam']
+        }]
+    };
+
+    const result = plugin.convertSearchParametersToTools(searchParams);
+
+    t.true(Array.isArray(result));
+    t.is(result.length, 1);
+    t.is(result[0].type, 'x_search');
+    t.deepEqual(result[0].allowed_x_handles, ['OpenAI', 'xai']);
+    t.deepEqual(result[0].excluded_x_handles, ['spam']);
+});
+
+// ============================================================================
+// Response Parsing Tests
+// ============================================================================
+
+test('parseResponsesApiFormat should extract output_text', t => {
+    const plugin = createMockPlugin();
+    const data = {
+        id: 'resp_123',
+        output_text: 'Hello from Grok!',
+        status: 'completed',
+        usage: { input_tokens: 10, output_tokens: 5 }
+    };
+
+    const result = plugin.parseResponsesApiFormat(data);
+
+    t.is(result.output_text, 'Hello from Grok!');
+    t.is(result.finishReason, 'completed');
+});
+
+test('parseResponsesApiFormat should handle citations array', t => {
+    const plugin = createMockPlugin();
+    const data = {
+        id: 'resp_123',
+        output_text: 'Here is some info [[1]](https://example.com)',
+        citations: ['https://example.com', 'https://test.org'],
+        status: 'completed'
+    };
+
+    const result = plugin.parseResponsesApiFormat(data);
+
+    t.truthy(result.citations);
+    t.is(result.citations.length, 2);
+    t.is(result.citations[0].url, 'https://example.com');
+    t.is(result.citations[1].url, 'https://test.org');
+});
+
+test('parseResponsesApiFormat should extract inline citations from text', t => {
+    const plugin = createMockPlugin();
+    const data = {
+        id: 'resp_123',
+        output_text: 'According to [[1]](https://example.com/article) and [[2]](https://test.org/post), this is true.',
+        status: 'completed'
+    };
+
+    const result = plugin.parseResponsesApiFormat(data);
+
+    t.truthy(result.citations);
+    t.is(result.citations.length, 2);
+    t.is(result.citations[0].url, 'https://example.com/article');
+    t.is(result.citations[1].url, 'https://test.org/post');
+});
+
+test('parseResponsesApiFormat should extract rich metadata from X citations', t => {
+    const plugin = createMockPlugin();
+    const data = {
+        id: 'resp_123',
+        output_text: '@elonmusk posted "This is exciting news!" [[1]](https://x.com/elonmusk/status/123456789)',
+        status: 'completed'
+    };
+
+    const result = plugin.parseResponsesApiFormat(data);
+
+    t.truthy(result.citations);
+    t.is(result.citations.length, 1);
+    t.is(result.citations[0].url, 'https://x.com/elonmusk/status/123456789');
+    t.is(result.citations[0].author, 'elonmusk');
+});
+
+test('parseResponsesApiFormat should handle output array format', t => {
+    const plugin = createMockPlugin();
+    const data = {
+        id: 'resp_123',
+        output: [
+            {
+                type: 'message',
+                content: [
+                    { type: 'output_text', text: 'Part 1' },
+                    { type: 'output_text', text: ' Part 2' }
+                ]
+            }
+        ],
+        status: 'completed'
+    };
+
+    const result = plugin.parseResponsesApiFormat(data);
+
+    t.is(result.output_text, 'Part 1 Part 2');
+});
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+test('parseResponse should handle empty data', t => {
+    const plugin = createMockPlugin();
+    const result = plugin.parseResponse(null);
+    t.is(result, '');
+});
+
+test('parseResponse should handle legacy OpenAI format', t => {
+    const plugin = createMockPlugin();
+    const data = {
+        choices: [
+            {
+                message: {
+                    content: 'Hello!',
+                    role: 'assistant'
+                },
+                finish_reason: 'stop'
+            }
+        ]
+    };
+
+    const result = plugin.parseResponse(data);
+
+    t.is(result.output_text, 'Hello!');
+    t.is(result.finishReason, 'stop');
+});
+
+test('processStreamEvent should ignore OpenAI response lifecycle events', t => {
+    const plugin = createMockPlugin();
+    const requestProgress = {};
+    const eventData = {
+        type: 'response.completed',
+        response: { id: 'resp_123' }
+    };
+
+    const result = plugin.processStreamEvent({ data: JSON.stringify(eventData) }, requestProgress);
+
+    t.is(result.progress, undefined);
+    t.is(result.data, undefined);
+});
+
+test('validateAndTransformTools should limit handles to 10', t => {
+    const plugin = createMockPlugin();
+    const manyHandles = Array.from({ length: 15 }, (_, i) => `handle${i}`);
+    const tools = {
+        x_search: {
+            allowed_x_handles: manyHandles
+        }
+    };
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.is(result[0].allowed_x_handles.length, 10);
+});
+
+test('getRequestParameters converts max_tokens to max_output_tokens for Responses API', async t => {
+    const plugin = createMockPlugin();
+
+    const params = await plugin.getRequestParameters('hello', {}, new Prompt({
+        messages: [{ role: 'user', content: '{{{text}}}' }]
+    }));
+
+    t.true(typeof params.max_output_tokens === 'number' && params.max_output_tokens > 0);
+    t.false(Object.prototype.hasOwnProperty.call(params, 'max_tokens'));
+});
+
+test('getRequestParameters prefers caller-supplied max_output_tokens over derived max_tokens', async t => {
+    const plugin = createMockPlugin();
+
+    const params = await plugin.getRequestParameters('hello', { max_output_tokens: 1234 }, new Prompt({
+        messages: [{ role: 'user', content: '{{{text}}}' }]
+    }));
+
+    t.is(params.max_output_tokens, 1234);
+    t.false(Object.prototype.hasOwnProperty.call(params, 'max_tokens'));
+});
+
+test('validateAndTransformTools should limit domains to 5', t => {
+    const plugin = createMockPlugin();
+    const manyDomains = Array.from({ length: 10 }, (_, i) => `domain${i}.com`);
+    const tools = {
+        web_search: {
+            allowed_domain: manyDomains
+        }
+    };
+
+    const result = plugin.validateAndTransformTools(tools);
+
+    t.is(result[0].filters.allowed_domains.length, 5);
+});

--- a/tests/unit/plugins/grokVisionPlugin.test.js
+++ b/tests/unit/plugins/grokVisionPlugin.test.js
@@ -69,6 +69,88 @@ test('should handle Grok-specific parameters', async t => {
   // Vision parameters are handled in message content, not as top-level parameters
 });
 
+test('should map reasoning effort for Grok requests', async t => {
+  const mockPathway = {
+    name: 'test-pathway',
+    temperature: 0.7,
+    prompt: 'Test prompt'
+  };
+
+  const mockModel = {
+    name: 'xai-grok-4-3',
+    type: 'GROK-VISION',
+    url: 'https://api.x.ai/v1/chat/completions',
+    headers: {
+      'Authorization': 'Bearer test-key',
+      'Content-Type': 'application/json'
+    },
+    params: {
+      model: 'grok-4.3'
+    },
+    reasoningEffortMap: {
+      none: 'none',
+      low: 'low',
+      medium: 'medium',
+      high: 'high'
+    },
+    maxTokenLength: 1000000,
+    maxReturnTokens: 128000
+  };
+
+  const plugin = new GrokVisionPlugin(mockPathway, mockModel);
+
+  for (const effort of ['none', 'low', 'medium', 'high']) {
+    const requestParams = await plugin.getRequestParameters(
+      'test text',
+      { reasoningEffort: effort },
+      {}
+    );
+    t.is(requestParams.reasoning_effort, effort);
+  }
+});
+
+test('should not send reasoning effort for Grok models without an explicit map', async t => {
+  const mockPathway = {
+    name: 'test-pathway',
+    temperature: 0.7,
+    prompt: 'Test prompt'
+  };
+
+  const grokModelsWithoutReasoningEffort = [
+    ['xai-grok-4-20-reasoning', 'grok-4.20-0309-reasoning'],
+    ['xai-grok-4-20-non-reasoning', 'grok-4.20-0309-non-reasoning'],
+    ['xai-grok-4-1-fast-reasoning', 'grok-4-1-fast-reasoning'],
+    ['xai-grok-4-1-fast-non-reasoning', 'grok-4-1-fast-non-reasoning'],
+    ['xai-grok-code-fast-1', 'grok-code-fast-1'],
+  ];
+
+  for (const [name, providerModel] of grokModelsWithoutReasoningEffort) {
+    const mockModel = {
+      name,
+      type: 'GROK-VISION',
+      url: 'https://api.x.ai/v1/chat/completions',
+      headers: {
+        'Authorization': 'Bearer test-key',
+        'Content-Type': 'application/json'
+      },
+      params: {
+        model: providerModel
+      },
+      maxTokenLength: 2000000,
+      maxReturnTokens: 128000
+    };
+
+    const plugin = new GrokVisionPlugin(mockPathway, mockModel);
+    const requestParams = await plugin.getRequestParameters(
+      'test text',
+      { reasoningEffort: 'high' },
+      {}
+    );
+
+    t.is(requestParams.reasoning_effort, undefined, `${name} should omit reasoning_effort`);
+  }
+});
+
 test('should handle all Live Search parameters correctly', async t => {
   const mockPathway = {
     name: 'test-pathway',

--- a/tests/unit/plugins/multimodal_conversion.test.js
+++ b/tests/unit/plugins/multimodal_conversion.test.js
@@ -1,8 +1,44 @@
 import test from 'ava';
 import OpenAIVisionPlugin from '../../../server/plugins/openAiVisionPlugin.js';
 import Claude3VertexPlugin from '../../../server/plugins/claude3VertexPlugin.js';
+import Claude4VertexPlugin from '../../../server/plugins/claude4VertexPlugin.js';
+import ClaudeAnthropicPlugin from '../../../server/plugins/claudeAnthropicPlugin.js';
 import Gemini15VisionPlugin from '../../../server/plugins/gemini15VisionPlugin.js';
 import GeminiVisionPlugin from '../../../server/plugins/geminiVisionPlugin.js';
+import axios from 'axios';
+
+const originalAxiosHead = axios.head;
+const originalAxiosGet = axios.get;
+const sampleJpegBuffer = Buffer.concat([
+    Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+    Buffer.alloc(256, 0),
+    Buffer.from([0xff, 0xd9]),
+]);
+const samplePdfBuffer = Buffer.concat([
+    Buffer.from('%PDF-1.4\n'),
+    Buffer.alloc(256, 65),
+    Buffer.from('\n%%EOF'),
+]);
+
+test.before(() => {
+    axios.head = async (url) => ({
+        headers: {
+            'content-type': String(url).endsWith('.pdf') ? 'application/pdf' : 'image/jpeg',
+        },
+    });
+    axios.get = async (url) => {
+        const isPdf = String(url).endsWith('.pdf');
+        return {
+            headers: { 'content-type': isPdf ? 'application/pdf' : 'image/jpeg' },
+            data: isPdf ? samplePdfBuffer : sampleJpegBuffer,
+        };
+    };
+});
+
+test.after.always(() => {
+    axios.head = originalAxiosHead;
+    axios.get = originalAxiosGet;
+});
 
 // Mock pathway and model for plugin initialization
 const mockPathway = { name: 'test', temperature: 0.7 };
@@ -134,7 +170,7 @@ test('Cortex special properties conversion', async (t) => {
     const { modifiedMessages: geminiMessages15, system: geminiSystem15 } = gemini15.convertMessagesToGemini(cortexMessages);
 
     // Check Claude conversion
-    t.true(claudeMessages[0].content[1].source.data.startsWith('/9j/4AAQ'));
+    t.true(validateBase64Image(claudeMessages[0].content[1].source.data));
 
     // Check Gemini conversion
     t.is(geminiMessages[0].parts[1].fileData.fileUri, 'gs://cortex-bucket/special-image.png');
@@ -507,6 +543,28 @@ test('Gemini 1.5 image URL edge cases', t => {
     t.is(modifiedMessages[0].parts.length, 1, 'Should only have the text part');
 });
 
+test('Gemini 1.5 preserves mimeType for signed blob URLs', t => {
+    const { gemini15 } = createPlugins();
+
+    const signedCsvUrl = 'https://myaccount.blob.core.windows.net/container/sample-production.users.csv?sv=2025-05-05&sig=abc123';
+    const messages = [
+        { role: 'user', content: [
+            { type: 'text', text: 'Process this file:' },
+            {
+                type: 'image_url',
+                mimeType: 'text/csv',
+                image_url: { url: signedCsvUrl }
+            }
+        ]}
+    ];
+
+    const { modifiedMessages } = gemini15.convertMessagesToGemini(messages);
+
+    t.true('fileData' in modifiedMessages[0].parts[1]);
+    t.is(modifiedMessages[0].parts[1].fileData.fileUri, signedCsvUrl);
+    t.is(modifiedMessages[0].parts[1].fileData.mimeType, 'text/csv');
+});
+
 // Test multiple images in single message for Claude
 test('Multiple images in single Claude message', async (t) => {
     const { claude } = createPlugins();
@@ -595,4 +653,136 @@ test('Large image handling', async (t) => {
     // (The exact behavior - rejection vs. compression - should match the model's specifications)
     t.is(claudeMessages[0].content[0].text, 'Check this large image:');
     t.is(geminiMessages[0].parts[0].text, 'Check this large image:');
+});
+
+// Test Claude 4 Vertex defaults to base64 for HTTP URLs (Vertex doesn't support URL sources)
+test('Claude 4 Vertex HTTP URL defaults to base64', async (t) => {
+    const claude4 = new Claude4VertexPlugin(mockPathway, mockModel);
+
+    const messages = [
+        { role: 'user', content: [
+            { type: 'text', text: 'What is in this image?' },
+            { type: 'image_url', image_url: { url: 'https://static.toiimg.com/thumb/msid-102827471,width-1280,height-720,resizemode-4/102827471.jpg' } }
+        ]}
+    ];
+
+    const { modifiedMessages } = await claude4.convertMessagesToClaudeVertex(messages);
+
+    t.is(modifiedMessages[0].content.length, 2);
+    t.is(modifiedMessages[0].content[0].text, 'What is in this image?');
+    t.is(modifiedMessages[0].content[1].type, 'image');
+    t.is(modifiedMessages[0].content[1].source.type, 'base64');
+    t.truthy(modifiedMessages[0].content[1].source.data);
+    t.true(validateBase64Image(modifiedMessages[0].content[1].source.data));
+});
+
+// Test Claude 4 Vertex with supportsImageUrls:true explicitly enabled uses URL passthrough
+test('Claude 4 Vertex with supportsImageUrls true uses url passthrough', async (t) => {
+    const claude4 = new Claude4VertexPlugin(mockPathway, { name: 'test-model', supportsImageUrls: true });
+
+    const messages = [
+        { role: 'user', content: [
+            { type: 'text', text: 'What is in this image?' },
+            { type: 'image_url', image_url: { url: 'https://example.com/photo.jpg' } }
+        ]}
+    ];
+
+    const { modifiedMessages } = await claude4.convertMessagesToClaudeVertex(messages);
+
+    t.is(modifiedMessages[0].content[1].type, 'image');
+    t.is(modifiedMessages[0].content[1].source.type, 'url');
+    t.is(modifiedMessages[0].content[1].source.url, 'https://example.com/photo.jpg');
+});
+
+// Test Claude 4 data: URL still uses base64 (data is already inline)
+test('Claude 4 data URL still uses base64', async (t) => {
+    const claude4 = new Claude4VertexPlugin(mockPathway, mockModel);
+
+    const messages = [
+        { role: 'user', content: [
+            { type: 'text', text: 'What is this?' },
+            { type: 'image_url', image_url: { url: sampleBase64Image } }
+        ]}
+    ];
+
+    const { modifiedMessages } = await claude4.convertMessagesToClaudeVertex(messages);
+
+    t.is(modifiedMessages[0].content[1].type, 'image');
+    t.is(modifiedMessages[0].content[1].source.type, 'base64');
+    t.truthy(modifiedMessages[0].content[1].source.data);
+    t.is(modifiedMessages[0].content[1].source.media_type, 'image/jpeg');
+});
+
+// Test data: URL still uses base64 even when supportsImageUrls is true
+test('Claude 4 data URL uses base64 even with supportsImageUrls true', async (t) => {
+    const claude4 = new Claude4VertexPlugin(mockPathway, { name: 'test-model', supportsImageUrls: true });
+
+    const messages = [
+        { role: 'user', content: [
+            { type: 'text', text: 'What is this?' },
+            { type: 'image_url', image_url: { url: sampleBase64Image } }
+        ]}
+    ];
+
+    const { modifiedMessages } = await claude4.convertMessagesToClaudeVertex(messages);
+
+    t.is(modifiedMessages[0].content[1].type, 'image');
+    t.is(modifiedMessages[0].content[1].source.type, 'base64');
+    t.truthy(modifiedMessages[0].content[1].source.data);
+});
+
+// Test Claude 3 still uses base64 for HTTP URLs (unchanged behavior)
+test('Claude 3 HTTP URL still uses base64', async (t) => {
+    const claude3 = new Claude3VertexPlugin(mockPathway, mockModel);
+
+    const messages = [
+        { role: 'user', content: [
+            { type: 'text', text: 'Analyze this:' },
+            { type: 'image_url', image_url: { url: 'https://static.toiimg.com/thumb/msid-102827471,width-1280,height-720,resizemode-4/102827471.jpg' } }
+        ]}
+    ];
+
+    const { modifiedMessages } = await claude3.convertMessagesToClaudeVertex(messages);
+
+    t.is(modifiedMessages[0].content[1].type, 'image');
+    t.is(modifiedMessages[0].content[1].source.type, 'base64');
+    t.truthy(modifiedMessages[0].content[1].source.data);
+    t.true(validateBase64Image(modifiedMessages[0].content[1].source.data));
+});
+
+// Test ClaudeAnthropicPlugin uses URL passthrough (direct Anthropic API supports it)
+test('ClaudeAnthropicPlugin HTTP URL uses source.type url passthrough', async (t) => {
+    const anthropic = new ClaudeAnthropicPlugin(mockPathway, mockModel);
+
+    const messages = [
+        { role: 'user', content: [
+            { type: 'text', text: 'What do you see?' },
+            { type: 'image_url', image_url: { url: 'https://example.com/image.png' } }
+        ]}
+    ];
+
+    const { modifiedMessages } = await anthropic.convertMessagesToClaudeVertex(messages);
+
+    t.is(modifiedMessages[0].content[1].type, 'image');
+    t.is(modifiedMessages[0].content[1].source.type, 'url');
+    t.is(modifiedMessages[0].content[1].source.url, 'https://example.com/image.png');
+});
+
+// Test ClaudeAnthropicPlugin with supportsImageUrls:false falls back to base64
+test('ClaudeAnthropicPlugin with supportsImageUrls false falls back to base64', async (t) => {
+    const anthropic = new ClaudeAnthropicPlugin(mockPathway, { name: 'test-model', supportsImageUrls: false });
+
+    const messages = [
+        { role: 'user', content: [
+            { type: 'text', text: 'Describe this:' },
+            { type: 'image_url', image_url: { url: 'https://static.toiimg.com/thumb/msid-102827471,width-1280,height-720,resizemode-4/102827471.jpg' } }
+        ]}
+    ];
+
+    const { modifiedMessages } = await anthropic.convertMessagesToClaudeVertex(messages);
+
+    t.is(modifiedMessages[0].content[1].type, 'image');
+    t.is(modifiedMessages[0].content[1].source.type, 'base64');
+    t.truthy(modifiedMessages[0].content[1].source.data);
+    t.true(validateBase64Image(modifiedMessages[0].content[1].source.data));
 });

--- a/tests/unit/plugins/openAiChatPlugin.test.js
+++ b/tests/unit/plugins/openAiChatPlugin.test.js
@@ -62,6 +62,74 @@ test('getRequestParameters', async (t) => {
     });
 });
 
+test('getRequestParameters requests usage for OpenAI-family streams', async (t) => {
+    const plugin = new OpenAIChatPlugin(pathway, model);
+    const result = await plugin.getRequestParameters('Help me', { stream: true }, mockPathwayResolverMessages.pathway.prompt);
+
+    t.deepEqual(result.stream_options, { include_usage: true });
+});
+
+test('getRequestParameters does not request stream usage for non-OpenAI adapters', async (t) => {
+    const plugin = new OpenAIChatPlugin(pathway, { ...model, type: 'KIMI-CHAT' });
+    const result = await plugin.getRequestParameters('Help me', { stream: true }, mockPathwayResolverMessages.pathway.prompt);
+
+    t.is(result.stream_options, undefined);
+});
+
+test('processStreamEvent does not complete stream on finish_reason before DONE', (t) => {
+    const plugin = new OpenAIChatPlugin(pathway, model);
+    const finishEvent = {
+        data: JSON.stringify({
+            choices: [
+                {
+                    delta: {},
+                    finish_reason: 'stop',
+                },
+            ],
+        }),
+    };
+    const usageEvent = {
+        data: JSON.stringify({
+            choices: [],
+            usage: {
+                prompt_tokens: 10,
+                completion_tokens: 2,
+                total_tokens: 12,
+            },
+        }),
+    };
+
+    const afterFinish = plugin.processStreamEvent(finishEvent, { requestId: 'req_1' });
+    t.is(afterFinish.progress, undefined);
+    t.is(afterFinish.data, finishEvent.data);
+
+    const afterUsage = plugin.processStreamEvent(usageEvent, { requestId: 'req_1' });
+    t.is(afterUsage.progress, undefined);
+    t.is(afterUsage.data, undefined);
+
+    const afterDone = plugin.processStreamEvent({ data: '[DONE]' }, { requestId: 'req_1' });
+    t.is(afterDone.progress, 1);
+});
+
+test('processStreamEvent waits for DONE when usage is not expected', (t) => {
+    const plugin = new OpenAIChatPlugin(pathway, model);
+    const finishEvent = {
+        data: JSON.stringify({
+            choices: [
+                {
+                    delta: {},
+                    finish_reason: 'stop',
+                },
+            ],
+        }),
+    };
+
+    const afterFinish = plugin.processStreamEvent(finishEvent, { requestId: 'req_1' });
+
+    t.is(afterFinish.progress, undefined);
+    t.is(afterFinish.data, finishEvent.data);
+});
+
 // Test the execute function
 test('execute', async (t) => {
     const plugin = new OpenAIChatPlugin(pathway, model);


### PR DESCRIPTION
## Summary

- updates Claude, Gemini, Grok, Groq, Ollama, local, and OpenAI model adapters
- adds tool-call, thinking, multimodal, streaming, and search-parameter coverage for model plugins
- makes copied multimodal fixtures deterministic for local test runs

## Notes

Stacked on #455, which adds the model/media runtime and Responses support used by this adapter coverage.

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/plugins/claude3VertexPlugin.test.js tests/unit/plugins/claude3VertexToolConversion.test.js tests/unit/plugins/claude4VertexPlugin.test.js tests/unit/plugins/claude4VertexToolConversion.test.js tests/unit/plugins/claudeAnthropicPlugin.test.js tests/unit/plugins/gemini15VisionPlugin.test.js tests/unit/plugins/gemini3ReasoningVisionPlugin.test.js tests/unit/plugins/grokResponsesPlugin.test.js tests/unit/plugins/grokVisionPlugin.test.js tests/unit/plugins/multimodal_conversion.test.js tests/unit/plugins/openAiChatPlugin.test.js tests/unit/plugins.streaming/plugin_stream_events.test.js`
- `git diff --cached --check`