### PR TITLE
Port streaming tool runtime from aj-cortex

### DIFF
--- a/server/clientToolCallbacks.js
+++ b/server/clientToolCallbacks.js
@@ -10,7 +10,7 @@ import { config } from '../config.js';
 const pendingCallbacks = new Map();
 
 // Default timeout for client tool responses (5 minutes)
-// Increased from 60s to 5min to accommodate longer operations like CreateApplet
+// Increased from 60s to 5min to accommodate longer operations like CreateWorkspace
 const DEFAULT_TIMEOUT = 300000;
 
 // Redis setup for cross-instance communication

--- a/server/graphql.js
+++ b/server/graphql.js
@@ -17,15 +17,17 @@ import { KeyvAdapter } from '@apollo/utils.keyvadapter';
 import cors from 'cors';
 import { buildModels, buildPathways } from '../config.js';
 import logger from '../lib/logger.js';
+import { getEntityStore } from '../lib/MongoEntityStore.js';
 import { buildModelEndpoints } from '../lib/requestExecutor.js';
 import { startModelSampler } from '../lib/modelSampler.js';
 import { startTestServer } from '../tests/helpers/server.js';
 import { requestState } from './requestState.js';
-import { cancelRequestResolver, submitClientToolResultResolver } from './resolver.js';
+import { cancelRequestResolver, submitClientToolResultResolver, injectAgentMessageResolver } from './resolver.js';
 import subscriptions from './subscriptions.js';
 import { getMessageTypeDefs } from './typeDef.js';
 import { buildRestEndpoints } from './rest.js';
 import { executeWorkspaceResolver, getExecuteWorkspaceTypeDefs } from './executeWorkspace.js';
+import crypto from 'crypto';
 
 // Utility functions
 // Server plugins
@@ -58,6 +60,15 @@ const getPlugins = (config) => {
     return { plugins, cache };
 }
 
