### PR TITLE
Port MCP tool runtime from aj-cortex

### DIFF
--- a/lib/mcpClient.js
+++ b/lib/mcpClient.js
@@ -1,0 +1,337 @@
+// mcpClient.js
+// MCP (Model Context Protocol) client for connecting to remote MCP servers
+// and exposing their tools to the cortex agent system.
+import { Client } from '@modelcontextprotocol/sdk/client';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import logger from './logger.js';
+
+const MCP_TIMEOUT_MS = 30000;
+
+/**
+ * Check whether a server config's OAuth token has expired.
+ * @param {object} serverConfig - Single MCP server config object
+ * @returns {boolean}
+ */
+export function isTokenExpired(serverConfig) {
+    const expiresAt = serverConfig?.expiresAt;
+    return !!(expiresAt && typeof expiresAt === 'number' && expiresAt <= Date.now());
+}
+
+/**
+ * Initialize MCP clients for each server in the config.
+ * @param {string} mcpConfigJson - JSON string of MCP server config: { serverKey: { type, url, headers? } }
+ * @returns {Promise<{ clients: Map<string, { client: Client, transport: StreamableHTTPClientTransport }>, expiredServers: string[] }>}
+ */
+export async function initializeMcpClients(mcpConfigJson) {
+    const clients = new Map();
+    const expiredServers = [];
+    if (!mcpConfigJson || typeof mcpConfigJson !== 'string') {
+        return { clients, expiredServers };
+    }
+
+    let config;
+    try {
+        config = JSON.parse(mcpConfigJson);
+    } catch (e) {
+        logger.warn(`Failed to parse mcpConfig: ${e.message}`);
+        return { clients, expiredServers };
+    }
+
+    if (!config || typeof config !== 'object') {
+        return { clients, expiredServers };
+    }
+
+    for (const [serverKey, serverConfig] of Object.entries(config)) {
+        if (!serverConfig?.url) {
+            logger.warn(`MCP server ${serverKey} missing url, skipping`);
+            continue;
+        }
+
+        const type = serverConfig.type || 'streamable-http';
+        if (type !== 'streamable-http') {
+            logger.warn(`MCP server ${serverKey} has unsupported type: ${type}, skipping`);
+            continue;
+        }
+
+        // Check token expiration before attempting connection
+        if (isTokenExpired(serverConfig)) {
+            const expiresAt = serverConfig.expiresAt;
+            logger.info(`[MCP:${serverKey}] token expired at ${new Date(expiresAt).toISOString()}, skipping connection`);
+            expiredServers.push(serverKey);
+            continue;
+        }
+
+        try {
+            const url = new URL(serverConfig.url);
+            const headers = serverConfig.headers || {};
+            const hasAuth = !!headers.Authorization;
+            const hasCloudId = !!headers['X-Atlassian-Cloud-Id'];
+            const configCloudId = serverConfig.cloudId;
+            const expiresAt = serverConfig.expiresAt;
+            logger.info(`[MCP:${serverKey}] connecting to ${serverConfig.url} | hasAuth=${hasAuth} | hasCloudId=${hasCloudId} | configCloudId=${configCloudId || 'none'} | headerKeys=${Object.keys(headers).join(',')} | expiresAt=${expiresAt ? new Date(expiresAt).toISOString() : 'none'} | now=${new Date().toISOString()}`);
+
+            const requestInit = { headers };
+            const transport = new StreamableHTTPClientTransport(url, { requestInit });
+            const client = new Client(
+                { name: 'cortex-mcp-client', version: '1.0.0' }
+            );
+
+            const connectTimestamp = Date.now();
+
+            client.onerror = (err) => logger.error(`[MCP:${serverKey}] client error (age=${Date.now() - connectTimestamp}ms): ${err?.message || err}`);
+            client.onclose = () => logger.warn(`[MCP:${serverKey}] client onclose fired (age=${Date.now() - connectTimestamp}ms)`, new Error('onclose stack trace').stack);
+
+            await Promise.race([
+                client.connect(transport),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('MCP connection timeout')), MCP_TIMEOUT_MS)
+                ),
+            ]);
+
+            const serverInfo = client.getServerVersion?.() || client.serverInfo || 'unknown';
+            const serverCaps = client.getServerCapabilities?.() || client.serverCapabilities || {};
+            logger.info(`[MCP:${serverKey}] connected in ${Date.now() - connectTimestamp}ms | serverInfo=${JSON.stringify(serverInfo)} | serverCaps=${JSON.stringify(serverCaps)}`);
+            clients.set(serverKey, { client, transport, connectTimestamp, cloudId: serverConfig.cloudId || null });
+        } catch (error) {
+            logger.warn(`Failed to connect to MCP server ${serverKey}: ${error?.message || error}`);
+        }
+    }
+
+    return { clients, expiredServers };
+}
+
+/**
+ * Convert MCP tool schema to OpenAI function-calling format.
+ * @param {object} tool - MCP tool definition
+ * @param {string} serverKey - Server identifier
+ * @param {object} [cloudIdState] - cloudId resolution result from auto-discovery
+ * @param {string} [cloudIdState.resolved] - Known cloudId (strip from schema, inject at call time)
+ * @param {Array}  [cloudIdState.availableSites] - Multiple sites the user must choose from
+ */
+function mcpToolToOpenAI(tool, serverKey, cloudIdState) {
+    const inputSchema = tool.inputSchema || { type: 'object', properties: {} };
+    let properties = { ...(inputSchema.properties || {}) };
+    let required = [...(inputSchema.required || [])];
+
+    if (cloudIdState?.resolved) {
+        // cloudId is known — strip from schema (injected server-side at call time)
+        delete properties.cloudId;
+        required = required.filter(r => r !== 'cloudId');
+    } else if (cloudIdState?.availableSites?.length > 0 && properties.cloudId) {
+        // Multiple sites — keep cloudId visible but list options so AI asks the user
+        const siteList = cloudIdState.availableSites
+            .map(s => `  - "${s.id}" (${s.url || s.name || 'unknown'})`)
+            .join('\n');
+        properties.cloudId = {
+            ...properties.cloudId,
+            description: `The Atlassian cloud site ID. You MUST ask the user which site to use. Available sites:\n${siteList}`,
+        };
+    }
+
+    return {
+        type: 'function',
+        function: {
+            name: tool.name,
+            description: tool.description || `MCP tool: ${tool.name}`,
+            parameters: {
+                type: inputSchema.type || 'object',
+                properties,
+                required,
+            },
+        },
+        icon: '🔌',
+        mcpServer: serverKey,
+    };
+}
+
+/**
+ * Discover tools from all connected MCP clients.
+ * @param {Map<string, { client: Client, transport: StreamableHTTPClientTransport }>} clients
+ * @returns {{ entityTools: Object, entityToolsOpenAiFormat: Array, toolToServerMap: Map<string, string> }}
+ */
+export async function discoverMcpTools(clients) {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+    const toolToServerMap = new Map();
+    // Lightweight catalog for tool search — contains name, description, server, and parameter names
+    // but NOT full schemas, keeping search results concise
+    const mcpToolCatalog = {};
+
+    for (const [serverKey, { client, connectTimestamp }] of clients) {
+        try {
+            logger.info(`[MCP:${serverKey}] listing tools (age=${Date.now() - connectTimestamp}ms)...`);
+            const result = await client.listTools();
+            const tools = result?.tools || [];
+            logger.info(`[MCP:${serverKey}] discovered ${tools.length} tools: ${tools.map(t => t.name).join(', ')}`);
+            for (const tool of tools) {
+                logger.debug(JSON.stringify({
+                    event: 'mcp_tool_schema',
+                    server: serverKey,
+                    tool: tool.name,
+                    schema: tool.inputSchema || {},
+                    description: tool.description || '',
+                }));
+            }
+
+            // Auto-discover cloudId if missing — Atlassian MCP servers expose
+            // getAccessibleAtlassianResources which returns the user's sites.
+            const entry = clients.get(serverKey);
+            let cloudIdState = entry.cloudId ? { resolved: entry.cloudId } : null;
+            if (!entry.cloudId) {
+                const resourcesTool = tools.find(t => t.name === 'getAccessibleAtlassianResources');
+                if (resourcesTool) {
+                    try {
+                        logger.info(`[MCP:${serverKey}] cloudId missing — calling getAccessibleAtlassianResources to auto-discover`);
+                        const resResult = await client.callTool({ name: 'getAccessibleAtlassianResources', arguments: {} });
+                        const resText = (resResult?.content || []).filter(c => c.type === 'text').map(c => c.text).join('\n');
+                        const sites = JSON.parse(resText);
+                        if (Array.isArray(sites) && sites.length > 0) {
+                            const preferredUrl = process.env.ATLASSIAN_PREFERRED_CLOUD;
+                            if (sites.length === 1) {
+                                // Single site — use it
+                                entry.cloudId = sites[0].id;
+                                cloudIdState = { resolved: entry.cloudId };
+                                logger.info(`[MCP:${serverKey}] auto-discovered cloudId: ${entry.cloudId} (${sites[0].name || sites[0].url || 'unknown'})`);
+                            } else if (preferredUrl) {
+                                // Multiple sites — look for preferred
+                                const match = sites.find(s => s.url?.includes(preferredUrl) || s.name?.includes(preferredUrl));
+                                if (match) {
+                                    entry.cloudId = match.id;
+                                    cloudIdState = { resolved: entry.cloudId };
+                                    logger.info(`[MCP:${serverKey}] auto-selected preferred cloudId: ${entry.cloudId} (${match.url || match.name}) from ${sites.length} sites`);
+                                } else {
+                                    // Preferred not found — let AI ask the user
+                                    cloudIdState = { availableSites: sites };
+                                    logger.info(`[MCP:${serverKey}] ${sites.length} sites found but preferred "${preferredUrl}" not among them — AI will ask user`);
+                                }
+                            } else {
+                                // Multiple sites, no preference configured — let AI ask the user
+                                cloudIdState = { availableSites: sites };
+                                logger.info(`[MCP:${serverKey}] ${sites.length} sites found, no ATLASSIAN_PREFERRED_CLOUD set — AI will ask user`);
+                            }
+                        } else {
+                            logger.warn(`[MCP:${serverKey}] getAccessibleAtlassianResources returned no sites: ${resText.slice(0, 200)}`);
+                        }
+                    } catch (err) {
+                        logger.warn(`[MCP:${serverKey}] failed to auto-discover cloudId: ${err?.message || err}`);
+                    }
+                }
+            }
+
+            for (const tool of tools) {
+                const toolName = tool.name?.toLowerCase();
+                if (!toolName) continue;
+
+                const openAiTool = mcpToolToOpenAI(tool, serverKey, cloudIdState);
+                const compositeKey = `${serverKey}__${toolName}`;
+
+                entityTools[compositeKey] = {
+                    definition: openAiTool,
+                    pathwayName: 'mcp_tool_execution',
+                    mcpServer: serverKey,
+                    mcpToolName: tool.name,
+                };
+                entityToolsOpenAiFormat.push({
+                    type: 'function',
+                    function: {
+                        name: compositeKey,
+                        description: openAiTool.function.description,
+                        parameters: openAiTool.function.parameters,
+                    },
+                });
+                toolToServerMap.set(compositeKey, serverKey);
+
+                // Build lightweight catalog entry for tool search
+                const paramNames = Object.keys(openAiTool.function?.parameters?.properties || {});
+                mcpToolCatalog[compositeKey] = {
+                    name: compositeKey,
+                    originalName: tool.name,
+                    server: serverKey,
+                    description: openAiTool.function.description || '',
+                    parameters: paramNames,
+                };
+            }
+        } catch (error) {
+            logger.warn(`Failed to list tools from MCP server ${serverKey}: ${error?.message || error}`);
+        }
+    }
+
+    return { entityTools, entityToolsOpenAiFormat, toolToServerMap, mcpToolCatalog };
+}
+
+/**
+ * Call a tool on an MCP server.
+ * @param {Map<string, { client: Client }>} clients
+ * @param {string} compositeToolName - e.g. "atlassian__toolname" (lowercased)
+ * @param {Object} args - Tool arguments
+ * @param {string} [originalToolName] - Original case-preserved tool name for MCP servers that are case-sensitive
+ * @returns {Promise<{ result: string|Object, toolImages?: Array }>}
+ */
+export async function callMcpTool(clients, compositeToolName, args, originalToolName) {
+    const parts = compositeToolName.split('__');
+    if (parts.length < 2) {
+        throw new Error(`Invalid MCP tool name: ${compositeToolName}`);
+    }
+    const serverKey = parts[0];
+    // Use the original case-preserved name if provided, otherwise fall back to extracting from composite key
+    const toolName = originalToolName || parts.slice(1).join('__');
+
+    const entry = clients.get(serverKey);
+    if (!entry) {
+        throw new Error(`MCP server ${serverKey} not connected`);
+    }
+
+    const { client, connectTimestamp, cloudId } = entry;
+    const transportState = client.transport ? 'alive' : 'null';
+
+    // Inject stored cloudId — always overrides AI-provided value to prevent hallucination.
+    // When cloudId is null (multi-site, user must choose), the AI's value passes through.
+    const finalArgs = { ...(args || {}) };
+    if (cloudId) {
+        finalArgs.cloudId = cloudId;
+        logger.info(`[MCP:${serverKey}] injecting cloudId=${cloudId} into tool ${toolName} args`);
+    }
+
+    logger.info(`[MCP:${serverKey}] calling tool ${toolName} | args=${JSON.stringify(finalArgs).slice(0, 200)} | transport=${transportState} | age=${Date.now() - (connectTimestamp || 0)}ms`);
+
+    try {
+        const callStart = Date.now();
+        const result = await client.callTool({
+            name: toolName,
+            arguments: finalArgs,
+        });
+        const content = result?.content || [];
+        const textParts = content
+            .filter((c) => c.type === 'text')
+            .map((c) => c.text);
+        const text = textParts.join('\n\n');
+        const isError = result?.isError || text.toLowerCase().includes('error') || text.toLowerCase().includes('failed');
+        logger.info(`[MCP:${serverKey}] tool ${toolName} returned in ${Date.now() - callStart}ms | contentTypes=${content.map(c => c.type).join(',')} | isError=${isError} | resultText=${text.slice(0, 500)}`);
+
+        if (result?.structuredContent) {
+            return { result: result.structuredContent };
+        }
+        return { result: text || JSON.stringify(result) };
+    } catch (error) {
+        const transportStateAfter = client.transport ? 'alive' : 'null';
+        logger.error(`[MCP:${serverKey}] tool call FAILED ${toolName} | error=${error?.message || error} | code=${error?.code} | transport=${transportStateAfter} | age=${Date.now() - (connectTimestamp || 0)}ms`);
+        throw error;
+    }
+}
+
+/**
+ * Close all MCP client connections.
+ * @param {Map<string, { client: Client, transport: StreamableHTTPClientTransport }>} clients
+ */
+export async function closeMcpClients(clients) {
+    for (const [serverKey, { transport, connectTimestamp }] of clients) {
+        try {
+            logger.info(`[MCP:${serverKey}] closing (age=${Date.now() - (connectTimestamp || 0)}ms)`);
+            await transport.close();
+            logger.info(`[MCP:${serverKey}] closed`);
+        } catch (error) {
+            logger.warn(`Error closing MCP client ${serverKey}: ${error?.message || error}`);
+        }
+    }
+    clients.clear();
+}