+const hashApiKey = (apiKey) => {
+    if (!apiKey) return null;
+    try {
+        return crypto.createHash('sha256').update(String(apiKey)).digest('hex').slice(0, 12);
+    } catch {
+        return null;
+    }
+};
+
 // Type Definitions for GraphQL
 const getTypedefs = (pathways, pathwayManager) => {
     const defaultTypeDefs = `#graphql
@@ -81,6 +92,7 @@ const getTypedefs = (pathways, pathwayManager) => {
     type Mutation {
         cancelRequest(requestId: String!): Boolean
         submitClientToolResult(requestId: String!, toolCallbackId: String!, result: String!, success: Boolean!): Boolean
+        injectAgentMessage(requestId: String!, message: String!): Boolean
     }
 
     ${getExecuteWorkspaceTypeDefs()}
@@ -137,12 +149,13 @@ const getResolvers = (config, pathways, pathwayManager) => {
     const resolvers = {
         Query: {
             ...queryResolvers,
-            executeWorkspace: (parent, args, contextValue, info) => 
+            executeWorkspace: (parent, args, contextValue, info) =>
                 executeWorkspaceResolver(parent, args, contextValue, info, config, pathwayManager)
         },
         Mutation: {
             'cancelRequest': cancelRequestResolver,
             'submitClientToolResult': submitClientToolResultResolver,
+            'injectAgentMessage': injectAgentMessageResolver,
             ...mutationResolvers,
             ...pathwayManagerResolvers.Mutation
         },
@@ -160,7 +173,20 @@ const build = async (config) => {
 
     // build model API endpoints and limiters
     buildModelEndpoints(config);
+
+    // OOB sampler keeps modelGroup member latency stats fresh on idle models.
     startModelSampler(config);
+
+    // Sync config-defined entities to MongoDB and warm cache
+    try {
+        const entityStore = getEntityStore();
+        if (entityStore.isConfigured()) {
+            await entityStore.syncConfigEntities(config.get('entityConfig'));
+            await entityStore.loadAllEntities();
+        }
+    } catch (error) {
+        logger.error(`Entity sync failed (non-fatal): ${error.message}`);
+    }
 
     //build api
     const pathways = config.get('pathways');
@@ -225,8 +251,13 @@ const build = async (config) => {
         app.use((req, res, next) => {
             let providedApiKey = req.headers['cortex-api-key'] || req.query['cortex-api-key'];
             if (!providedApiKey) {
+                // Support OpenAI-style Bearer token
                 providedApiKey = req.headers['authorization'];
                 providedApiKey = providedApiKey?.startsWith('Bearer ') ? providedApiKey.slice(7) : providedApiKey;
+            }
+            if (!providedApiKey) {
+                // Support Anthropic-style x-api-key header
+                providedApiKey = req.headers['x-api-key'];
             }
 
             if (!cortexApiKeys.includes(providedApiKey)) {
@@ -251,6 +282,7 @@ const build = async (config) => {
                         .send('Unauthorized');
                 }
             } else {
+                req.cortexApiKeyId = hashApiKey(providedApiKey);
                 next();
             }
         });

--- a/server/pathwayResolver.js
+++ b/server/pathwayResolver.js
@@ -11,10 +11,12 @@ import { requestState } from './requestState.js';
 import { normalizeUsage } from './rest/restUtils.js';
 import { callPathway, addCitationsToResolver } from '../lib/pathwayTools.js';
 import logger from '../lib/logger.js';
+import { clearPendingMessages } from './pendingUserMessages.js';
 import { publishRequestProgress } from '../lib/redisSubscription.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createParser } from 'eventsource-parser';
 import CortexResponse from '../lib/cortexResponse.js';
+import latencyTrace from '../lib/latencyTrace.js';
 
 const modelTypesExcludedFromProgressUpdates = ['OPENAI-DALLE2', 'OPENAI-DALLE3'];
 
@@ -80,6 +82,16 @@ class PathwayResolver {
 
         // set up initial prompt
         this.pathwayPrompt = pathway.prompt;
+
+        latencyTrace.mark('resolver.created', {
+            requestId: this.requestId,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+            stream: Boolean(args?.stream),
+            async: Boolean(args?.async),
+            chatHistoryLength: Array.isArray(args?.chatHistory) ? args.chatHistory.length : undefined,
+            tools: Array.isArray(args?.entityToolsOpenAiFormat) ? args.entityToolsOpenAiFormat.length : undefined,
+        });
     }
     
     // Legacy 'tool' property is now stored in pathwayResultData
@@ -91,8 +103,6 @@ class PathwayResolver {
                 toolCallbackName: this.pathwayResultData.toolCallbackName, 
                 title: this.pathwayResultData.title,
                 search: this.pathwayResultData.search,
-                coding: this.pathwayResultData.coding,
-                codeRequestId: this.pathwayResultData.codeRequestId,
                 toolCallbackId: this.pathwayResultData.toolCallbackId,
                 toolUsed: this.pathwayResultData.toolUsed,
                 citations: this.pathwayResultData.citations,
@@ -112,6 +122,17 @@ class PathwayResolver {
             // Optionally warn: invalid format or merge error
             console.warn('Invalid tool property assignment:', e);
         }
+    }
+
+    /**
+     * Check if this request has been canceled. Checks both the direct
+     * requestId and rootRequestId (for nested/child requests).
+     */
+    isCanceled() {
+        return !!(
+            (requestState[this.requestId] || {}).canceled ||
+            (this.rootRequestId && (requestState[this.rootRequestId] || {}).canceled)
+        );
     }
 
     publishNestedRequestProgress(requestProgress) {
@@ -138,6 +159,12 @@ class PathwayResolver {
     // This code handles async and streaming responses for either long-running
     // tasks or streaming model responses
     async asyncResolve(args) {
+        const span = latencyTrace.start('resolver.asyncResolve', {
+            requestId: this.requestId,
+            rootRequestId: this.rootRequestId || undefined,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+        });
         let responseData = null;
 
         try {
@@ -152,6 +179,7 @@ class PathwayResolver {
                 info: '',
                 error: this.errors.join(', ')
             });
+            latencyTrace.end(span, { responseKind: 'error', errors: this.errors.length });
             return;
         }
 
@@ -163,6 +191,7 @@ class PathwayResolver {
                 info: '',
                 error: this.errors.join(', ')
             });
+            latencyTrace.end(span, { responseKind: 'empty', errors: this.errors.length });
             return;
         }
 
@@ -191,6 +220,11 @@ class PathwayResolver {
                 });
             }
         }
+
+        latencyTrace.end(span, {
+            responseKind: responseData && typeof responseData.on === 'function' ? 'stream' : typeof responseData,
+            errors: this.errors.length,
+        });
     }
 
     mergeResolver(otherResolver) {
@@ -318,20 +352,52 @@ class PathwayResolver {
     }
 
     async handleStream(response) {
+        const requestId = this.rootRequestId || this.requestId;
+        const span = latencyTrace.start('stream.read', {
+            requestId,
+            resolverRequestId: this.requestId,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+        });
         let streamErrorOccurred = false;
         let streamErrorMessage = null;
         let completionSent = false;
         let receivedSSEData = false; // Track if we actually received SSE events
         let receivedAnyData = false; // Track if we received ANY data from the stream
         let toolCallbackInvoked = false; // Track if a tool callback was invoked (stream close is expected)
+        let firstChunkLogged = false;
+        let firstSSELogged = false;
+        let firstPublishLogged = false;
+        let dataChunkCount = 0;
+        let sseEventCount = 0;
+        let publishedEventCount = 0;
+        this.toolCallbackInvoked = false; // Expose to callers (e.g., agent loop) so they know not to race
         // Accumulate streamed content for continuity memory
         this.streamedContent = '';
-        const requestId = this.rootRequestId || this.requestId;
 
         if (response && typeof response.on === 'function') {
             try {
                 const incomingMessage = response;
                 let streamEnded = false;
+                const existingAbortRequest = requestState[requestId]?.abortRequest;
+                const abortStream = () => {
+                    if (typeof existingAbortRequest === 'function') {
+                        existingAbortRequest();
+                    }
+                    if (!streamEnded && typeof incomingMessage.destroy === 'function') {
+                        incomingMessage.destroy(new Error('Request canceled'));
+                    }
+                };
+                requestState[requestId] = {
+                    ...requestState[requestId],
+                    abortRequest: abortStream,
+                };
+                const clearAbortStream = () => {
+                    if (requestState[requestId]?.abortRequest === abortStream) {
+                        delete requestState[requestId].abortRequest;
+                    }
+                };
+                let finishStreamRead = null;
 
                 const onParse = (event) => {
                     let requestProgress = {
@@ -347,7 +413,16 @@ class PathwayResolver {
                         logger.debug(`data: ${event.data}`)
 
                         receivedSSEData = true; // Only mark SSE data when we get actual 'event' type
-                        this.captureStreamUsage(event.data);
+                        sseEventCount++;
+                        if (!firstSSELogged) {
+                            firstSSELogged = true;
+                            latencyTrace.mark('stream.firstSSE', {
+                                requestId,
+                                resolverRequestId: this.requestId,
+                                pathway: this.pathway?.name,
+                                model: this.modelName,
+                            });
+                        }
 
                         // Check for error events in the stream data
                         try {
@@ -366,25 +441,80 @@ class PathwayResolver {
 
                     try {
                         requestProgress = this.modelExecutor.plugin.processStreamEvent(event, requestProgress);
+                        this.captureStreamUsage(event.data);
+                        if (requestProgress?.data && requestProgress.data !== event.data) {
+                            this.captureStreamUsage(requestProgress.data);
+                        }
+                        if (requestProgress?.error) {
+                            streamErrorOccurred = true;
+                            streamErrorMessage = requestProgress.error;
+                        }
                         // Check if plugin signaled a tool callback was invoked
                         if (requestProgress.toolCallbackInvoked) {
                             toolCallbackInvoked = true;
+                            this.toolCallbackInvoked = true;
+                            latencyTrace.mark('stream.toolCallbackInvoked', {
+                                requestId,
+                                resolverRequestId: this.requestId,
+                                pathway: this.pathway?.name,
+                                model: this.modelName,
+                            });
                         }
                     } catch (error) {
                         streamErrorOccurred = true;
                         streamErrorMessage = error instanceof Error ? error.message : String(error);
                         logger.error(`Stream processing error: ${error instanceof Error ? error.stack || error.message : JSON.stringify(error)}`);
                         incomingMessage.off('data', processStream);
+                        finishStreamRead && finishStreamRead();
                         return;
                     }
 
                     try {
                         if (!streamEnded && requestProgress.data) {
+                            publishedEventCount++;
+                            if (!firstPublishLogged) {
+                                firstPublishLogged = true;
+                                latencyTrace.mark('stream.firstPublish', {
+                                    requestId,
+                                    resolverRequestId: this.requestId,
+                                    pathway: this.pathway?.name,
+                                    model: this.modelName,
+                                    progress: requestProgress.progress,
+                                });
+                            }
                             this.publishNestedRequestProgress(requestProgress);
                             streamEnded = requestProgress.progress === 1;
                             if (streamEnded) {
                                 completionSent = true;
+                                incomingMessage.off('data', processStream);
+                                if (typeof incomingMessage.destroy === 'function') {
+                                    incomingMessage.destroy();
+                                }
+                                finishStreamRead && finishStreamRead();
                             }
+                        } else if (!streamEnded && requestProgress.progress === 1 && !toolCallbackInvoked) {
+                            publishedEventCount++;
+                            if (!firstPublishLogged) {
+                                firstPublishLogged = true;
+                                latencyTrace.mark('stream.firstPublish', {
+                                    requestId,
+                                    resolverRequestId: this.requestId,
+                                    pathway: this.pathway?.name,
+                                    model: this.modelName,
+                                    progress: requestProgress.progress,
+                                });
+                            }
+                            this.publishNestedRequestProgress({
+                                ...requestProgress,
+                                data: '',
+                            });
+                            streamEnded = true;
+                            completionSent = true;
+                            incomingMessage.off('data', processStream);
+                            if (typeof incomingMessage.destroy === 'function') {
+                                incomingMessage.destroy();
+                            }
+                            finishStreamRead && finishStreamRead();
                         }
                     } catch (error) {
                         logger.error(`Could not publish the stream message: "${event.data}", ${error instanceof Error ? error.stack || error.message : JSON.stringify(error)}`);
@@ -396,30 +526,76 @@ class PathwayResolver {
 
                 const processStream = (data) => {
                     receivedAnyData = true; // Track that we got data from the stream
+                    dataChunkCount++;
+                    if (!firstChunkLogged) {
+                        firstChunkLogged = true;
+                        if (response._cortexTtfbMonitor && response._cortexTtfbStart) {
+                            response._cortexTtfbMonitor.recordTTFB(
+                                Date.now() - response._cortexTtfbStart,
+                                response._cortexTtfbSource || 'live',
+                            );
+                        }
+                        latencyTrace.mark('stream.firstChunk', {
+                            requestId,
+                            resolverRequestId: this.requestId,
+                            pathway: this.pathway?.name,
+                            model: this.modelName,
+                            bytes: data?.length,
+                        });
+                    }
                     sseParser.feed(data.toString());
                 }
 
                 if (incomingMessage) {
-                    await new Promise((resolve, reject) => {
-                        incomingMessage.on('data', processStream);
-                        incomingMessage.on('end', resolve);
-                        incomingMessage.on('error', (err) => {
-                            streamErrorOccurred = true;
-                            streamErrorMessage = err instanceof Error ? err.message : String(err);
-                            reject(err);
+                    try {
+                        await new Promise((resolve, reject) => {
+                            let settled = false;
+                            const resolveOnce = () => {
+                                if (settled) {
+                                    return;
+                                }
+                                settled = true;
+                                resolve();
+                            };
+                            const rejectOnce = (err) => {
+                                if (settled) {
+                                    return;
+                                }
+                                settled = true;
+                                reject(err);
+                            };
+                            finishStreamRead = resolveOnce;
+                            incomingMessage.on('data', processStream);
+                            incomingMessage.on('end', resolveOnce);
+                            incomingMessage.on('error', (err) => {
+                                if (this.isCanceled()) {
+                                    resolveOnce();
+                                    return;
+                                }
+                                streamErrorOccurred = true;
+                                streamErrorMessage = err instanceof Error ? err.message : String(err);
+                                rejectOnce(err);
+                            });
+                            incomingMessage.on('close', () => {
+                                if (this.isCanceled()) {
+                                    resolveOnce();
+                                    return;
+                                }
+                                // Stream closed - detect various incomplete states
+                                if (!receivedAnyData && !streamErrorOccurred && !toolCallbackInvoked) {
+                                    // Stream opened but closed with NO data at all - this is likely a provider issue
+                                    logger.warn('Stream closed with no data received (empty stream)');
+                                } else if (receivedSSEData && !completionSent && !streamErrorOccurred && !toolCallbackInvoked) {
+                                    // Got SSE data but no completion signal
+                                    logger.warn('Stream closed before terminal event; final usage may be missing');
+                                }
+                                resolveOnce();
+                            });
                         });
-                        incomingMessage.on('close', () => {
-                            // Stream closed - detect various incomplete states
-                            if (!receivedAnyData && !streamErrorOccurred && !toolCallbackInvoked) {
-                                // Stream opened but closed with NO data at all - this is likely a provider issue
-                                logger.warn('Stream closed with no data received (empty stream)');
-                            } else if (receivedSSEData && !completionSent && !streamErrorOccurred && !toolCallbackInvoked) {
-                                // Got SSE data but no completion signal
-                                logger.warn('Stream closed without completion signal');
-                            }
-                            resolve();
-                        });
-                    });
+                    } finally {
+                        finishStreamRead = null;
+                        clearAbortStream();
+                    }
                 }
 
             } catch (error) {
@@ -428,6 +604,34 @@ class PathwayResolver {
                     streamErrorMessage = error instanceof Error ? error.message : String(error);
                 }
                 logger.error(`Could not subscribe to stream: ${error instanceof Error ? error.stack || error.message : JSON.stringify(error)}`);
+            }
+
+            // Safety net: if the stream ended without a finishReason but the plugin
+            // has pending tool calls that were never dispatched, dispatch them now.
+            // This handles edge-case models that never send finishReason: "STOP".
+            if (!toolCallbackInvoked && !completionSent && !streamErrorOccurred) {
+                const plugin = this.modelExecutor.plugin;
+                if (plugin.hadToolCalls && plugin.toolCallsBuffer?.length > 0 && plugin.pathwayToolCallback) {
+                    const validToolCalls = plugin.toolCallsBuffer.filter(tc => tc?.function?.name);
+                    if (validToolCalls.length > 0) {
+                        const toolMessage = {
+                            role: 'assistant',
+                            content: plugin.contentBuffer || '',
+                            tool_calls: validToolCalls,
+                        };
+                        plugin.pathwayToolCallback(this.args, toolMessage, this);
+                        toolCallbackInvoked = true;
+                        this.toolCallbackInvoked = true;
+                        latencyTrace.mark('stream.toolCallbackInvoked', {
+                            requestId,
+                            resolverRequestId: this.requestId,
+                            pathway: this.pathway?.name,
+                            model: this.modelName,
+                            source: 'safetyNet',
+                        });
+                        plugin.toolCallsBuffer = [];
+                    }
+                }
             }
 
             // Detect empty stream (opened but closed with no data) - this should be retried
@@ -456,9 +660,21 @@ class PathwayResolver {
                     info: JSON.stringify(this.pathwayResultData || {}),
                     error: errorMessage
                 });
+                completionSent = true;
+                publishedEventCount++;
             }
 
             // Return stream result for retry logic
+            latencyTrace.end(span, {
+                success: completionSent || toolCallbackInvoked,
+                emptyStream,
+                streamErrorOccurred,
+                completionSent,
+                toolCallbackInvoked,
+                dataChunkCount,
+                sseEventCount,
+                publishedEventCount,
+            });
             return {
                 success: completionSent || toolCallbackInvoked,
                 emptyStream,
@@ -467,10 +683,19 @@ class PathwayResolver {
         }
 
         // Non-stream response
+        latencyTrace.end(span, { success: true, emptyStream: false, nonStream: true });
         return { success: true, emptyStream: false, error: null };
     }
 
     async resolve(args) {
+        const span = latencyTrace.start('resolver.resolve', {
+            requestId: this.requestId,
+            rootRequestId: args?.rootRequestId || undefined,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+            stream: Boolean(args?.stream),
+            async: Boolean(args?.async),
+        });
         // Either we're dealing with an async request, stream, or regular request
         if (args.async || args.stream) {
             if (!requestState[this.requestId]) {
@@ -478,42 +703,55 @@ class PathwayResolver {
             }
             this.rootRequestId = args.rootRequestId ?? null;
             requestState[this.requestId] = { ...requestState[this.requestId], args, resolver: this.asyncResolve.bind(this), pathwayResolver: this };
+            latencyTrace.end(span, { returnedRequestId: true });
             return this.requestId;
         }
         else {
             // Syncronously process the request
-            return await this.executePathway(args);
+            try {
+                return await this.executePathway(args);
+            } finally {
+                latencyTrace.end(span, { returnedRequestId: false });
+            }
         }
     }
 
     async executePathway(args) {
-        // Bidirectional context transformation for backward compatibility:
-        // 1. If agentContext provided: extract contextId/contextKey for legacy pathways
-        // 2. If contextId provided without agentContext: create agentContext for new pathways
-        if (args.agentContext && Array.isArray(args.agentContext) && args.agentContext.length > 0) {
-            const defaultCtx = args.agentContext.find(ctx => ctx.default) || args.agentContext[0];
-            if (defaultCtx) {
-                args.contextId = defaultCtx.contextId;
-                args.contextKey = defaultCtx.contextKey || null;
-            }
-        } else if (args.contextId && !args.agentContext) {
-            // Backward compat: create agentContext from legacy contextId/contextKey
-            args.agentContext = [{ 
-                contextId: args.contextId, 
-                contextKey: args.contextKey || null, 
-                default: true 
-            }];
-        }
-        
+        const span = latencyTrace.start('resolver.executePathway', {
+            requestId: this.requestId,
+            rootRequestId: this.rootRequestId || undefined,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+            customExecutePathway: Boolean(this.pathway.executePathway),
+        });
         if (this.pathway.executePathway && typeof this.pathway.executePathway === 'function') {
-            return await this.pathway.executePathway({ args, runAllPrompts: this.promptAndParse.bind(this), resolver: this });
+            try {
+                return await this.pathway.executePathway({ args, runAllPrompts: this.promptAndParse.bind(this), resolver: this });
+            } finally {
+                latencyTrace.end(span);
+            }
         }
         else {
-            return await this.promptAndParse(args);
+            try {
+                return await this.promptAndParse(args);
+            } finally {
+                latencyTrace.end(span);
+            }
         }
     }
 
     async promptAndParse(args) {
+        const span = latencyTrace.start('resolver.promptAndParse', {
+            requestId: this.requestId,
+            rootRequestId: this.rootRequestId || undefined,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+            stream: Boolean(args?.stream),
+            async: Boolean(args?.async),
+        });
+        // Reset per-call flag — will be set by handleStream() if a tool callback fires
+        this.toolCallbackInvoked = false;
+
         // Check if model is specified in args and swap if different from current model
         if (args.modelOverride && args.modelOverride !== this.modelName) {
             try {
@@ -590,7 +828,21 @@ class PathwayResolver {
         let data = null;
         
         for (let retries = 0; retries < MAX_RETRIES; retries++) {
+            const loadMemorySpan = latencyTrace.start('resolver.loadMemory', {
+                requestId: this.requestId,
+                rootRequestId: this.rootRequestId || undefined,
+                pathway: this.pathway?.name,
+                retry: retries,
+                memoryEnabled,
+            });
             await loadMemory(); // Reset memory state on each retry
+            latencyTrace.end(loadMemorySpan, {
+                memorySelfChars: this.memorySelf?.length || 0,
+                memoryDirectivesChars: this.memoryDirectives?.length || 0,
+                memoryTopicsChars: this.memoryTopics?.length || 0,
+                memoryUserChars: this.memoryUser?.length || 0,
+                memoryContextChars: this.memoryContext?.length || 0,
+            });
             
             data = await this.processRequest(args);
             if (!data) {
@@ -628,11 +880,22 @@ class PathwayResolver {
         }
 
         if (data !== null) {
+            const saveMemorySpan = latencyTrace.start('resolver.saveChangedMemory', {
+                requestId: this.requestId,
+                rootRequestId: this.rootRequestId || undefined,
+                pathway: this.pathway?.name,
+            });
             await saveChangedMemory();
+            latencyTrace.end(saveMemorySpan);
         }
 
         addCitationsToResolver(this, data);
 
+        latencyTrace.end(span, {
+            resultKind: data && typeof data.on === 'function' ? 'stream' : typeof data,
+            errors: this.errors.length,
+            warnings: this.warnings.length,
+        });
         return data;
     }
 
@@ -642,9 +905,23 @@ class PathwayResolver {
         logger.warn(warning);
     }
 
-    // Add an error and log it
+    // Add an error and log it (GraphQL exposes errors as [String] — store strings only)
     logError(error) {
-        this.errors.push(error);
+        let msg = 'Unknown error';
+        if (error != null) {
+            if (typeof error === 'string') msg = error;
+            else if (error instanceof Error) msg = error.message || String(error);
+            else if (typeof error === 'object' && typeof error.message === 'string') {
+                msg = error.message;
+            } else {
+                try {
+                    msg = JSON.stringify(error);
+                } catch {
+                    msg = String(error);
+                }
+            }
+        }
+        this.errors.push(msg);
         logger.error(error);
     }
 
@@ -708,12 +985,32 @@ class PathwayResolver {
 
     // Process the request and return the result        
     async processRequest({ text, ...parameters }) {
+        const span = latencyTrace.start('resolver.processRequest', {
+            requestId: this.requestId,
+            rootRequestId: this.rootRequestId || undefined,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+            promptCount: this.prompts.length,
+            stream: Boolean(parameters?.stream),
+            async: Boolean(parameters?.async),
+        });
         text = await this.summarizeIfEnabled({ text, ...parameters }); // summarize if flag enabled
         const chunks = text && this.processInputText(text) || [text];
+        latencyTrace.mark('resolver.chunks', {
+            requestId: this.requestId,
+            rootRequestId: this.rootRequestId || undefined,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+            chunkCount: chunks.length,
+            promptCount: this.prompts.length,
+            anticipatedRequestCount: chunks.length * this.prompts.length,
+            textChars: typeof text === 'string' ? text.length : undefined,
+        });
 
         let anticipatedRequestCount = chunks.length * this.prompts.length   
 
         if ((requestState[this.requestId] || {}).canceled) {
+            clearPendingMessages(this.requestId);
             throw new Error('Request canceled');
         }
 
@@ -736,7 +1033,9 @@ class PathwayResolver {
             const data = await Promise.all(chunks.map(chunk =>
                 this.applyPromptsSerially(chunk, parameters)));
             // Join the chunks with newlines
-            return data.join(this.pathway.joinChunksWith || "\n\n");
+            const joined = data.join(this.pathway.joinChunksWith || "\n\n");
+            latencyTrace.end(span, { chunkCount: chunks.length, parallel: true });
+            return joined;
         } else {
             // Apply prompts one by one, serially, across all chunks
             // This is the default processing mode and will make previousResult available at the object level
@@ -788,6 +1087,7 @@ class PathwayResolver {
             }
             // store the previous result in the PathwayResolver
             this.previousResult = previousResult;
+            latencyTrace.end(span, { chunkCount: chunks.length, parallel: false });
             return result;
         }
 
@@ -814,7 +1114,6 @@ class PathwayResolver {
             throw new Error(`Model ${resolvedName} not found in config`);
         }
 
-        // Update model references
         this.modelName = resolvedName;
         this.model = this.endpoints[resolvedName];
 
@@ -829,19 +1128,37 @@ class PathwayResolver {
 
     async applyPrompt(prompt, text, parameters) {
         if (requestState[this.requestId].canceled) {
+            clearPendingMessages(this.requestId);
             return;
         }
+        const span = latencyTrace.start('resolver.applyPrompt', {
+            requestId: this.requestId,
+            rootRequestId: this.rootRequestId || undefined,
+            pathway: this.pathway?.name,
+            model: this.modelName,
+            stream: Boolean(parameters?.stream),
+            async: Boolean(parameters?.async),
+            textChars: typeof text === 'string' ? text.length : undefined,
+            previousResultChars: typeof parameters?.previousResult === 'string' ? parameters.previousResult.length : undefined,
+        });
         let result = '';
 
-        result = await this.modelExecutor.execute(text, { 
-            ...parameters, 
-            ...this.savedContext,
-            memorySelf: this.memorySelf,
-            memoryDirectives: this.memoryDirectives,
-            memoryTopics: this.memoryTopics,
-            memoryUser: this.memoryUser,
-            memoryContext: this.memoryContext
-        }, prompt, this);
+        try {
+            result = await this.modelExecutor.execute(text, {
+                ...parameters,
+                ...this.savedContext,
+                memorySelf: this.memorySelf,
+                memoryDirectives: this.memoryDirectives,
+                memoryTopics: this.memoryTopics,
+                memoryUser: this.memoryUser,
+                memoryContext: this.memoryContext
+            }, prompt, this);
+        } finally {
+            latencyTrace.end(span, {
+                resultKind: result && typeof result.on === 'function' ? 'stream' : typeof result,
+                resultChars: typeof result === 'string' ? result.length : undefined,
+            });
+        }
         
         requestState[this.requestId].completedCount++;
 

--- a/server/pendingUserMessages.js
+++ b/server/pendingUserMessages.js
@@ -1,0 +1,171 @@
+// pendingUserMessages.js
+// Queue for user messages injected into running agent loops.
+// Uses Redis pub/sub for cross-instance delivery (same pattern as clientToolCallbacks.js).
+// The local in-memory queue is populated by the Redis subscriber; the agent loop drains it.
+
+import logger from '../lib/logger.js';
+import Redis from 'ioredis';
+import { config } from '../config.js';
+import { requestState } from './requestState.js';
+import { publishRequestProgress } from '../lib/redisSubscription.js';
+
+// Local queue — only contains messages for requests running on THIS instance
+// Map<requestId, Array<{ message: string, timestamp: number }>>
+const pendingMessages = new Map();
+
+// Redis pub/sub for cross-instance routing
+const connectionString = config.get('storageConnectionString');
+const channel = 'pendingUserMessages';
+
+let subscriptionClient;
+let publisherClient;
+
+if (connectionString) {
+    logger.info(`Setting up Redis pub/sub for user message injection on channel: ${channel}`);
+
+    try {
+        subscriptionClient = new Redis(connectionString);
+        subscriptionClient.on('error', (error) => {
+            logger.error(`Redis subscriptionClient error (pendingUserMessages): ${error}`);
+        });
+
+        subscriptionClient.on('connect', () => {
+            subscriptionClient.subscribe(channel, (error) => {
+                if (error) {
+                    logger.error(`Error subscribing to Redis channel ${channel}: ${error}`);
+                } else {
+                    logger.info(`Subscribed to pending user messages channel: ${channel}`);
+                }
+            });
+        });
+
+        subscriptionClient.on('message', (ch, message) => {
+            if (ch === channel) {
+                try {
+                    const { requestId, userMessage } = JSON.parse(message);
+                    // Only queue locally if this instance owns the request
+                    if (requestState[requestId]) {
+                        queueLocalMessage(requestId, userMessage);
+                    }
+                } catch (error) {
+                    logger.error(`Error processing pending user message from Redis: ${error}`);
+                }
+            }
+        });
+    } catch (error) {
+        logger.error(`Redis connection error (pendingUserMessages): ${error}`);
+    }
+
+    try {
+        publisherClient = new Redis(connectionString);
+        publisherClient.on('error', (error) => {
+            logger.error(`Redis publisherClient error (pendingUserMessages): ${error}`);
+        });
+    } catch (error) {
+        logger.error(`Redis connection error (pendingUserMessages publisher): ${error}`);
+    }
+}
+
+/**
+ * Add a message to the local in-memory queue directly (bypasses Redis).
+ * Exported for unit testing and for the Redis subscriber.
+ */
+export function queueLocalMessage(requestId, message) {
+    if (!requestId || !message) return false;
+
+    if (!pendingMessages.has(requestId)) {
+        pendingMessages.set(requestId, []);
+    }
+
+    const timestamp = Date.now();
+
+    pendingMessages.get(requestId).push({
+        message,
+        timestamp,
+    });
+
+    logger.info(`Queued user message for request ${requestId} (queue size: ${pendingMessages.get(requestId).length})`);
+
+    // Emit a synthetic toolMessage on the request's progress stream so the
+    // client can render the injected message inline without optimistic insertion.
+    publishRequestProgress({
+        requestId,
+        progress: 0.5,
+        data: JSON.stringify(""),
+        info: JSON.stringify({
+            toolMessage: {
+                type: 'start',
+                callId: `inject-${timestamp}`,
+                icon: '💬',
+                userMessage: message,
+                presentation: 'inline_user',
+            }
+        }),
+    });
+
+    return true;
+}
+
+/**
+ * Queue a user message for injection into a running request's agent loop.
+ * Publishes to Redis so all instances receive it; the instance owning the
+ * requestId will queue it locally.
+ * @param {string} requestId
+ * @param {string} message
+ * @returns {Promise<boolean>}
+ */
+export async function queueUserMessage(requestId, message) {
+    if (!requestId || !message) return false;
+
+    if (publisherClient) {
+        try {
+            await publisherClient.publish(channel, JSON.stringify({ requestId, userMessage: message }));
+            logger.info(`Published user message to Redis for request ${requestId}`);
+            return true;
+        } catch (error) {
+            logger.error(`Error publishing user message to Redis: ${error}`);
+            // Fall back to local queue (works if request is on this instance)
+            return queueLocalMessage(requestId, message);
+        }
+    } else {
+        // No Redis — queue locally (single-instance mode)
+        return queueLocalMessage(requestId, message);
+    }
+}
+
+/**
+ * Drain all pending messages for a request (returns and removes them).
+ * Called by the agent loop before each model call.
+ * @param {string} requestId
+ * @returns {Array<{ message: string, timestamp: number }>}
+ */
+export function drainPendingMessages(requestId) {
+    if (!requestId || !pendingMessages.has(requestId)) return [];
+
+    const messages = pendingMessages.get(requestId);
+    pendingMessages.delete(requestId);
+
+    if (messages.length > 0) {
+        logger.info(`Drained ${messages.length} pending user message(s) for request ${requestId}`);
+    }
+    return messages;
+}
+
+/**
+ * Check if any messages are pending (non-destructive).
+ * @param {string} requestId
+ * @returns {boolean}
+ */
+export function hasPendingMessages(requestId) {
+    if (!requestId) return false;
+    const queue = pendingMessages.get(requestId);
+    return queue != null && queue.length > 0;
+}
+
+/**
+ * Clean up pending messages for a completed/canceled request.
+ * @param {string} requestId
+ */
+export function clearPendingMessages(requestId) {
+    pendingMessages.delete(requestId);
+}

--- a/server/resolver.js
+++ b/server/resolver.js
@@ -4,6 +4,25 @@ import CortexResponse from '../lib/cortexResponse.js';
 import logger, { withRequestLoggingDisabled } from '../lib/logger.js';
 import { sanitizeBase64 } from '../lib/util.js';
 import { resolveClientToolCallback } from './clientToolCallbacks.js';
+import { queueUserMessage } from './pendingUserMessages.js';
+
+/** GraphQL declares pathway errors/warnings as [String]; coerce any accumulated values. */
+function coerceGraphqlStringList(values) {
+    if (!Array.isArray(values)) return [];
+    return values.map((item) => {
+        if (item == null) return '';
+        if (typeof item === 'string') return item;
+        if (item instanceof Error) return item.message || String(item);
+        if (typeof item === 'object') {
+            try {
+                return JSON.stringify(item);
+            } catch {
+                return String(item);
+            }
+        }
+        return String(item);
+    });
+}
 
 // This resolver uses standard parameters required by Apollo server:
 // (parent, args, contextValue, info)
@@ -79,8 +98,8 @@ const rootResolver = async (parent, args, contextValue, info) => {
         debug, 
         result, 
         resultData,
-        warnings, 
-        errors, 
+        warnings: coerceGraphqlStringList(warnings),
+        errors: coerceGraphqlStringList(errors),
         previousResult, 
         tool, 
         contextId: savedContextId 
@@ -96,7 +115,8 @@ const resolver = async (parent, args, contextValue, _info) => {
 const cancelRequestResolver = (parent, args, contextValue, _info) => {
     const { requestId } = args;
     const { requestState } = contextValue;
-    requestState[requestId] = { canceled: true };
+    requestState[requestId] = { ...requestState[requestId], canceled: true };
+    requestState[requestId]?.abortRequest?.();
     return true
 }
 
@@ -134,6 +154,15 @@ const submitClientToolResultResolver = async (parent, args, contextValue, _info)
     }
 }
 
+const injectAgentMessageResolver = async (parent, args, contextValue, _info) => {
+    const { requestId, message } = args;
+
+    // No requestState check — with Redis pub/sub, the request may be on
+    // a different instance. The message is published to all instances and
+    // only the one owning the requestId will queue it locally.
+    return queueUserMessage(requestId, message);
+};
+
 export {
-    resolver, rootResolver, cancelRequestResolver, submitClientToolResultResolver
+    resolver, rootResolver, cancelRequestResolver, submitClientToolResultResolver, injectAgentMessageResolver
 };

--- a/tests/unit/core/cancelRequestAbort.test.js
+++ b/tests/unit/core/cancelRequestAbort.test.js
@@ -1,0 +1,367 @@
+import test from 'ava';
+import { PassThrough } from 'stream';
+import CortexRequest from '../../../lib/cortexRequest.js';
+import { axios, executeRequest } from '../../../lib/requestExecutor.js';
+import { PathwayResolver } from '../../../server/pathwayResolver.js';
+import { requestState } from '../../../server/requestState.js';
+import { cancelRequestResolver } from '../../../server/resolver.js';
+
+test.serial('cancelRequest marks request canceled and invokes abort hook', (t) => {
+    const requestId = 'cancel-abort-hook';
+    let abortCalled = false;
+    requestState[requestId] = {
+        abortRequest() {
+            abortCalled = true;
+        },
+    };
+
+    try {
+        const result = cancelRequestResolver(null, { requestId }, { requestState });
+
+        t.true(result);
+        t.true(requestState[requestId].canceled);
+        t.true(abortCalled);
+    } finally {
+        delete requestState[requestId];
+    }
+});
+
+test.serial('streaming model request registers abortable provider signal', async (t) => {
+    const requestId = 'stream-abort-signal';
+    const originalPost = axios.post;
+    let capturedSignal = null;
+
+    axios.post = async (_url, _data, options) => {
+        capturedSignal = options.signal;
+        return {
+            status: 200,
+            data: new PassThrough(),
+        };
+    };
+
+    const endpoint = {
+        name: 'test-endpoint',
+        url: 'https://example.test/responses',
+        data: {},
+        params: {},
+        headers: {},
+        limiter: {
+            schedule(_options, task) {
+                return task();
+            },
+        },
+    };
+    const model = {
+        name: 'test-stream-model',
+        supportsStreaming: true,
+        endpoints: [endpoint],
+    };
+    const cortexRequest = new CortexRequest({
+        data: { stream: true },
+        model,
+        pathwayResolver: {
+            requestId,
+            model,
+            pathway: { timeout: 120 },
+        },
+    });
+
+    try {
+        await executeRequest(cortexRequest);
+
+        t.truthy(capturedSignal);
+        t.false(capturedSignal.aborted);
+        t.is(typeof requestState[requestId]?.abortRequest, 'function');
+
+        cancelRequestResolver(null, { requestId }, { requestState });
+
+        t.true(capturedSignal.aborted);
+        t.true(requestState[requestId].canceled);
+    } finally {
+        axios.post = originalPost;
+        delete requestState[requestId];
+    }
+});
+
+test.serial('nested streaming model request registers abort hook on root request id', async (t) => {
+    const rootRequestId = 'stream-abort-root-signal';
+    const childRequestId = 'stream-abort-child-signal';
+    const originalPost = axios.post;
+    let capturedSignal = null;
+
+    axios.post = async (_url, _data, options) => {
+        capturedSignal = options.signal;
+        return new Promise((_resolve, reject) => {
+            capturedSignal.addEventListener('abort', () => {
+                const error = new Error('canceled');
+                error.name = 'CanceledError';
+                error.code = 'ERR_CANCELED';
+                reject(error);
+            }, { once: true });
+        });
+    };
+
+    const endpoint = {
+        name: 'test-endpoint',
+        url: 'https://example.test/responses',
+        data: {},
+        params: {},
+        headers: {},
+        limiter: {
+            schedule(_options, task) {
+                return task();
+            },
+        },
+    };
+    const model = {
+        name: 'test-stream-model',
+        supportsStreaming: true,
+        endpoints: [endpoint],
+    };
+    const cortexRequest = new CortexRequest({
+        data: { stream: true },
+        model,
+        pathwayResolver: {
+            requestId: childRequestId,
+            rootRequestId,
+            model,
+            pathway: { timeout: 120 },
+        },
+    });
+
+    try {
+        const requestPromise = executeRequest(cortexRequest);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        t.truthy(capturedSignal);
+        t.false(capturedSignal.aborted);
+        t.is(typeof requestState[rootRequestId]?.abortRequest, 'function');
+        t.is(typeof requestState[childRequestId]?.abortRequest, 'function');
+
+        cancelRequestResolver(null, { requestId: rootRequestId }, { requestState });
+
+        const error = await requestPromise.then(
+            () => null,
+            (rejection) => rejection,
+        );
+        t.truthy(error);
+        t.is(error.name, 'CanceledError');
+        t.true(capturedSignal.aborted);
+        t.true(requestState[rootRequestId].canceled);
+    } finally {
+        axios.post = originalPost;
+        delete requestState[rootRequestId];
+        delete requestState[childRequestId];
+    }
+});
+
+test.serial('streaming provider cancellation does not retry after abort', async (t) => {
+    const requestId = 'stream-abort-no-retry';
+    const originalPost = axios.post;
+    let callCount = 0;
+    let capturedSignal = null;
+
+    axios.post = async (_url, _data, options) => {
+        callCount += 1;
+
+        if (callCount > 1) {
+            throw new Error('provider call retried after cancellation');
+        }
+
+        capturedSignal = options.signal;
+        return new Promise((_resolve, reject) => {
+            capturedSignal.addEventListener('abort', () => {
+                const error = new Error('canceled');
+                error.name = 'CanceledError';
+                error.code = 'ERR_CANCELED';
+                reject(error);
+            }, { once: true });
+        });
+    };
+
+    const endpoint = {
+        name: 'test-endpoint',
+        url: 'https://example.test/responses',
+        data: {},
+        params: {},
+        headers: {},
+        limiter: {
+            schedule(_options, task) {
+                return task();
+            },
+        },
+    };
+    const model = {
+        name: 'test-stream-model',
+        supportsStreaming: true,
+        endpoints: [endpoint],
+    };
+    const cortexRequest = new CortexRequest({
+        data: { stream: true },
+        model,
+        pathwayResolver: {
+            requestId,
+            model,
+            pathway: { timeout: 120 },
+        },
+    });
+
+    try {
+        const requestPromise = executeRequest(cortexRequest);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        t.truthy(capturedSignal);
+        cancelRequestResolver(null, { requestId }, { requestState });
+
+        const error = await requestPromise.then(
+            () => null,
+            (rejection) => rejection,
+        );
+        t.truthy(error);
+        t.is(error.name, 'CanceledError');
+        t.is(callCount, 1);
+    } finally {
+        axios.post = originalPost;
+        delete requestState[requestId];
+    }
+});
+
+test.serial('cancelRequest destroys active provider stream', async (t) => {
+    const requestId = 'stream-abort-active-provider';
+    const stream = new PassThrough();
+    let previousAbortCalled = false;
+
+    requestState[requestId] = {
+        abortRequest() {
+            previousAbortCalled = true;
+        },
+    };
+
+    const pathwayResolver = Object.create(PathwayResolver.prototype);
+    Object.assign(pathwayResolver, {
+        requestId,
+        rootRequestId: null,
+        pathway: { name: 'test-pathway' },
+        modelName: 'test-stream-model',
+        modelExecutor: {
+            plugin: {
+                processStreamEvent(_event, requestProgress) {
+                    return requestProgress;
+                },
+            },
+        },
+        pathwayResultData: {},
+        errors: [],
+        publishNestedRequestProgress() {},
+    });
+
+    try {
+        const streamPromise = pathwayResolver.handleStream(stream);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        cancelRequestResolver(null, { requestId }, { requestState });
+        await streamPromise;
+
+        t.true(previousAbortCalled);
+        t.true(stream.destroyed);
+        t.true(requestState[requestId].canceled);
+        t.is(requestState[requestId].abortRequest, undefined);
+    } finally {
+        delete requestState[requestId];
+    }
+});
+
+test.serial('handleStream keeps active streams alive past pathway timeout', async (t) => {
+    const requestId = 'stream-active';
+    const stream = new PassThrough();
+    let publishCount = 0;
+
+    requestState[requestId] = {};
+
+    const pathwayResolver = Object.create(PathwayResolver.prototype);
+    Object.assign(pathwayResolver, {
+        requestId,
+        rootRequestId: null,
+        pathway: { name: 'test-pathway', timeout: 0.01 },
+        modelName: 'test-stream-model',
+        modelExecutor: {
+            plugin: {
+                processStreamEvent(event, requestProgress) {
+                    const payload = JSON.parse(event.data);
+                    requestProgress.data = event.data;
+                    if (payload.done) {
+                        requestProgress.progress = 1;
+                    }
+                    return requestProgress;
+                },
+            },
+        },
+        pathwayResultData: {},
+        errors: [],
+        publishNestedRequestProgress() {
+            publishCount += 1;
+        },
+    });
+
+    try {
+        const streamPromise = pathwayResolver.handleStream(stream);
+        stream.write('data: {"chunk":1}\n\n');
+
+        await new Promise((resolve) => setTimeout(resolve, 35));
+        t.false(stream.destroyed);
+
+        stream.write('data: {"chunk":2}\n\n');
+        await new Promise((resolve) => setTimeout(resolve, 35));
+        t.false(stream.destroyed);
+
+        stream.write('data: {"done":true}\n\n');
+
+        const result = await streamPromise;
+
+        t.true(result.success);
+        t.true(stream.destroyed);
+        t.is(publishCount, 3);
+    } finally {
+        delete requestState[requestId];
+    }
+});
+
+test.serial('handleStream resolves and destroys stream after terminal progress event', async (t) => {
+    const requestId = 'stream-terminal-event';
+    const stream = new PassThrough();
+
+    requestState[requestId] = {};
+
+    const pathwayResolver = Object.create(PathwayResolver.prototype);
+    Object.assign(pathwayResolver, {
+        requestId,
+        rootRequestId: null,
+        pathway: { name: 'test-pathway', timeout: 120 },
+        modelName: 'test-stream-model',
+        modelExecutor: {
+            plugin: {
+                processStreamEvent(_event, requestProgress) {
+                    requestProgress.data = JSON.stringify({ done: true });
+                    requestProgress.progress = 1;
+                    return requestProgress;
+                },
+            },
+        },
+        pathwayResultData: {},
+        errors: [],
+        publishNestedRequestProgress() {},
+    });
+
+    try {
+        const streamPromise = pathwayResolver.handleStream(stream);
+        stream.write('data: {"type":"response.completed"}\n\n');
+
+        const result = await streamPromise;
+
+        t.true(stream.destroyed);
+        t.true(result.success);
+        t.is(requestState[requestId].abortRequest, undefined);
+    } finally {
+        delete requestState[requestId];
+    }
+});

--- a/tests/unit/core/pendingUserMessages.test.js
+++ b/tests/unit/core/pendingUserMessages.test.js
@@ -1,0 +1,127 @@
+// pendingUserMessages.test.js
+// Tests for the pending user message queue used by agent message injection.
+// Uses queueLocalMessage (bypasses Redis pub/sub) for deterministic unit tests.
+
+import test from 'ava';
+import { queueLocalMessage, drainPendingMessages, hasPendingMessages, clearPendingMessages } from '../../../server/pendingUserMessages.js';
+
+// Clean up between tests to avoid cross-contamination
+test.beforeEach(() => {
+    clearPendingMessages('test-req-1');
+    clearPendingMessages('test-req-2');
+    clearPendingMessages('test-req-3');
+});
+
+test.serial('queueLocalMessage adds a message to the queue', t => {
+    const result = queueLocalMessage('test-req-1', 'hello');
+    t.true(result);
+    t.true(hasPendingMessages('test-req-1'));
+});
+
+test.serial('queueLocalMessage returns false for empty requestId', t => {
+    t.false(queueLocalMessage('', 'hello'));
+    t.false(queueLocalMessage(null, 'hello'));
+    t.false(queueLocalMessage(undefined, 'hello'));
+});
+
+test.serial('queueLocalMessage returns false for empty message', t => {
+    t.false(queueLocalMessage('test-req-1', ''));
+    t.false(queueLocalMessage('test-req-1', null));
+    t.false(queueLocalMessage('test-req-1', undefined));
+});
+
+test.serial('drainPendingMessages returns and removes all messages', t => {
+    queueLocalMessage('test-req-1', 'msg1');
+    queueLocalMessage('test-req-1', 'msg2');
+    queueLocalMessage('test-req-1', 'msg3');
+
+    const messages = drainPendingMessages('test-req-1');
+    t.is(messages.length, 3);
+    t.is(messages[0].message, 'msg1');
+    t.is(messages[1].message, 'msg2');
+    t.is(messages[2].message, 'msg3');
+
+    // Queue should be empty after drain
+    t.false(hasPendingMessages('test-req-1'));
+    t.deepEqual(drainPendingMessages('test-req-1'), []);
+});
+
+test.serial('drainPendingMessages returns empty array for unknown requestId', t => {
+    const messages = drainPendingMessages('nonexistent');
+    t.deepEqual(messages, []);
+});
+
+test.serial('drainPendingMessages returns empty array for null requestId', t => {
+    t.deepEqual(drainPendingMessages(null), []);
+    t.deepEqual(drainPendingMessages(undefined), []);
+    t.deepEqual(drainPendingMessages(''), []);
+});
+
+test.serial('hasPendingMessages returns false for empty/unknown requestId', t => {
+    t.false(hasPendingMessages(''));
+    t.false(hasPendingMessages(null));
+    t.false(hasPendingMessages(undefined));
+    t.false(hasPendingMessages('nonexistent'));
+});
+
+test.serial('hasPendingMessages returns true only when messages exist', t => {
+    t.false(hasPendingMessages('test-req-1'));
+    queueLocalMessage('test-req-1', 'hello');
+    t.true(hasPendingMessages('test-req-1'));
+    drainPendingMessages('test-req-1');
+    t.false(hasPendingMessages('test-req-1'));
+});
+
+test.serial('clearPendingMessages removes the queue', t => {
+    queueLocalMessage('test-req-1', 'msg1');
+    queueLocalMessage('test-req-1', 'msg2');
+    t.true(hasPendingMessages('test-req-1'));
+
+    clearPendingMessages('test-req-1');
+    t.false(hasPendingMessages('test-req-1'));
+    t.deepEqual(drainPendingMessages('test-req-1'), []);
+});
+
+test.serial('clearPendingMessages is safe to call on nonexistent requestId', t => {
+    t.notThrows(() => clearPendingMessages('nonexistent'));
+    t.notThrows(() => clearPendingMessages(null));
+});
+
+test.serial('queues are independent per requestId', t => {
+    queueLocalMessage('test-req-1', 'for-req-1');
+    queueLocalMessage('test-req-2', 'for-req-2');
+
+    t.true(hasPendingMessages('test-req-1'));
+    t.true(hasPendingMessages('test-req-2'));
+    t.false(hasPendingMessages('test-req-3'));
+
+    const msgs1 = drainPendingMessages('test-req-1');
+    t.is(msgs1.length, 1);
+    t.is(msgs1[0].message, 'for-req-1');
+
+    // req-2 should still have its message
+    t.true(hasPendingMessages('test-req-2'));
+    const msgs2 = drainPendingMessages('test-req-2');
+    t.is(msgs2.length, 1);
+    t.is(msgs2[0].message, 'for-req-2');
+});
+
+test.serial('messages include timestamps', t => {
+    const before = Date.now();
+    queueLocalMessage('test-req-1', 'hello');
+    const after = Date.now();
+
+    const messages = drainPendingMessages('test-req-1');
+    t.is(messages.length, 1);
+    t.true(messages[0].timestamp >= before);
+    t.true(messages[0].timestamp <= after);
+});
+
+test.serial('messages are returned in insertion order', t => {
+    queueLocalMessage('test-req-1', 'first');
+    queueLocalMessage('test-req-1', 'second');
+    queueLocalMessage('test-req-1', 'third');
+
+    const messages = drainPendingMessages('test-req-1');
+    t.deepEqual(messages.map(m => m.message), ['first', 'second', 'third']);
+});


### PR DESCRIPTION
## Summary

- adds pending user-message queueing for long-running streamed tool flows
- wires request cancellation through active provider abort hooks and stream cleanup
- updates GraphQL/resolver plumbing for injected agent messages and cancellation-safe errors

## Notes

Stacked on #456, which updates the model adapters used by these streaming paths.

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/core/pendingUserMessages.test.js tests/unit/core/cancelRequestAbort.test.js tests/unit/rest/responsesStreaming.test.js tests/unit/plugins.streaming/plugin_stream_events.test.js`
- `git diff --cached --check`