--- a/lib/pathwayTools.js
+++ b/lib/pathwayTools.js
@@ -7,9 +7,19 @@ import logger from '../lib/logger.js';
 import { requestState } from '../server/requestState.js';
 import { processPathwayParameters } from '../server/typeDef.js';
 import { waitForClientToolResult } from '../server/clientToolCallbacks.js';
+import { callMcpTool } from '../lib/mcpClient.js';
+import latencyTrace from '../lib/latencyTrace.js';
 
 // callPathway - call a pathway from another pathway
 const callPathway = async (pathwayName, inArgs, pathwayResolver) => {
+    const span = latencyTrace.start('tool.callPathway', {
+        requestId: pathwayResolver?.requestId,
+        rootRequestId: pathwayResolver?.rootRequestId || undefined,
+        parentPathway: pathwayResolver?.pathway?.name,
+        pathway: pathwayName,
+        stream: Boolean(inArgs?.stream),
+        async: Boolean(inArgs?.async),
+    });
 
     // Clone the args object to avoid modifying the original
     const args = JSON.parse(JSON.stringify(inArgs));
@@ -32,10 +42,6 @@ const callPathway = async (pathwayName, inArgs, pathwayResolver) => {
 
     let data = await pathway.rootResolver(parent, {...processedArgs, rootRequestId}, contextValue );
 
-    if (pathwayResolver && contextValue.pathwayResolver) {
-        pathwayResolver.mergeResolver(contextValue.pathwayResolver);
-    }
-
     let returnValue = data?.result || null;
 
     if (args.async || args.stream) {
@@ -48,14 +54,361 @@ const callPathway = async (pathwayName, inArgs, pathwayResolver) => {
         requestState[requestId].started = true;
 
         resolver && await resolver(args);
-        
+
         returnValue = null;
     }
-    
+
+    // Merge after execution completes (sync or async) so pathwayResultData
+    // (including artifacts) reflects the final state of the sub-pathway resolver.
+    if (pathwayResolver && contextValue.pathwayResolver) {
+        pathwayResolver.mergeResolver(contextValue.pathwayResolver);
+    }
+
+    latencyTrace.end(span, {
+        childRequestId: contextValue.pathwayResolver?.requestId,
+        returnKind: returnValue && typeof returnValue.on === 'function' ? 'stream' : typeof returnValue,
+        returnChars: typeof returnValue === 'string' ? returnValue.length : undefined,
+    });
     return returnValue;
 };
 
+// Pull inline screenshots / images out of a client-side tool's result so
+// they're delivered to the model as vision input (via toolImages →
+// image_url parts in the agent loop) rather than as base64 strings stuffed
+// inside the tool result JSON. Recognized top-level shapes:
+//
+//   { screenshot: { base64, mimeType }, ... }            // canvas / page-inspect tools
+//   { screenshots: [{ base64, mimeType }, ...], ... }
+//   { imageUrl: { url, ... }, ... }                      // ViewImage convention
+//   { imageUrls: [{ url, ... }, ...], ... }
+//
+// Returns { result: <stringified data with images stripped>, toolImages: [...] }.
+// Non-object data (string / number / null) is passed through unchanged with
+// no extracted images.
+const extractClientToolImages = (data) => {
+    if (typeof data === 'string') {
+        return { result: data, toolImages: [] };
+    }
+    if (!data || typeof data !== 'object') {
+        return { result: JSON.stringify(data), toolImages: [] };
+    }
+
+    // Shallow clone so we don't mutate the caller's data — pathwayResolver.tool
+    // captures the original (un-stripped) version for downstream consumers.
+    const cleaned = { ...data };
+    const toolImages = [];
+
+    if (cleaned.imageUrl && typeof cleaned.imageUrl === 'object') {
+        toolImages.push(cleaned.imageUrl);
+        delete cleaned.imageUrl;
+    }
+    if (Array.isArray(cleaned.imageUrls)) {
+        toolImages.push(...cleaned.imageUrls);
+        delete cleaned.imageUrls;
+    }
+
+    const pushScreenshot = (shot) => {
+        if (!shot || typeof shot !== 'object') return;
+        const { base64, mimeType, mime_type } = shot;
+        if (typeof base64 !== 'string' || !base64) return;
+        const mime = mimeType || mime_type || 'image/png';
+        toolImages.push({ image_url: { url: `data:${mime};base64,${base64}` } });
+    };
+    if (cleaned.screenshot) {
+        pushScreenshot(cleaned.screenshot);
+        delete cleaned.screenshot;
+    }
+    if (Array.isArray(cleaned.screenshots)) {
+        cleaned.screenshots.forEach(pushScreenshot);
+        delete cleaned.screenshots;
+    }
+
+    return { result: JSON.stringify(cleaned), toolImages };
+};
+
+function toolEntryToOpenAiTool(toolKey, toolEntry, forceToolKeyName = false) {
+    const toolFunction = toolEntry?.definition?.function || {};
+    const name = (forceToolKeyName || toolEntry?.mcpServer) ? toolKey : (toolFunction.name || toolKey);
+    return {
+        type: 'function',
+        function: {
+            name,
+            description: toolFunction.description || '',
+            parameters: toolFunction.parameters || { type: 'object', properties: {} },
+        },
+    };
+}
+
+function hasOpenAiToolSchema(entityToolsOpenAiFormat, toolKey, toolEntry) {
+    if (!Array.isArray(entityToolsOpenAiFormat)) return false;
+    const toolFunctionName = toolEntry?.definition?.function?.name || toolKey;
+    return entityToolsOpenAiFormat.some(tool => {
+        const name = tool?.function?.name;
+        return typeof name === 'string' && (
+            name.toLowerCase() === toolKey.toLowerCase() ||
+            name.toLowerCase() === toolFunctionName.toLowerCase()
+        );
+    });
+}
+
+const INSPECT_TOOL_RESULT_DEFAULT_LIMIT = 4000;
+const INSPECT_TOOL_RESULT_MAX_LIMIT = 12000;
+const INSPECT_TOOL_RESULT_MAX_SEARCH_MATCHES = 5;
+const INSPECT_TOOL_RESULT_SEARCH_CONTEXT_MAX = 1200;
+
+function clampInspectLimit(limit) {
+    const parsed = Number(limit);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return INSPECT_TOOL_RESULT_DEFAULT_LIMIT;
+    }
+    return Math.min(Math.floor(parsed), INSPECT_TOOL_RESULT_MAX_LIMIT);
+}
+
+function parseToolResultSnapshotContent(content) {
+    if (typeof content !== 'string') {
+        return { envelope: null, text: '' };
+    }
+    try {
+        const envelope = JSON.parse(content);
+        const streamParts = [
+            ['stdout', envelope.stdoutPreview],
+            ['stderr', envelope.stderrPreview],
+        ].filter(([, value]) => typeof value === 'string');
+        if (streamParts.length > 1) {
+            return {
+                envelope,
+                text: streamParts.map(([label, value]) => `[${label}]\n${value}`).join('\n\n'),
+            };
+        }
+        const candidates = [
+            envelope.contentPreview,
+            streamParts[0]?.[1],
+            envelope.result,
+        ];
+        const text = candidates.find(value => typeof value === 'string') || content;
+        return { envelope, text };
+    } catch {
+        return { envelope: null, text: content };
+    }
+}
+
+function buildToolResultSummary(resultRef, snap, envelope, text) {
+    return {
+        ok: true,
+        resultRef,
+        mode: 'summary',
+        tool: envelope?.tool,
+        kind: envelope?.kind,
+        summary: envelope?.summary,
+        compacted: envelope?.compacted,
+        contentTotalChars: envelope?.contentTotalChars,
+        stdoutTotalChars: envelope?.stdoutTotalChars,
+        stderrTotalChars: envelope?.stderrTotalChars,
+        storedChars: snap?.length || snap?.content?.length || text.length,
+        readableChars: text.length,
+        artifactRefs: Array.isArray(envelope?.artifactRefs) ? envelope.artifactRefs : undefined,
+    };
+}
+
+function valuePathSegment(key) {
+    if (typeof key === 'number') return `[${key}]`;
+    return /^[A-Za-z_$][\w$]*$/.test(key) ? `.${key}` : `[${JSON.stringify(key)}]`;
+}
+
+function contextAroundMatch(value, index, needleLength, limit) {
+    const maxContext = Math.min(limit, INSPECT_TOOL_RESULT_SEARCH_CONTEXT_MAX);
+    const start = Math.max(0, index - Math.floor((maxContext - needleLength) / 2));
+    const end = Math.min(value.length, start + maxContext);
+    return {
+        snippetOffset: start,
+        snippet: `${start > 0 ? '...' : ''}${value.slice(start, end)}${end < value.length ? '...' : ''}`,
+    };
+}
+
+function findJsonStringOffset(text, value, valueOffset, cursor) {
+    const encoded = JSON.stringify(value);
+    const start = text.indexOf(encoded, cursor.position);
+    if (start === -1) return null;
+    cursor.position = start + encoded.length;
+    return start + 1 + valueOffset;
+}
+
+function collectJsonSearchMatches(value, query, limit, matches, cursor, path = '$') {
+    if (matches.length >= INSPECT_TOOL_RESULT_MAX_SEARCH_MATCHES) return;
+
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => {
+            collectJsonSearchMatches(item, query, limit, matches, cursor, `${path}${valuePathSegment(index)}`);
+        });
+        return;
+    }
+
+    if (value && typeof value === 'object') {
+        Object.entries(value).forEach(([key, item]) => {
+            collectJsonSearchMatches(item, query, limit, matches, cursor, `${path}${valuePathSegment(key)}`);
+        });
+        return;
+    }
+
+    const textValue = typeof value === 'string' ? value : String(value ?? '');
+    if (!textValue) return;
+
+    const haystack = textValue.toLowerCase();
+    const needle = query.toLowerCase();
+    let searchFrom = 0;
+    while (matches.length < INSPECT_TOOL_RESULT_MAX_SEARCH_MATCHES) {
+        const index = haystack.indexOf(needle, searchFrom);
+        if (index === -1) break;
+        const context = contextAroundMatch(textValue, index, needle.length, limit);
+        matches.push({
+            offset: findJsonStringOffset(cursor.sourceText, textValue, index, cursor) ?? undefined,
+            valueOffset: index,
+            path,
+            snippetOffset: context.snippetOffset,
+            snippet: context.snippet,
+        });
+        searchFrom = index + Math.max(needle.length, 1);
+    }
+}
+
+function searchJsonPayload(text, query, limit) {
+    try {
+        const parsed = JSON.parse(text);
+        const matches = [];
+        collectJsonSearchMatches(parsed, query, limit, matches, { sourceText: text, position: 0 });
+        return matches.length > 0 ? matches : null;
+    } catch {
+        return null;
+    }
+}
+
+function inspectToolResult(args, pathwayResolver) {
+    const resultRef = typeof args.resultRef === 'string' ? args.resultRef.trim() : '';
+    if (!resultRef) {
+        return { result: JSON.stringify({ error: true, message: 'resultRef is required.' }) };
+    }
+
+    const snap = pathwayResolver?._toolResultSnapshots?.get(resultRef);
+    if (!snap || typeof snap.content !== 'string') {
+        return {
+            result: JSON.stringify({
+                error: true,
+                resultRef,
+                message: `Tool result ${resultRef} is not available in this request.`,
+            }),
+        };
+    }
+
+    const mode = typeof args.mode === 'string' ? args.mode : 'summary';
+    const limit = clampInspectLimit(args.limit);
+    const { envelope, text } = parseToolResultSnapshotContent(snap.content);
+    const base = buildToolResultSummary(resultRef, snap, envelope, text);
+
+    if (mode === 'summary') {
+        return { result: JSON.stringify(base) };
+    }
+
+    if (mode === 'head') {
+        return {
+            result: JSON.stringify({
+                ...base,
+                mode,
+                offset: 0,
+                limit,
+                content: text.slice(0, limit),
+                hasMore: text.length > limit,
+            }),
+        };
+    }
+
+    if (mode === 'tail') {
+        const offset = Math.max(0, text.length - limit);
+        return {
+            result: JSON.stringify({
+                ...base,
+                mode,
+                offset,
+                limit,
+                content: text.slice(offset),
+                hasMoreBefore: offset > 0,
+            }),
+        };
+    }
+
+    if (mode === 'chunk') {
+        const offset = Math.max(0, Math.floor(Number(args.offset) || 0));
+        return {
+            result: JSON.stringify({
+                ...base,
+                mode,
+                offset,
+                limit,
+                content: text.slice(offset, offset + limit),
+                hasMoreBefore: offset > 0,
+                hasMoreAfter: offset + limit < text.length,
+            }),
+        };
+    }
+
+    if (mode === 'search') {
+        const query = typeof args.query === 'string' ? args.query : '';
+        if (!query.trim()) {
+            return {
+                result: JSON.stringify({
+                    error: true,
+                    resultRef,
+                    mode,
+                    message: 'query is required for search mode.',
+                }),
+            };
+        }
+        const haystack = text.toLowerCase();
+        const needle = query.toLowerCase();
+        let matches = searchJsonPayload(text, query, limit) || [];
+        if (!matches.length) {
+            let searchFrom = 0;
+            while (matches.length < INSPECT_TOOL_RESULT_MAX_SEARCH_MATCHES) {
+                const index = haystack.indexOf(needle, searchFrom);
+                if (index === -1) break;
+                const snippetStart = Math.max(0, index - Math.floor(limit / 2));
+                const snippetEnd = Math.min(text.length, snippetStart + limit);
+                matches.push({
+                    offset: index,
+                    snippetOffset: snippetStart,
+                    snippet: text.slice(snippetStart, snippetEnd),
+                });
+                searchFrom = index + Math.max(needle.length, 1);
+            }
+        }
+        return {
+            result: JSON.stringify({
+                ...base,
+                mode,
+                query,
+                limit,
+                matchCount: matches.length,
+                matches,
+            }),
+        };
+    }
+
+    return {
+        result: JSON.stringify({
+            error: true,
+            resultRef,
+            mode,
+            message: 'mode must be one of summary, head, tail, chunk, or search.',
+        }),
+    };
+}
+
 const callTool = async (toolName, args, toolDefinitions, pathwayResolver) => {
+    const span = latencyTrace.start('tool.call', {
+        requestId: pathwayResolver?.requestId,
+        rootRequestId: pathwayResolver?.rootRequestId || undefined,
+        pathway: pathwayResolver?.pathway?.name,
+        toolName,
+    });
     let toolResult = null;
     let toolImages = [];
 
@@ -92,6 +445,111 @@ const callTool = async (toolName, args, toolDefinitions, pathwayResolver) => {
     logger.debug(`callTool: Starting execution of ${toolName} ${JSON.stringify(logArgs)}`);
 
     try {
+        // Built-in tool: SearchAvailableTools — searches the MCP tool catalog and
+        // dynamically loads matched tools into the entity's available tools so the model
+        // can call them in subsequent turns.
+        if (toolDef.pathwayName === '_builtin_search_tools') {
+            const catalog = {
+                ...(pathwayResolver?.args?.localToolCatalog || {}),
+                ...(pathwayResolver?.args?.mcpToolCatalog || {}),
+            };
+            const deferred = {
+                ...(pathwayResolver?.args?.localEntityToolsDeferred || {}),
+                ...(pathwayResolver?.args?.mcpEntityToolsDeferred || {}),
+            };
+            const query = (args.query || '').toLowerCase();
+
+            if (!query) {
+                const result = { result: JSON.stringify({ error: true, message: 'A search query is required.' }) };
+                latencyTrace.end(span, { toolKind: 'builtin', error: 'missing_query' });
+                return result;
+            }
+
+            // Split query into keywords for matching
+            const keywords = query.split(/\s+/).filter(Boolean);
+
+            // Score each catalog entry by how many keywords match name, description, or parameter names
+            const scored = Object.values(catalog).map(entry => {
+                const haystack = `${entry.name} ${entry.displayName || ''} ${entry.originalName} ${entry.description} ${entry.parameters.join(' ')}`.toLowerCase();
+                const score = keywords.reduce((s, kw) => s + (haystack.includes(kw) ? 1 : 0), 0);
+                return { ...entry, score };
+            });
+
+            // Return top matches (score > 0), up to 5
+            const matches = scored
+                .filter(e => e.score > 0)
+                .sort((a, b) => b.score - a.score)
+                .slice(0, 5);
+
+            if (matches.length === 0) {
+                const result = { result: JSON.stringify({ tools: [], message: `No tools found matching "${args.query}". Try different keywords.` }) };
+                latencyTrace.end(span, { toolKind: 'builtin', matchCount: 0 });
+                return result;
+            }
+
+            // Dynamically load matched tools into the entity's available tool set
+            const entityTools = pathwayResolver?.args?.entityTools;
+            const entityToolsOpenAiFormat = pathwayResolver?.args?.entityToolsOpenAiFormat;
+            const loadedToolNames = [];
+
+            for (const match of matches) {
+                const toolKey = match.name;
+                if (!deferred[toolKey]) {
+                    continue;
+                }
+                if (entityTools && !entityTools[toolKey]) {
+                    entityTools[toolKey] = deferred[toolKey];
+                }
+                if (entityToolsOpenAiFormat && !hasOpenAiToolSchema(entityToolsOpenAiFormat, toolKey, deferred[toolKey])) {
+                    entityToolsOpenAiFormat.push(toolEntryToOpenAiTool(toolKey, deferred[toolKey], match.source !== 'local'));
+                    loadedToolNames.push(toolKey);
+                }
+            }
+
+            if (loadedToolNames.length > 0) {
+                logger.info(`SearchAvailableTools: loaded ${loadedToolNames.length} tools into context: ${loadedToolNames.join(', ')}`);
+            }
+
+            // Return concise search results to the model
+            const resultTools = matches.map(m => ({
+                name: m.source === 'local' ? (m.displayName || m.originalName || m.name) : m.name,
+                description: m.description,
+                server: m.server,
+            }));
+
+            const result = { result: JSON.stringify({ tools: resultTools, message: `Found ${resultTools.length} tool(s). These tools are now available for you to call directly.` }) };
+            latencyTrace.end(span, { toolKind: 'builtin', matchCount: resultTools.length, loadedToolCount: loadedToolNames.length });
+            return result;
+        }
+
+        if (toolDef.pathwayName === '_builtin_inspect_tool_result') {
+            const result = inspectToolResult(args, pathwayResolver);
+            latencyTrace.end(span, { toolKind: 'builtin', resultKind: typeof result?.result });
+            return result;
+        }
+
+        // Check if this is an MCP tool
+        if (toolDef.mcpServer) {
+            const mcpClients = pathwayResolver?.args?.mcpClients;
+            if (!mcpClients || mcpClients.size === 0) {
+                throw new Error('MCP clients not initialized');
+            }
+            // Only pass tool-specific parameters defined in the tool's schema,
+            // not the full args object (which includes chatHistory, entityTools, etc.)
+            const toolParamKeys = Object.keys(toolDef.definition?.function?.parameters?.properties || {});
+            const mcpArgs = {};
+            for (const key of toolParamKeys) {
+                if (key in args) {
+                    mcpArgs[key] = args[key];
+                }
+            }
+            // Use the original MCP tool name (preserving case) from the tool definition,
+            // not the lowercased composite key, since MCP servers are case-sensitive.
+            const mcpResult = await callMcpTool(mcpClients, toolName, mcpArgs, toolDef.mcpToolName);
+            latencyTrace.end(span, { toolKind: 'mcp', resultKind: typeof mcpResult?.result });
+            return mcpResult;
+        }
+
         // Check if this is a client-side tool
         if (toolDef.clientSide === true || toolDef.definition?.clientSide === true) {
             logger.info(`Tool ${toolName} is a client-side tool - waiting for client execution`);
@@ -129,29 +587,62 @@ const callTool = async (toolName, args, toolDefinitions, pathwayResolver) => {
                 // Wait for the client to execute the tool and send back the result
                 logger.info(`Waiting for client tool result: ${toolCallbackId}`);
                 try {
-                    // Use 5 minute timeout to accommodate longer operations like CreateApplet
+                    // Use 5 minute timeout to accommodate longer operations like CreateWorkspace
                     const clientResult = await waitForClientToolResult(toolCallbackId, requestId, 300000);
-                    logger.info(`Received client tool result for ${toolCallbackId}: ${JSON.stringify(clientResult).substring(0, 200)}`);
+                    const serializedClientResult = JSON.stringify(clientResult) ?? String(clientResult);
+                    const resultData = clientResult?.data;
+                    const resultDataType = Array.isArray(resultData) ? 'array' : typeof resultData;
+                    logger.info(JSON.stringify({
+                        event: 'client_tool_result_received',
+                        requestId,
+                        toolCallbackId,
+                        success: clientResult?.success === true,
+                        resultDataType,
+                        resultDataKeys: resultData && typeof resultData === 'object' && !Array.isArray(resultData)
+                            ? Object.keys(resultData)
+                            : undefined,
+                        resultBytes: serializedClientResult.length,
+                    }));
+                    logger.debug(JSON.stringify({
+                        event: 'client_tool_result_payload',
+                        requestId,
+                        toolCallbackId,
+                        result: clientResult,
+                    }));
                     
                     // If the client reported an error, throw it
                     if (!clientResult.success) {
                         throw new Error(clientResult.error || 'Client tool execution failed');
                     }
                     
-                    // Return the client's result
-                    toolResult = typeof clientResult.data === 'string' 
-                        ? clientResult.data 
-                        : JSON.stringify(clientResult.data);
-                    
-                    // Update resolver with tool result
+                    // Extract any inline screenshots / images from the
+                    // client's result before stringifying. Otherwise they
+                    // sit inside the tool result JSON as raw base64, which
+                    // (a) bloats the message past the agent's truncation
+                    // cutoff, getting chopped mid-base64, and (b) reaches
+                    // the model as text noise rather than as vision input.
+                    // Pulling them into toolImages routes them through the
+                    // image_url path the agent loop already implements.
+                    const { result: cleanedResult, toolImages: extractedImages } =
+                        extractClientToolImages(clientResult.data);
+                    toolResult = cleanedResult;
+
+                    // Update resolver with the original (un-stripped) data —
+                    // downstream consumers may want to see screenshots too.
                     pathwayResolver.tool = JSON.stringify({
                         ...toolCallbackData,
                         result: clientResult.data
                     });
-                    
+
+                    latencyTrace.end(span, {
+                        toolKind: 'client',
+                        toolCallbackId,
+                        hasResult: Boolean(toolResult),
+                        toolImagesLength: extractedImages?.length || 0,
+                    });
                     return {
                         result: toolResult,
-                        images: []
+                        toolImages: extractedImages,
                     };
                 } catch (error) {
                     logger.error(`Error waiting for client tool result: ${error.message}`);
@@ -184,7 +675,9 @@ const callTool = async (toolName, args, toolDefinitions, pathwayResolver) => {
         }
 
         if (toolResult === null) {
-            return { error: `Tool ${toolName} returned null result` };
+            const result = { error: `Tool ${toolName} returned null result` };
+            latencyTrace.end(span, { toolKind: 'pathway', pathwayName, error: result.error });
+            return result;
         }
 
         // Handle search results accumulation
@@ -195,6 +688,12 @@ const callTool = async (toolName, args, toolDefinitions, pathwayResolver) => {
             parsedResult = typeof toolResult === 'string' ? JSON.parse(toolResult) : toolResult;
         } catch (e) {
             // If parsing fails, just return the original result
+            latencyTrace.end(span, {
+                toolKind: 'pathway',
+                pathwayName: toolDef.pathwayName,
+                resultKind: typeof toolResult,
+                parseableJson: false,
+            });
             return {
                 result: toolResult,
                 toolImages: toolImages
@@ -208,11 +707,15 @@ const callTool = async (toolName, args, toolDefinitions, pathwayResolver) => {
             }
 
             // Check if tool result has imageUrl or imageUrls field (for ViewImage/ViewImages tools)
+            // Extract into toolImages and remove from parsedResult so the URLs
+            // don't also appear in the tool result content sent to the model
             if (parsedResult.imageUrl && typeof parsedResult.imageUrl === 'object') {
                 toolImages.push(parsedResult.imageUrl);
+                delete parsedResult.imageUrl;
             }
             if (parsedResult.imageUrls && Array.isArray(parsedResult.imageUrls)) {
                 toolImages.push(...parsedResult.imageUrls);
+                delete parsedResult.imageUrls;
             }
 
             // Check if this is a search response
@@ -263,11 +766,22 @@ const callTool = async (toolName, args, toolDefinitions, pathwayResolver) => {
             hasToolImages: !!finalResult.toolImages,
             toolImagesLength: finalResult.toolImages?.length || 0
         })}`);
+        latencyTrace.end(span, {
+            toolKind: toolDef.clientSide === true || toolDef.definition?.clientSide === true
+                ? 'client'
+                : toolDef.mcpServer
+                    ? 'mcp'
+                    : 'pathway',
+            pathwayName: toolDef.pathwayName,
+            hasResult: !!finalResult.result,
+            toolImagesLength: finalResult.toolImages?.length || 0,
+        });
         return finalResult;
     } catch (error) {
         logger.error(`Error calling tool ${toolName}: ${error.message}`);
         const errorResult = { error: error.message };
         logger.debug(`callTool: ${toolName} failed, returning error: ${JSON.stringify(errorResult)}`);
+        latencyTrace.end(span, { error: error.message });
         return errorResult;
     }
 }
@@ -447,4 +961,4 @@ const withTimeout = (promise, timeoutMs, errorMessage = 'Operation timed out') =
     });
 };
 
-export { callPathway, gpt3Encode, gpt3Decode, say, callTool, addCitationsToResolver, sendToolStart, sendToolFinish, withTimeout };
+export { callPathway, gpt3Encode, gpt3Decode, say, callTool, addCitationsToResolver, sendToolStart, sendToolFinish, withTimeout, extractClientToolImages };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@dqbd/tiktoken": "^1.0.20",
         "@graphql-tools/schema": "^9.0.12",
         "@keyv/redis": "^2.5.4",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.3.4",
         "axios-cache-interceptor": "^1.0.1",
         "bottleneck": "^2.19.5",
@@ -1660,6 +1661,18 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
@@ -1676,6 +1689,393 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -2810,6 +3210,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -3725,6 +4158,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -3792,9 +4239,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4208,6 +4655,18 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
@@ -4215,6 +4674,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.18"
+      }
+    },
+    "node_modules/eventsource/node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/express": {
@@ -4263,6 +4731,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4282,6 +4768,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-defer": {
@@ -4319,6 +4811,22 @@
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
       "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -4878,6 +5386,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
@@ -5045,6 +5562,15 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5183,7 +5709,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -5226,11 +5751,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/iterall": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
@@ -5256,6 +5796,18 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -5897,6 +6449,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -6048,6 +6609,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -6075,6 +6645,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-conf": {
@@ -6385,6 +6964,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -6449,6 +7037,32 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/run-applescript": {
@@ -6643,6 +7257,27 @@
       },
       "bin": {
         "sha.js": "bin.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/side-channel": {
@@ -7202,6 +7837,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/winston": {
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
@@ -7352,6 +8002,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
@@ -7516,6 +8172,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@dqbd/tiktoken": "^1.0.20",
     "@graphql-tools/schema": "^9.0.12",
     "@keyv/redis": "^2.5.4",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.3.4",
     "axios-cache-interceptor": "^1.0.1",
     "bottleneck": "^2.19.5",

--- a/tests/unit/lib/mcpClient.test.js
+++ b/tests/unit/lib/mcpClient.test.js
@@ -1,0 +1,589 @@
+// mcpClient.test.js
+// Unit tests for the MCP (Model Context Protocol) client module
+import test from 'ava';
+import { isTokenExpired, initializeMcpClients } from '../../../lib/mcpClient.js';
+
+// We cannot import the real mcpClient module because it depends on @modelcontextprotocol/sdk
+// which requires actual server connections. Instead, we test the pure logic functions
+// by reimplementing the testable parts inline or by testing via callTool integration.
+
+// ----- mcpToolToOpenAI logic tests -----
+
+// Replicate the pure function for unit testing (same logic as in mcpClient.js)
+function mcpToolToOpenAI(tool, serverKey, cloudIdState) {
+    const inputSchema = tool.inputSchema || { type: 'object', properties: {} };
+    let properties = { ...(inputSchema.properties || {}) };
+    let required = [...(inputSchema.required || [])];
+
+    if (cloudIdState?.resolved) {
+        delete properties.cloudId;
+        required = required.filter(r => r !== 'cloudId');
+    } else if (cloudIdState?.availableSites?.length > 0 && properties.cloudId) {
+        const siteList = cloudIdState.availableSites
+            .map(s => `  - "${s.id}" (${s.url || s.name || 'unknown'})`)
+            .join('\n');
+        properties.cloudId = {
+            ...properties.cloudId,
+            description: `The Atlassian cloud site ID. You MUST ask the user which site to use. Available sites:\n${siteList}`,
+        };
+    }
+
+    return {
+        type: 'function',
+        function: {
+            name: tool.name,
+            description: tool.description || `MCP tool: ${tool.name}`,
+            parameters: {
+                type: inputSchema.type || 'object',
+                properties,
+                required,
+            },
+        },
+        icon: '🔌',
+        mcpServer: serverKey,
+    };
+}
+
+test('mcpToolToOpenAI converts basic MCP tool to OpenAI format', (t) => {
+    const mcpTool = {
+        name: 'search_issues',
+        description: 'Search for issues in the project',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                query: { type: 'string', description: 'Search query' },
+                limit: { type: 'number', description: 'Max results' },
+            },
+            required: ['query'],
+        },
+    };
+
+    const result = mcpToolToOpenAI(mcpTool, 'jira');
+
+    t.is(result.type, 'function');
+    t.is(result.function.name, 'search_issues');
+    t.is(result.function.description, 'Search for issues in the project');
+    t.deepEqual(result.function.parameters.required, ['query']);
+    t.truthy(result.function.parameters.properties.query);
+    t.truthy(result.function.parameters.properties.limit);
+    t.is(result.icon, '🔌');
+    t.is(result.mcpServer, 'jira');
+});
+
+test('mcpToolToOpenAI handles tool without inputSchema', (t) => {
+    const mcpTool = {
+        name: 'list_all',
+        description: 'List all items',
+    };
+
+    const result = mcpToolToOpenAI(mcpTool, 'server1');
+
+    t.is(result.function.name, 'list_all');
+    t.deepEqual(result.function.parameters, {
+        type: 'object',
+        properties: {},
+        required: [],
+    });
+});
+
+test('mcpToolToOpenAI generates default description when missing', (t) => {
+    const mcpTool = {
+        name: 'my_tool',
+    };
+
+    const result = mcpToolToOpenAI(mcpTool, 'server1');
+
+    t.is(result.function.description, 'MCP tool: my_tool');
+});
+
+test('mcpToolToOpenAI handles inputSchema without required field', (t) => {
+    const mcpTool = {
+        name: 'optional_tool',
+        description: 'A tool with all optional params',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                param1: { type: 'string' },
+            },
+        },
+    };
+
+    const result = mcpToolToOpenAI(mcpTool, 'server1');
+
+    t.deepEqual(result.function.parameters.required, []);
+    t.truthy(result.function.parameters.properties.param1);
+});
+
+test('mcpToolToOpenAI strips cloudId when resolved', (t) => {
+    const mcpTool = {
+        name: 'search_issues',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                cloudId: { type: 'string', description: 'Cloud site ID' },
+                query: { type: 'string' },
+            },
+            required: ['cloudId', 'query'],
+        },
+    };
+
+    const result = mcpToolToOpenAI(mcpTool, 'atlassian', { resolved: 'cloud-123' });
+
+    t.falsy(result.function.parameters.properties.cloudId);
+    t.truthy(result.function.parameters.properties.query);
+    t.deepEqual(result.function.parameters.required, ['query']);
+});
+
+test('mcpToolToOpenAI keeps cloudId with site list when multiple sites', (t) => {
+    const mcpTool = {
+        name: 'search_issues',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                cloudId: { type: 'string', description: 'Original desc' },
+                query: { type: 'string' },
+            },
+            required: ['cloudId', 'query'],
+        },
+    };
+
+    const sites = [
+        { id: 'aaa', url: 'https://site-a.atlassian.net' },
+        { id: 'bbb', name: 'Site B' },
+    ];
+    const result = mcpToolToOpenAI(mcpTool, 'atlassian', { availableSites: sites });
+
+    t.truthy(result.function.parameters.properties.cloudId);
+    t.true(result.function.parameters.properties.cloudId.description.includes('MUST ask'));
+    t.true(result.function.parameters.properties.cloudId.description.includes('aaa'));
+    t.true(result.function.parameters.properties.cloudId.description.includes('bbb'));
+    t.deepEqual(result.function.parameters.required, ['cloudId', 'query']);
+});
+
+test('mcpToolToOpenAI passes through unchanged without cloudIdState', (t) => {
+    const mcpTool = {
+        name: 'search_issues',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                cloudId: { type: 'string' },
+                query: { type: 'string' },
+            },
+            required: ['cloudId', 'query'],
+        },
+    };
+
+    const result = mcpToolToOpenAI(mcpTool, 'atlassian');
+
+    t.truthy(result.function.parameters.properties.cloudId);
+    t.deepEqual(result.function.parameters.required, ['cloudId', 'query']);
+});
+
+// ----- discoverMcpTools catalog building logic tests -----
+
+// Replicate the catalog-building logic from discoverMcpTools for unit testing
+function buildMcpToolCatalog(tools, serverKey) {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+    const toolToServerMap = new Map();
+    const mcpToolCatalog = {};
+
+    for (const tool of tools) {
+        const toolName = tool.name?.toLowerCase();
+        if (!toolName) continue;
+
+        const openAiTool = mcpToolToOpenAI(tool, serverKey);
+        const compositeKey = `${serverKey}__${toolName}`;
+
+        entityTools[compositeKey] = {
+            definition: openAiTool,
+            pathwayName: 'mcp_tool_execution',
+            mcpServer: serverKey,
+            mcpToolName: tool.name,
+        };
+        entityToolsOpenAiFormat.push({
+            type: 'function',
+            function: {
+                name: compositeKey,
+                description: openAiTool.function.description,
+                parameters: openAiTool.function.parameters,
+            },
+        });
+        toolToServerMap.set(compositeKey, serverKey);
+
+        const paramNames = Object.keys(openAiTool.function?.parameters?.properties || {});
+        mcpToolCatalog[compositeKey] = {
+            name: compositeKey,
+            originalName: tool.name,
+            server: serverKey,
+            description: openAiTool.function.description || '',
+            parameters: paramNames,
+        };
+    }
+
+    return { entityTools, entityToolsOpenAiFormat, toolToServerMap, mcpToolCatalog };
+}
+
+test('buildMcpToolCatalog creates composite keys with lowercase tool names', (t) => {
+    const tools = [
+        { name: 'SearchIssues', description: 'Search', inputSchema: { type: 'object', properties: {} } },
+    ];
+
+    const result = buildMcpToolCatalog(tools, 'atlassian');
+
+    t.truthy(result.entityTools['atlassian__searchissues']);
+    t.is(result.mcpToolCatalog['atlassian__searchissues'].originalName, 'SearchIssues');
+});
+
+test('buildMcpToolCatalog preserves original tool name for case-sensitive MCP servers', (t) => {
+    const tools = [
+        { name: 'GetPageById', description: 'Get a page', inputSchema: { type: 'object', properties: { pageId: { type: 'string' } } } },
+    ];
+
+    const result = buildMcpToolCatalog(tools, 'confluence');
+
+    const entry = result.entityTools['confluence__getpagebyid'];
+    t.is(entry.mcpToolName, 'GetPageById');
+    t.is(entry.mcpServer, 'confluence');
+});
+
+test('buildMcpToolCatalog skips tools without names', (t) => {
+    const tools = [
+        { name: 'valid_tool', description: 'Valid' },
+        { description: 'No name tool' },
+        { name: '', description: 'Empty name' },
+    ];
+
+    const result = buildMcpToolCatalog(tools, 'server');
+
+    t.is(Object.keys(result.entityTools).length, 1);
+    t.truthy(result.entityTools['server__valid_tool']);
+});
+
+test('buildMcpToolCatalog populates catalog with parameter names', (t) => {
+    const tools = [
+        {
+            name: 'create_issue',
+            description: 'Create an issue',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    title: { type: 'string' },
+                    description: { type: 'string' },
+                    priority: { type: 'string' },
+                },
+                required: ['title'],
+            },
+        },
+    ];
+
+    const result = buildMcpToolCatalog(tools, 'jira');
+
+    const catalogEntry = result.mcpToolCatalog['jira__create_issue'];
+    t.deepEqual(catalogEntry.parameters, ['title', 'description', 'priority']);
+    t.is(catalogEntry.server, 'jira');
+});
+
+test('buildMcpToolCatalog handles multiple tools from same server', (t) => {
+    const tools = [
+        { name: 'tool_a', description: 'Tool A' },
+        { name: 'tool_b', description: 'Tool B' },
+        { name: 'tool_c', description: 'Tool C' },
+    ];
+
+    const result = buildMcpToolCatalog(tools, 'myserver');
+
+    t.is(Object.keys(result.entityTools).length, 3);
+    t.is(result.entityToolsOpenAiFormat.length, 3);
+    t.is(result.toolToServerMap.size, 3);
+    t.is(Object.keys(result.mcpToolCatalog).length, 3);
+});
+
+// ----- callMcpTool argument parsing logic tests -----
+
+test('callMcpTool composite name parsing extracts server and tool name', (t) => {
+    // Test the parsing logic used in callMcpTool
+    const compositeToolName = 'atlassian__search_issues';
+    const parts = compositeToolName.split('__');
+    const serverKey = parts[0];
+    const toolName = parts.slice(1).join('__');
+
+    t.is(serverKey, 'atlassian');
+    t.is(toolName, 'search_issues');
+});
+
+test('callMcpTool composite name with double underscores in tool name', (t) => {
+    // Tool names might contain __ themselves
+    const compositeToolName = 'server__tool__with__underscores';
+    const parts = compositeToolName.split('__');
+    const serverKey = parts[0];
+    const toolName = parts.slice(1).join('__');
+
+    t.is(serverKey, 'server');
+    t.is(toolName, 'tool__with__underscores');
+});
+
+test('callMcpTool prefers originalToolName over composite key extraction', (t) => {
+    const compositeToolName = 'atlassian__searchissues';
+    const originalToolName = 'SearchIssues';
+    const parts = compositeToolName.split('__');
+    const toolName = originalToolName || parts.slice(1).join('__');
+
+    t.is(toolName, 'SearchIssues');
+});
+
+test('callMcpTool invalid composite name (no separator) should be detectable', (t) => {
+    const compositeToolName = 'invalidname';
+    const parts = compositeToolName.split('__');
+
+    t.true(parts.length < 2);
+});
+
+test('callMcpTool cloudId injection logic', (t) => {
+    // Test the cloudId injection logic — always inject stored cloudId
+    const cloudId = 'cloud-123';
+    const args = { query: 'test' };
+
+    const finalArgs = { ...args };
+    if (cloudId) {
+        finalArgs.cloudId = cloudId;
+    }
+
+    t.is(finalArgs.cloudId, 'cloud-123');
+    t.is(finalArgs.query, 'test');
+});
+
+test('callMcpTool cloudId injection overrides AI-provided value', (t) => {
+    // Stored cloudId always wins — prevents AI hallucination
+    const cloudId = 'cloud-123';
+    const args = { query: 'test', cloudId: 'hallucinated-value' };
+
+    const finalArgs = { ...args };
+    if (cloudId) {
+        finalArgs.cloudId = cloudId;
+    }
+
+    t.is(finalArgs.cloudId, 'cloud-123');
+});
+
+test('callMcpTool cloudId injection skipped when no cloudId configured', (t) => {
+    const cloudId = null;
+    const args = { query: 'test' };
+
+    const finalArgs = { ...args };
+    if (cloudId) {
+        finalArgs.cloudId = cloudId;
+    }
+
+    t.is(finalArgs.cloudId, undefined);
+});
+
+// ----- initializeMcpClients input validation logic tests -----
+
+test('initializeMcpClients returns empty map for null input', async (t) => {
+    // Test the validation logic from initializeMcpClients
+    const mcpConfigJson = null;
+    const shouldReturn = !mcpConfigJson || typeof mcpConfigJson !== 'string';
+    t.true(shouldReturn);
+});
+
+test('initializeMcpClients returns empty map for non-string input', async (t) => {
+    const mcpConfigJson = 123;
+    const shouldReturn = !mcpConfigJson || typeof mcpConfigJson !== 'string';
+    t.true(shouldReturn);
+});
+
+test('initializeMcpClients returns empty map for empty string', async (t) => {
+    const mcpConfigJson = '';
+    const shouldReturn = !mcpConfigJson || typeof mcpConfigJson !== 'string';
+    t.true(shouldReturn);
+});
+
+test('initializeMcpClients handles invalid JSON gracefully', (t) => {
+    const mcpConfigJson = 'not valid json {{{';
+    let config;
+    try {
+        config = JSON.parse(mcpConfigJson);
+    } catch (e) {
+        config = null;
+    }
+    t.is(config, null);
+});
+
+test('initializeMcpClients skips servers without url', (t) => {
+    const mcpConfigJson = JSON.stringify({
+        server1: { type: 'streamable-http' },
+        server2: { url: 'https://example.com/mcp', type: 'streamable-http' },
+    });
+
+    const config = JSON.parse(mcpConfigJson);
+    const validServers = Object.entries(config).filter(([, sc]) => sc?.url);
+
+    t.is(validServers.length, 1);
+    t.is(validServers[0][0], 'server2');
+});
+
+test('initializeMcpClients skips unsupported transport types', (t) => {
+    const mcpConfigJson = JSON.stringify({
+        server1: { url: 'https://example.com/mcp', type: 'websocket' },
+        server2: { url: 'https://example.com/mcp', type: 'streamable-http' },
+        server3: { url: 'https://example.com/mcp' }, // defaults to streamable-http
+    });
+
+    const config = JSON.parse(mcpConfigJson);
+    const validServers = Object.entries(config).filter(([, sc]) => {
+        if (!sc?.url) return false;
+        const type = sc.type || 'streamable-http';
+        return type === 'streamable-http';
+    });
+
+    t.is(validServers.length, 2);
+});
+
+// ----- closeMcpClients logic tests -----
+
+test('closeMcpClients clears the clients map', async (t) => {
+    const clients = new Map();
+    clients.set('server1', {
+        transport: { close: async () => {} },
+        connectTimestamp: Date.now(),
+    });
+    clients.set('server2', {
+        transport: { close: async () => {} },
+        connectTimestamp: Date.now(),
+    });
+
+    // Replicate the closeMcpClients logic
+    for (const [, { transport }] of clients) {
+        await transport.close();
+    }
+    clients.clear();
+
+    t.is(clients.size, 0);
+});
+
+test('closeMcpClients handles transport.close errors gracefully', async (t) => {
+    const clients = new Map();
+    clients.set('broken', {
+        transport: {
+            close: async () => {
+                throw new Error('Connection already closed');
+            },
+        },
+        connectTimestamp: Date.now(),
+    });
+
+    // Should not throw
+    for (const [, { transport }] of clients) {
+        try {
+            await transport.close();
+        } catch (error) {
+            // gracefully ignored
+        }
+    }
+    clients.clear();
+
+    t.is(clients.size, 0);
+});
+
+// ----- MCP tool result content parsing tests -----
+
+test('MCP tool result text content parsing joins multiple text parts', (t) => {
+    const result = {
+        content: [
+            { type: 'text', text: 'Part 1' },
+            { type: 'image', data: 'base64...' },
+            { type: 'text', text: 'Part 2' },
+        ],
+    };
+
+    const content = result?.content || [];
+    const textParts = content.filter((c) => c.type === 'text').map((c) => c.text);
+    const text = textParts.join('\n\n');
+
+    t.is(text, 'Part 1\n\nPart 2');
+});
+
+test('MCP tool result with structuredContent returns structured data', (t) => {
+    const result = {
+        content: [{ type: 'text', text: 'text result' }],
+        structuredContent: { issues: [{ id: 1, title: 'Bug' }] },
+    };
+
+    if (result.structuredContent) {
+        t.deepEqual(result.structuredContent, { issues: [{ id: 1, title: 'Bug' }] });
+    }
+});
+
+test('MCP tool result empty content falls back to JSON.stringify', (t) => {
+    const result = {
+        content: [],
+    };
+
+    const content = result?.content || [];
+    const textParts = content.filter((c) => c.type === 'text').map((c) => c.text);
+    const text = textParts.join('\n\n');
+
+    const finalResult = text || JSON.stringify(result);
+    t.is(finalResult, '{"content":[]}');
+});
+
+test('MCP tool result error detection via isError flag', (t) => {
+    const result = {
+        isError: true,
+        content: [{ type: 'text', text: 'Something went wrong' }],
+    };
+
+    const text = result.content.filter((c) => c.type === 'text').map((c) => c.text).join('\n\n');
+    const isError = result?.isError || text.toLowerCase().includes('error') || text.toLowerCase().includes('failed');
+
+    t.true(isError);
+});
+
+test('MCP tool result error detection via text content', (t) => {
+    const result = {
+        content: [{ type: 'text', text: 'The operation failed due to permissions' }],
+    };
+
+    const text = result.content.filter((c) => c.type === 'text').map((c) => c.text).join('\n\n');
+    const isError = result?.isError || text.toLowerCase().includes('error') || text.toLowerCase().includes('failed');
+
+    t.true(isError);
+});
+
+// ----- Token expiration detection tests -----
+// These use the real isTokenExpired/initializeMcpClients from mcpClient.js
+// so the tests break if the logic changes.
+
+test('isTokenExpired returns true for past timestamp', (t) => {
+    t.true(isTokenExpired({ expiresAt: Date.now() - 60000 }));
+});
+
+test('isTokenExpired returns false for future timestamp', (t) => {
+    t.false(isTokenExpired({ expiresAt: Date.now() + 3600000 }));
+});
+
+test('isTokenExpired returns false for missing expiresAt', (t) => {
+    t.false(isTokenExpired({ url: 'https://example.com/mcp' }));
+});
+
+test('isTokenExpired returns false for non-numeric expiresAt', (t) => {
+    t.false(isTokenExpired({ expiresAt: 'invalid' }));
+});
+
+test('isTokenExpired returns false for null/undefined config', (t) => {
+    t.false(isTokenExpired(null));
+    t.false(isTokenExpired(undefined));
+});
+
+test('initializeMcpClients returns expired servers without attempting connection', async (t) => {
+    const mcpConfigJson = JSON.stringify({
+        atlassian: { url: 'https://mcp.atlassian.com/v1/mcp', type: 'streamable-http', expiresAt: Date.now() - 60000 },
+        slack: { url: 'https://mcp.slack.com/mcp', type: 'streamable-http', expiresAt: Date.now() - 1 },
+    });
+
+    const { clients, expiredServers } = await initializeMcpClients(mcpConfigJson);
+
+    t.deepEqual(expiredServers, ['atlassian', 'slack']);
+    t.is(clients.size, 0);
+});

--- a/tests/unit/lib/pathwayTools.clientToolImages.test.js
+++ b/tests/unit/lib/pathwayTools.clientToolImages.test.js
@@ -1,0 +1,105 @@
+import test from 'ava';
+import { extractClientToolImages } from '../../../lib/pathwayTools.js';
+
+test('passes string data through unchanged with no images', t => {
+    const out = extractClientToolImages('hello world');
+    t.is(out.result, 'hello world');
+    t.deepEqual(out.toolImages, []);
+});
+
+test('passes null / number / boolean through with no images', t => {
+    t.deepEqual(extractClientToolImages(null), { result: 'null', toolImages: [] });
+    t.deepEqual(extractClientToolImages(42), { result: '42', toolImages: [] });
+    t.deepEqual(extractClientToolImages(true), { result: 'true', toolImages: [] });
+});
+
+test('extracts top-level screenshot envelope into a data: URL image_url', t => {
+    const data = {
+        contentType: 'html',
+        current: { title: 'page', workspacePath: null },
+        screenshot: { type: 'image', mimeType: 'image/png', base64: 'AAAA' },
+    };
+    const out = extractClientToolImages(data);
+    t.deepEqual(out.toolImages, [
+        { image_url: { url: 'data:image/png;base64,AAAA' } },
+    ]);
+    const cleaned = JSON.parse(out.result);
+    t.false('screenshot' in cleaned, 'screenshot should be stripped from result');
+    t.is(cleaned.contentType, 'html', 'other fields preserved');
+    t.is(cleaned.current.title, 'page');
+});
+
+test('honors mime_type alias and falls back to image/png', t => {
+    const out = extractClientToolImages({ screenshot: { mime_type: 'image/jpeg', base64: '/9j/' } });
+    t.is(out.toolImages[0].image_url.url, 'data:image/jpeg;base64,/9j/');
+
+    const out2 = extractClientToolImages({ screenshot: { base64: 'X' } });
+    t.is(out2.toolImages[0].image_url.url, 'data:image/png;base64,X');
+});
+
+test('handles a screenshots array', t => {
+    const out = extractClientToolImages({
+        screenshots: [
+            { mimeType: 'image/png', base64: 'A' },
+            { mimeType: 'image/jpeg', base64: 'B' },
+        ],
+        keep: 'me',
+    });
+    t.is(out.toolImages.length, 2);
+    t.is(out.toolImages[0].image_url.url, 'data:image/png;base64,A');
+    t.is(out.toolImages[1].image_url.url, 'data:image/jpeg;base64,B');
+    const cleaned = JSON.parse(out.result);
+    t.false('screenshots' in cleaned);
+    t.is(cleaned.keep, 'me');
+});
+
+test('skips screenshot envelopes with no base64 (e.g. failed capture)', t => {
+    const out = extractClientToolImages({ screenshot: { mimeType: 'image/png' } });
+    t.deepEqual(out.toolImages, []);
+    // Also strips the empty envelope so the model isn't told there's a useless screenshot field.
+    t.false('screenshot' in JSON.parse(out.result));
+});
+
+test('extracts top-level imageUrl / imageUrls', t => {
+    const out = extractClientToolImages({
+        imageUrl: { url: 'https://example.com/a.png', originalFilename: 'a.png' },
+        imageUrls: [
+            { url: 'https://example.com/b.png' },
+            { url: 'https://example.com/c.png' },
+        ],
+        unrelated: 1,
+    });
+    t.is(out.toolImages.length, 3);
+    t.is(out.toolImages[0].url, 'https://example.com/a.png');
+    t.is(out.toolImages[1].url, 'https://example.com/b.png');
+    t.is(out.toolImages[2].url, 'https://example.com/c.png');
+    const cleaned = JSON.parse(out.result);
+    t.false('imageUrl' in cleaned);
+    t.false('imageUrls' in cleaned);
+    t.is(cleaned.unrelated, 1);
+});
+
+test('does not mutate the caller-supplied data object', t => {
+    const data = {
+        screenshot: { mimeType: 'image/png', base64: 'A' },
+        keep: { nested: 'value' },
+    };
+    const before = JSON.stringify(data);
+    extractClientToolImages(data);
+    t.is(JSON.stringify(data), before, 'input data should be unchanged');
+});
+
+test('result fits under the agent truncation cutoff for typical screenshot payloads', t => {
+    // The original bug: a ~58 KB JSON envelope (mostly base64 PNG) was truncated
+    // to 50 KB mid-base64. After extraction the stringified result should be tiny.
+    const fakeBase64 = 'A'.repeat(60_000);
+    const data = {
+        contentType: 'html',
+        current: { title: 'page' },
+        screenshot: { mimeType: 'image/png', base64: fakeBase64 },
+    };
+    const out = extractClientToolImages(data);
+    t.true(out.result.length < 1000, `result should be small after extraction (got ${out.result.length} chars)`);
+    t.is(out.toolImages.length, 1);
+    t.true(out.toolImages[0].image_url.url.includes(fakeBase64));
+});

--- a/tests/unit/lib/pathwayTools.mcpTools.test.js
+++ b/tests/unit/lib/pathwayTools.mcpTools.test.js
@@ -1,0 +1,862 @@
+// pathwayTools.mcpTools.test.js
+// Tests for MCP tool search and execution logic in callTool (pathwayTools.js)
+import test from 'ava';
+import { callTool } from '../../../lib/pathwayTools.js';
+
+// ----- _builtin_search_tools tests -----
+
+test('SearchAvailableTools returns error when query is empty', async (t) => {
+    const toolDefinitions = {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const result = await callTool('SearchAvailableTools', { query: '' }, toolDefinitions, null);
+
+    const parsed = JSON.parse(result.result);
+    t.true(parsed.error);
+    t.true(parsed.message.includes('search query is required'));
+});
+
+test('SearchAvailableTools returns no matches for unrelated query', async (t) => {
+    const catalog = {
+        'jira__search_issues': {
+            name: 'jira__search_issues',
+            originalName: 'SearchIssues',
+            server: 'jira',
+            description: 'Search for issues in Jira',
+            parameters: ['query', 'project'],
+        },
+    };
+
+    const toolDefinitions = {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const pathwayResolver = {
+        args: {
+            mcpToolCatalog: catalog,
+            mcpEntityToolsDeferred: {},
+            entityTools: {},
+            entityToolsOpenAiFormat: [],
+        },
+    };
+
+    const result = await callTool('SearchAvailableTools', { query: 'zzzzzznotfound' }, toolDefinitions, pathwayResolver);
+
+    const parsed = JSON.parse(result.result);
+    t.is(parsed.tools.length, 0);
+    t.true(parsed.message.includes('No tools found'));
+});
+
+test('SearchAvailableTools matches tools by keyword', async (t) => {
+    const catalog = {
+        'jira__search_issues': {
+            name: 'jira__search_issues',
+            originalName: 'SearchIssues',
+            server: 'jira',
+            description: 'Search for issues in Jira project tracker',
+            parameters: ['query', 'project'],
+        },
+        'confluence__create_page': {
+            name: 'confluence__create_page',
+            originalName: 'CreatePage',
+            server: 'confluence',
+            description: 'Create a new page in Confluence wiki',
+            parameters: ['title', 'content', 'spaceKey'],
+        },
+        'jira__create_issue': {
+            name: 'jira__create_issue',
+            originalName: 'CreateIssue',
+            server: 'jira',
+            description: 'Create a new issue in Jira',
+            parameters: ['summary', 'description', 'priority'],
+        },
+    };
+
+    const deferred = {
+        'jira__search_issues': {
+            definition: {
+                function: {
+                    name: 'search_issues',
+                    description: 'Search for issues in Jira project tracker',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+        'jira__create_issue': {
+            definition: {
+                function: {
+                    name: 'create_issue',
+                    description: 'Create a new issue in Jira',
+                    parameters: { type: 'object', properties: { summary: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+
+    const toolDefinitions = {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const pathwayResolver = {
+        args: {
+            mcpToolCatalog: catalog,
+            mcpEntityToolsDeferred: deferred,
+            entityTools,
+            entityToolsOpenAiFormat,
+        },
+    };
+
+    const result = await callTool('SearchAvailableTools', { query: 'search issues' }, toolDefinitions, pathwayResolver);
+
+    const parsed = JSON.parse(result.result);
+    t.true(parsed.tools.length > 0);
+    // search_issues should score highest (matches both "search" and "issues")
+    t.is(parsed.tools[0].name, 'jira__search_issues');
+});
+
+test('SearchAvailableTools dynamically loads matched tools into entityTools', async (t) => {
+    const catalog = {
+        'server__tool_a': {
+            name: 'server__tool_a',
+            originalName: 'ToolA',
+            server: 'server',
+            description: 'A tool that does things',
+            parameters: ['param1'],
+        },
+    };
+
+    const deferred = {
+        'server__tool_a': {
+            definition: {
+                function: {
+                    name: 'tool_a',
+                    description: 'A tool that does things',
+                    parameters: { type: 'object', properties: { param1: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+
+    const toolDefinitions = {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const pathwayResolver = {
+        args: {
+            mcpToolCatalog: catalog,
+            mcpEntityToolsDeferred: deferred,
+            entityTools,
+            entityToolsOpenAiFormat,
+        },
+    };
+
+    await callTool('SearchAvailableTools', { query: 'tool' }, toolDefinitions, pathwayResolver);
+
+    // Tool should now be loaded into entityTools
+    t.truthy(entityTools['server__tool_a']);
+    t.is(entityToolsOpenAiFormat.length, 1);
+    t.is(entityToolsOpenAiFormat[0].function.name, 'server__tool_a');
+});
+
+test('SearchAvailableTools searches and loads local deferred tools', async (t) => {
+    const catalog = {
+        workspacessh: {
+            name: 'workspacessh',
+            displayName: 'WorkspaceSSH',
+            originalName: 'WorkspaceSSH',
+            server: 'cortex',
+            source: 'local',
+            description: 'Execute commands in a persistent Linux workspace',
+            parameters: ['command'],
+        },
+    };
+
+    const deferred = {
+        workspacessh: {
+            definition: {
+                function: {
+                    name: 'WorkspaceSSH',
+                    description: 'Execute commands in a persistent Linux workspace',
+                    parameters: { type: 'object', properties: { command: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const entityTools = { workspacessh: deferred.workspacessh };
+    const entityToolsOpenAiFormat = [];
+
+    const toolDefinitions = {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const pathwayResolver = {
+        args: {
+            localToolCatalog: catalog,
+            localEntityToolsDeferred: deferred,
+            entityTools,
+            entityToolsOpenAiFormat,
+        },
+    };
+
+    const result = await callTool('SearchAvailableTools', { query: 'workspace command' }, toolDefinitions, pathwayResolver);
+
+    const parsed = JSON.parse(result.result);
+    t.is(parsed.tools[0].name, 'WorkspaceSSH');
+    t.is(entityToolsOpenAiFormat.length, 1);
+    t.is(entityToolsOpenAiFormat[0].function.name, 'WorkspaceSSH');
+});
+
+test('SearchAvailableTools does not duplicate loaded local schemas', async (t) => {
+    const catalog = {
+        workspacessh: {
+            name: 'workspacessh',
+            displayName: 'WorkspaceSSH',
+            originalName: 'WorkspaceSSH',
+            server: 'cortex',
+            source: 'local',
+            description: 'Execute commands',
+            parameters: ['command'],
+        },
+    };
+    const deferred = {
+        workspacessh: {
+            definition: {
+                function: {
+                    name: 'WorkspaceSSH',
+                    description: 'Execute commands',
+                    parameters: { type: 'object', properties: { command: { type: 'string' } } },
+                },
+            },
+        },
+    };
+    const entityToolsOpenAiFormat = [{
+        type: 'function',
+        function: { name: 'WorkspaceSSH', description: 'Execute commands', parameters: { type: 'object', properties: {} } },
+    }];
+
+    await callTool('SearchAvailableTools', { query: 'commands' }, {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    }, {
+        args: {
+            localToolCatalog: catalog,
+            localEntityToolsDeferred: deferred,
+            entityTools: { workspacessh: deferred.workspacessh },
+            entityToolsOpenAiFormat,
+        },
+    });
+
+    t.is(entityToolsOpenAiFormat.length, 1);
+});
+
+test('SearchAvailableTools does not duplicate already-loaded tools', async (t) => {
+    const catalog = {
+        'server__tool_a': {
+            name: 'server__tool_a',
+            originalName: 'ToolA',
+            server: 'server',
+            description: 'A tool',
+            parameters: [],
+        },
+    };
+
+    const deferred = {
+        'server__tool_a': {
+            definition: {
+                function: {
+                    name: 'tool_a',
+                    description: 'A tool',
+                    parameters: { type: 'object', properties: {} },
+                },
+            },
+        },
+    };
+
+    // Tool already loaded
+    const entityTools = {
+        'server__tool_a': deferred['server__tool_a'],
+    };
+    const entityToolsOpenAiFormat = [{
+        type: 'function',
+        function: { name: 'server__tool_a', description: 'A tool', parameters: { type: 'object', properties: {} } },
+    }];
+
+    const toolDefinitions = {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const pathwayResolver = {
+        args: {
+            mcpToolCatalog: catalog,
+            mcpEntityToolsDeferred: deferred,
+            entityTools,
+            entityToolsOpenAiFormat,
+        },
+    };
+
+    await callTool('SearchAvailableTools', { query: 'tool' }, toolDefinitions, pathwayResolver);
+
+    // Should not duplicate
+    t.is(entityToolsOpenAiFormat.length, 1);
+});
+
+test('SearchAvailableTools limits results to top 5', async (t) => {
+    const catalog = {};
+    const deferred = {};
+
+    // Create 10 tools that all match "tool"
+    for (let i = 0; i < 10; i++) {
+        const key = `server__tool_${i}`;
+        catalog[key] = {
+            name: key,
+            originalName: `Tool${i}`,
+            server: 'server',
+            description: `Tool number ${i}`,
+            parameters: [],
+        };
+        deferred[key] = {
+            definition: {
+                function: {
+                    name: `tool_${i}`,
+                    description: `Tool number ${i}`,
+                    parameters: { type: 'object', properties: {} },
+                },
+            },
+        };
+    }
+
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+
+    const toolDefinitions = {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const pathwayResolver = {
+        args: {
+            mcpToolCatalog: catalog,
+            mcpEntityToolsDeferred: deferred,
+            entityTools,
+            entityToolsOpenAiFormat,
+        },
+    };
+
+    const result = await callTool('SearchAvailableTools', { query: 'tool' }, toolDefinitions, pathwayResolver);
+
+    const parsed = JSON.parse(result.result);
+    t.true(parsed.tools.length <= 5);
+    t.true(parsed.message.includes('Found'));
+});
+
+test('SearchAvailableTools ranks by keyword match score', async (t) => {
+    const catalog = {
+        'server__general_tool': {
+            name: 'server__general_tool',
+            originalName: 'GeneralTool',
+            server: 'server',
+            description: 'A general purpose utility',
+            parameters: [],
+        },
+        'server__search_issues': {
+            name: 'server__search_issues',
+            originalName: 'SearchIssues',
+            server: 'server',
+            description: 'Search for issues and bugs in the tracker',
+            parameters: ['query'],
+        },
+        'server__list_issues': {
+            name: 'server__list_issues',
+            originalName: 'ListIssues',
+            server: 'server',
+            description: 'List all issues',
+            parameters: [],
+        },
+    };
+
+    const toolDefinitions = {
+        searchavailabletools: {
+            pathwayName: '_builtin_search_tools',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'SearchAvailableTools',
+                    parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                },
+            },
+        },
+    };
+
+    const pathwayResolver = {
+        args: {
+            mcpToolCatalog: catalog,
+            mcpEntityToolsDeferred: {},
+            entityTools: {},
+            entityToolsOpenAiFormat: [],
+        },
+    };
+
+    const result = await callTool('SearchAvailableTools', { query: 'search issues' }, toolDefinitions, pathwayResolver);
+
+    const parsed = JSON.parse(result.result);
+    // "search_issues" should be first because it matches both keywords
+    t.is(parsed.tools[0].name, 'server__search_issues');
+});
+
+// ----- MCP tool execution path tests -----
+
+test('callTool for MCP tool throws when mcpClients not initialized', async (t) => {
+    const toolDefinitions = {
+        'server__my_tool': {
+            mcpServer: 'server',
+            mcpToolName: 'MyTool',
+            definition: {
+                function: {
+                    parameters: { type: 'object', properties: { q: { type: 'string' } } },
+                },
+            },
+            pathwayName: 'mcp_tool_execution',
+        },
+    };
+
+    const pathwayResolver = {
+        args: { mcpClients: null },
+    };
+
+    const result = await callTool('server__my_tool', { q: 'test' }, toolDefinitions, pathwayResolver);
+
+    t.truthy(result.error);
+    t.true(result.error.includes('MCP clients not initialized'));
+});
+
+test('callTool for MCP tool throws when mcpClients is empty', async (t) => {
+    const toolDefinitions = {
+        'server__my_tool': {
+            mcpServer: 'server',
+            mcpToolName: 'MyTool',
+            definition: {
+                function: {
+                    parameters: { type: 'object', properties: { q: { type: 'string' } } },
+                },
+            },
+            pathwayName: 'mcp_tool_execution',
+        },
+    };
+
+    const pathwayResolver = {
+        args: { mcpClients: new Map() },
+    };
+
+    const result = await callTool('server__my_tool', { q: 'test' }, toolDefinitions, pathwayResolver);
+
+    t.truthy(result.error);
+    t.true(result.error.includes('MCP clients not initialized'));
+});
+
+test('callTool for MCP tool filters args to only tool-specific parameters', async (t) => {
+    // This test verifies that callTool only passes tool-defined parameters to MCP,
+    // not the full args (which include chatHistory, entityTools, etc.)
+    const toolDefinitions = {
+        'server__my_tool': {
+            mcpServer: 'server',
+            mcpToolName: 'MyTool',
+            definition: {
+                function: {
+                    parameters: {
+                        type: 'object',
+                        properties: {
+                            query: { type: 'string' },
+                            limit: { type: 'number' },
+                        },
+                    },
+                },
+            },
+            pathwayName: 'mcp_tool_execution',
+        },
+    };
+
+    // Extract the filtering logic (same as in callTool)
+    const toolDef = toolDefinitions['server__my_tool'];
+    const args = {
+        query: 'test search',
+        limit: 10,
+        chatHistory: [{ role: 'user', content: 'hi' }],
+        entityTools: { lots: 'of tools' },
+        stream: false,
+        toolFunction: 'server__my_tool',
+    };
+
+    const toolParamKeys = Object.keys(toolDef.definition?.function?.parameters?.properties || {});
+    const mcpArgs = {};
+    for (const key of toolParamKeys) {
+        if (key in args) {
+            mcpArgs[key] = args[key];
+        }
+    }
+
+    t.deepEqual(mcpArgs, { query: 'test search', limit: 10 });
+    t.is(mcpArgs.chatHistory, undefined);
+    t.is(mcpArgs.entityTools, undefined);
+});
+
+test('InspectToolResult returns bounded summary and chunks from snapshot store', async (t) => {
+    const toolDefinitions = {
+        inspecttoolresult: {
+            pathwayName: '_builtin_inspect_tool_result',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'InspectToolResult',
+                    parameters: {
+                        type: 'object',
+                        properties: {
+                            resultRef: { type: 'string' },
+                            mode: { type: 'string' },
+                            offset: { type: 'number' },
+                            limit: { type: 'number' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const fullEnvelope = JSON.stringify({
+        _toolResultEnvelope: true,
+        resultRef: 'tr_1',
+        tool: 'workspacessh',
+        kind: 'workspace-shell',
+        compacted: false,
+        success: true,
+        summary: 'full',
+        stdoutPreview: '0123456789abcdefghijklmnopqrstuvwxyz',
+    });
+
+    const summaryResult = await callTool('InspectToolResult', {
+        resultRef: 'tr_1',
+    }, toolDefinitions, {
+        _toolResultSnapshots: new Map([['tr_1', { content: fullEnvelope, length: fullEnvelope.length }]]),
+    });
+
+    const summary = JSON.parse(summaryResult.result);
+    t.true(summary.ok);
+    t.is(summary.mode, 'summary');
+    t.is(summary.resultRef, 'tr_1');
+    t.is(summary.tool, 'workspacessh');
+    t.is(summary.readableChars, 36);
+    t.falsy(summaryResult.historyMutation);
+
+    const chunkResult = await callTool('InspectToolResult', {
+        resultRef: 'tr_1',
+        mode: 'chunk',
+        offset: 10,
+        limit: 5,
+    }, toolDefinitions, {
+        _toolResultSnapshots: new Map([['tr_1', { content: fullEnvelope, length: fullEnvelope.length }]]),
+    });
+
+    const chunk = JSON.parse(chunkResult.result);
+    t.true(chunk.ok);
+    t.is(chunk.mode, 'chunk');
+    t.is(chunk.offset, 10);
+    t.is(chunk.limit, 5);
+    t.is(chunk.content, 'abcde');
+    t.true(chunk.hasMoreBefore);
+    t.true(chunk.hasMoreAfter);
+});
+
+test('InspectToolResult includes stderr for mixed stdout and stderr snapshots', async (t) => {
+    const toolDefinitions = {
+        inspecttoolresult: {
+            pathwayName: '_builtin_inspect_tool_result',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'InspectToolResult',
+                    parameters: {
+                        type: 'object',
+                        properties: {
+                            resultRef: { type: 'string' },
+                            mode: { type: 'string' },
+                            query: { type: 'string' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const fullEnvelope = JSON.stringify({
+        _toolResultEnvelope: true,
+        resultRef: 'tr_mixed',
+        tool: 'workspacessh',
+        kind: 'workspace-shell',
+        stdoutPreview: 'stdout line',
+        stdoutTotalChars: 11,
+        stderrPreview: 'stderr diagnostic',
+        stderrTotalChars: 17,
+    });
+
+    const snapshotStore = new Map([['tr_mixed', { content: fullEnvelope, length: fullEnvelope.length }]]);
+    const headResult = await callTool('InspectToolResult', {
+        resultRef: 'tr_mixed',
+        mode: 'head',
+    }, toolDefinitions, {
+        _toolResultSnapshots: snapshotStore,
+    });
+
+    const head = JSON.parse(headResult.result);
+    t.true(head.ok);
+    t.true(head.content.includes('[stdout]\nstdout line'));
+    t.true(head.content.includes('[stderr]\nstderr diagnostic'));
+    t.is(head.stderrTotalChars, 17);
+
+    const searchResult = await callTool('InspectToolResult', {
+        resultRef: 'tr_mixed',
+        mode: 'search',
+        query: 'diagnostic',
+    }, toolDefinitions, {
+        _toolResultSnapshots: snapshotStore,
+    });
+
+    const search = JSON.parse(searchResult.result);
+    t.is(search.matchCount, 1);
+    t.true(search.matches[0].snippet.includes('stderr diagnostic'));
+});
+
+test('InspectToolResult supports bounded search within a snapshot', async (t) => {
+    const toolDefinitions = {
+        inspecttoolresult: {
+            pathwayName: '_builtin_inspect_tool_result',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'InspectToolResult',
+                    parameters: {
+                        type: 'object',
+                        properties: {
+                            resultRef: { type: 'string' },
+                            mode: { type: 'string' },
+                            query: { type: 'string' },
+                            limit: { type: 'number' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const fullEnvelope = JSON.stringify({
+        _toolResultEnvelope: true,
+        resultRef: 'tr_1',
+        tool: 'searchinternet',
+        kind: 'generic',
+        compacted: false,
+        summary: 'search result',
+        contentPreview: 'alpha needle beta gamma NEEDLE delta',
+    });
+
+    const result = await callTool('InspectToolResult', {
+        resultRef: 'tr_1',
+        mode: 'search',
+        query: 'needle',
+        limit: 18,
+    }, toolDefinitions, {
+        _toolResultSnapshots: new Map([['tr_1', { content: fullEnvelope }]]),
+    });
+
+    const parsed = JSON.parse(result.result);
+    t.true(parsed.ok);
+    t.is(parsed.mode, 'search');
+    t.is(parsed.query, 'needle');
+    t.is(parsed.matchCount, 2);
+    t.is(parsed.matches[0].offset, 6);
+    t.true(parsed.matches[0].snippet.includes('needle'));
+    t.true(parsed.matches[1].snippet.includes('NEEDLE'));
+});
+
+test('InspectToolResult search returns concise JSON leaf snippets', async (t) => {
+    const toolDefinitions = {
+        inspecttoolresult: {
+            pathwayName: '_builtin_inspect_tool_result',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'InspectToolResult',
+                    parameters: {
+                        type: 'object',
+                        properties: {
+                            resultRef: { type: 'string' },
+                            mode: { type: 'string' },
+                            query: { type: 'string' },
+                            limit: { type: 'number' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const repeatedWrapper = {
+        searchResultId: 'result-wrapper-one',
+        metadata: {
+            source: 'wire',
+            repeated: 'same envelope fields repeated around every result',
+        },
+        snippet: 'The new tariff policy was discussed in detail by officials.',
+    };
+    const fullEnvelope = JSON.stringify({
+        _toolResultEnvelope: true,
+        resultRef: 'tr_1',
+        tool: 'searchindex',
+        kind: 'generic',
+        compacted: false,
+        summary: 'search result',
+        contentPreview: JSON.stringify([
+            repeatedWrapper,
+            {
+                ...repeatedWrapper,
+                searchResultId: 'result-wrapper-two',
+                snippet: 'Another tariff mention appears in a separate concise leaf value.',
+            },
+        ]),
+    });
+
+    const result = await callTool('InspectToolResult', {
+        resultRef: 'tr_1',
+        mode: 'search',
+        query: 'tariff',
+        limit: 2000,
+    }, toolDefinitions, {
+        _toolResultSnapshots: new Map([['tr_1', { content: fullEnvelope }]]),
+    });
+
+    const parsed = JSON.parse(result.result);
+    t.true(parsed.ok);
+    t.is(parsed.matchCount, 2);
+    t.is(parsed.matches[0].path, '$[0].snippet');
+    t.is(parsed.matches[1].path, '$[1].snippet');
+    t.true(parsed.matches[0].snippet.includes('tariff'));
+    t.false(parsed.matches[0].snippet.includes('searchResultId'));
+    t.true(Number.isFinite(parsed.matches[0].offset));
+});
+
+test('InspectToolResult returns an error when the snapshot is not present', async (t) => {
+    const toolDefinitions = {
+        inspecttoolresult: {
+            pathwayName: '_builtin_inspect_tool_result',
+            definition: {
+                type: 'function',
+                function: {
+                    name: 'InspectToolResult',
+                    parameters: {
+                        type: 'object',
+                        properties: {
+                            resultRef: { type: 'string' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const result = await callTool('InspectToolResult', {
+        resultRef: 'tr_missing',
+    }, toolDefinitions, {
+        _toolResultSnapshots: new Map(),
+    });
+
+    const parsed = JSON.parse(result.result);
+    t.true(parsed.error);
+    t.true(parsed.message.includes('not available'));
+});
+
+// ----- Tool not found test -----
+
+test('callTool throws for unknown tool', async (t) => {
+    const toolDefinitions = {};
+
+    const error = await t.throwsAsync(
+        callTool('nonexistent_tool', {}, toolDefinitions, null)
+    );
+
+    t.true(error.message.includes('Tool nonexistent_tool not found'));
+});


### PR DESCRIPTION
## Summary

- adds MCP client initialization, discovery, tool execution, and cleanup helpers
- extends pathway tool execution with MCP tools, deferred tool search, client tool image extraction, and tool-result inspection
- adds focused unit coverage for MCP client behavior and pathway tool handling

## Notes

Stacked on #457, which adds the streaming tool runtime and cancellation plumbing used by these paths.

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/lib/mcpClient.test.js tests/unit/lib/pathwayTools.mcpTools.test.js tests/unit/lib/pathwayTools.clientToolImages.test.js tests/unit/core/cancelRequestAbort.test.js`
- `git diff --cached --check`