### PR TITLE
Port request-scoped tool helpers from aj-cortex

### DIFF
--- a/pathways/system/entity/tools/shared/request_scoped_tools.js
+++ b/pathways/system/entity/tools/shared/request_scoped_tools.js
@@ -1,0 +1,312 @@
+function toOpenAiToolFormat(definition) {
+    const {
+        icon,
+        pathwayParams,
+        silent,
+        defaultUserMessage,
+        allowResultCompaction,
+        ...definitionWithoutExtras
+    } = definition;
+    return definitionWithoutExtras;
+}
+
+function registerRuntimeTool(entityTools, entityToolsOpenAiFormat, toolName, toolEntry, openAiTool = null) {
+    const toolKey = toolName.toLowerCase();
+    if (entityTools[toolKey]) {
+        return false;
+    }
+
+    entityTools[toolKey] = toolEntry;
+    entityToolsOpenAiFormat.push(openAiTool || toOpenAiToolFormat(toolEntry.definition));
+    return true;
+}
+
+function registerInspectToolResult(entityTools, entityToolsOpenAiFormat) {
+    return registerRuntimeTool(entityTools, entityToolsOpenAiFormat, 'InspectToolResult', {
+        definition: {
+            type: 'function',
+            icon: '🔎',
+            toolCost: 1,
+            silent: true,
+            function: {
+                name: 'InspectToolResult',
+                description: 'Read a bounded view of a prior large tool result by resultRef without expanding it into the conversation history. Use summary first, then head, tail, chunk, or search when you need specific details from a compacted or oversized result.',
+                parameters: {
+                    type: 'object',
+                    properties: {
+                        resultRef: {
+                            type: 'string',
+                            description: 'Result reference from a prior tool result, such as tr_3.',
+                        },
+                        mode: {
+                            type: 'string',
+                            enum: ['summary', 'head', 'tail', 'chunk', 'search'],
+                            description: 'How to inspect the result. Defaults to summary.',
+                        },
+                        query: {
+                            type: 'string',
+                            description: 'Required for search mode. Case-insensitive text to find within the result. JSON results return concise matching leaf values with paths instead of repeated wrappers.',
+                        },
+                        offset: {
+                            type: 'number',
+                            description: 'Character offset for chunk mode. Defaults to 0.',
+                        },
+                        limit: {
+                            type: 'number',
+                            description: 'Maximum characters to return for head, tail, chunk, or each search snippet. Defaults to a bounded value and is capped.',
+                        },
+                    },
+                    required: ['resultRef'],
+                },
+            },
+        },
+        pathwayName: '_builtin_inspect_tool_result',
+    });
+}
+
+const SEARCH_TOOLS_DESCRIPTION_BASE = `Search the in-memory catalog of available tools, then make matching tools callable for this request. Your visible tool list is a starting subset — the catalog below holds many more capabilities that are not loaded yet. Whenever the user wants something and you do not see a matching tool, your first action is to call this with relevant keywords or with the exact tool name from the catalog. Matched tools become callable in the same response. Never tell the user a capability is missing without searching first.`;
+
+const CATALOG_DESC_MAX_LENGTH = 80;
+const CATALOG_PER_GROUP_MAX = 50;
+
+function summarizeCatalogDescription(description) {
+    if (!description) {
+        return '';
+    }
+    const cleaned = String(description).replace(/\s+/g, ' ').trim();
+    if (cleaned.length <= CATALOG_DESC_MAX_LENGTH) {
+        return cleaned;
+    }
+    return `${cleaned.slice(0, CATALOG_DESC_MAX_LENGTH - 1).trimEnd()}…`;
+}
+
+function formatCatalogSection(header, entries) {
+    if (!entries || entries.length === 0) {
+        return '';
+    }
+    const visible = entries.slice(0, CATALOG_PER_GROUP_MAX);
+    const lines = visible.map(entry => {
+        const name = entry.displayName || entry.originalName || entry.name;
+        const desc = summarizeCatalogDescription(entry.description);
+        return desc ? `- ${name} — ${desc}` : `- ${name}`;
+    });
+    if (entries.length > visible.length) {
+        lines.push(`- …and ${entries.length - visible.length} more`);
+    }
+    return `\n[${header}]\n${lines.join('\n')}`;
+}
+
+function buildSearchToolsDescription(localToolCatalog, mcpToolCatalog) {
+    const sections = [];
+
+    const localEntries = Object.values(localToolCatalog || {});
+    if (localEntries.length > 0) {
+        sections.push(formatCatalogSection('Local — Cortex', localEntries));
+    }
+
+    const mcpByServer = new Map();
+    for (const entry of Object.values(mcpToolCatalog || {})) {
+        const server = entry?.server || 'mcp';
+        if (!mcpByServer.has(server)) {
+            mcpByServer.set(server, []);
+        }
+        mcpByServer.get(server).push(entry);
+    }
+    for (const [server, entries] of mcpByServer) {
+        sections.push(formatCatalogSection(`MCP — ${server}`, entries));
+    }
+
+    if (sections.length === 0) {
+        return SEARCH_TOOLS_DESCRIPTION_BASE;
+    }
+
+    return `${SEARCH_TOOLS_DESCRIPTION_BASE}\n\nAvailable capabilities (search by keyword or exact name):${sections.join('\n')}`;
+}
+
+function registerSearchAvailableTools(entityTools, entityToolsOpenAiFormat, options = {}) {
+    const {
+        mcpClients = new Map(),
+        mcpToolCatalog = {},
+        localToolCatalog = {},
+        mcpExpiredServers = [],
+        logger = null,
+    } = options;
+
+    const hasMcpTools = mcpClients && mcpClients.size > 0;
+    const hasLocalTools = Object.keys(localToolCatalog || {}).length > 0;
+    if (!hasMcpTools && !hasLocalTools) {
+        return false;
+    }
+
+    if (logger && hasMcpTools) {
+        const serverNames = [...mcpClients.keys()].join(', ');
+        logger.info(`Discovered ${Object.keys(mcpToolCatalog || {}).length} MCP tools from ${mcpClients.size} server(s) [${serverNames}] — deferred (not loaded into context)`);
+    }
+
+    return registerRuntimeTool(entityTools, entityToolsOpenAiFormat, 'SearchAvailableTools', {
+        definition: {
+            type: 'function',
+            icon: '🔍',
+            toolCost: 1,
+            silent: true,
+            defaultUserMessage: 'Searching available tools',
+            function: {
+                name: 'SearchAvailableTools',
+                description: buildSearchToolsDescription(localToolCatalog, mcpToolCatalog),
+                parameters: {
+                    type: 'object',
+                    properties: {
+                        query: {
+                            type: 'string',
+                            description: 'Keywords describing the capability you need (e.g. "applet", "image", "search issues") or an exact tool name copied from the catalog in this tool\'s description.',
+                        },
+                    },
+                    required: ['query'],
+                },
+            },
+        },
+        pathwayName: '_builtin_search_tools',
+    });
+}
+
+function registerReauthenticateMcpServer(entityTools, entityToolsOpenAiFormat, options = {}) {
+    const { mcpExpiredServers = [], logger = null } = options;
+    if (!Array.isArray(mcpExpiredServers) || mcpExpiredServers.length === 0) {
+        return false;
+    }
+
+    const expiredList = mcpExpiredServers.join(', ');
+    if (logger) {
+        logger.info(`Registering ReauthenticateMcpServer client-side tool for expired servers: ${expiredList}`);
+    }
+
+    return registerRuntimeTool(entityTools, entityToolsOpenAiFormat, 'ReauthenticateMcpServer', {
+        definition: {
+            type: 'function',
+            function: {
+                name: 'ReauthenticateMcpServer',
+                description: `Re-authenticate an expired MCP service connection. The following services have expired authentication tokens and their tools are unavailable until re-authenticated: ${expiredList}. Call this tool to open a re-authentication window for the user. After the user completes re-authentication, the connection will be restored for subsequent messages.`,
+                parameters: {
+                    type: 'object',
+                    properties: {
+                        serverKey: {
+                            type: 'string',
+                            enum: mcpExpiredServers,
+                            description: 'The MCP server to re-authenticate.',
+                        },
+                        userMessage: {
+                            type: 'string',
+                            description: 'A brief message to the user explaining why re-authentication is needed.',
+                        },
+                    },
+                    required: ['serverKey', 'userMessage'],
+                },
+            },
+            icon: '🔑',
+        },
+        pathwayName: 'client_side_execution',
+        clientSide: true,
+    }, {
+        type: 'function',
+        function: {
+            name: 'ReauthenticateMcpServer',
+            description: `Re-authenticate an expired MCP service connection. The following services have expired authentication tokens and their tools are unavailable until re-authenticated: ${expiredList}. Call this tool to open a re-authentication window for the user. After the user completes re-authentication, the connection will be restored for subsequent messages.`,
+            parameters: {
+                type: 'object',
+                properties: {
+                    serverKey: {
+                        type: 'string',
+                        enum: mcpExpiredServers,
+                        description: 'The MCP server to re-authenticate.',
+                    },
+                    userMessage: {
+                        type: 'string',
+                        description: 'A brief message to the user explaining why re-authentication is needed.',
+                    },
+                },
+                required: ['serverKey', 'userMessage'],
+            },
+        },
+        icon: '🔑',
+    });
+}
+
+function registerConnectMcpServer(entityTools, entityToolsOpenAiFormat, options = {}) {
+    const { availableServers = [], logger = null } = options;
+    if (!Array.isArray(availableServers) || availableServers.length === 0) {
+        return false;
+    }
+
+    const serviceIds = availableServers.map(server => server.id);
+    const serviceList = availableServers.map(server => `- ${server.id}: ${server.name} — ${server.description}`).join('\n');
+    if (logger) {
+        logger.info(`Registering ConnectMcpServer client-side tool for ${serviceIds.length} available service(s): ${serviceIds.join(', ')}`);
+    }
+
+    return registerRuntimeTool(entityTools, entityToolsOpenAiFormat, 'ConnectMcpServer', {
+        definition: {
+            type: 'function',
+            function: {
+                name: 'ConnectMcpServer',
+                description: `Connect a new external service that the user has not set up yet. Call this tool when the user wants to use a service that is not currently connected. This will open an authentication window for the user to authorize access. After connecting, the service's tools will be available in subsequent messages.\n\nAvailable services to connect:\n${serviceList}`,
+                parameters: {
+                    type: 'object',
+                    properties: {
+                        serverKey: {
+                            type: 'string',
+                            enum: serviceIds,
+                            description: 'The service to connect.',
+                        },
+                        userMessage: {
+                            type: 'string',
+                            description: 'A brief message to the user explaining why connecting this service would be helpful.',
+                        },
+                    },
+                    required: ['serverKey', 'userMessage'],
+                },
+            },
+            icon: '🔗',
+        },
+        pathwayName: 'client_side_execution',
+        clientSide: true,
+    }, {
+        type: 'function',
+        function: {
+            name: 'ConnectMcpServer',
+            description: `Connect a new external service that the user has not set up yet. Call this tool when the user wants to use a service that is not currently connected. This will open an authentication window for the user to authorize access. After connecting, the service's tools will be available in subsequent messages.\n\nAvailable services to connect:\n${serviceList}`,
+            parameters: {
+                type: 'object',
+                properties: {
+                    serverKey: {
+                        type: 'string',
+                        enum: serviceIds,
+                        description: 'The service to connect.',
+                    },
+                    userMessage: {
+                        type: 'string',
+                        description: 'A brief message to the user explaining why connecting this service would be helpful.',
+                    },
+                },
+                required: ['serverKey', 'userMessage'],
+            },
+        },
+        icon: '🔗',
+    });
+}
+
+function registerRequestScopedTools(entityTools, entityToolsOpenAiFormat, options = {}) {
+    registerSearchAvailableTools(entityTools, entityToolsOpenAiFormat, options);
+    registerReauthenticateMcpServer(entityTools, entityToolsOpenAiFormat, options);
+    registerConnectMcpServer(entityTools, entityToolsOpenAiFormat, options);
+    if (options.compactionEnabled !== false) {
+        registerInspectToolResult(entityTools, entityToolsOpenAiFormat, options);
+    }
+}
+
+export {
+    registerConnectMcpServer,
+    registerInspectToolResult,
+    registerReauthenticateMcpServer,
+    registerRequestScopedTools,
+    registerSearchAvailableTools,
+};

--- a/pathways/system/entity/tools/shared/tool_migrations.js
+++ b/pathways/system/entity/tools/shared/tool_migrations.js
@@ -1,0 +1,99 @@
+// tool_migrations.js
+// Auto-migration map for entity tool lists
+// Applied when entity loads to handle renamed/consolidated tools
+
+/**
+ * Tool migration map: oldName (lowercase) -> newName (lowercase)
+ *
+ * When tools are renamed or consolidated, add entries here.
+ * Entities with old tool names will automatically get the new names.
+ */
+export const TOOL_MIGRATIONS = {
+    // Consolidations: workspace tools -> WorkspaceSSH
+    'workspaceshell': 'workspacessh',
+    'workspaceread': 'workspacessh',
+    'workspacewrite': 'workspacessh',
+    'workspaceedit': 'workspacessh',
+    'workspacebrowse': 'workspacessh',
+    'workspacestatus': 'workspacessh',
+    'workspaceupload': 'workspacessh',
+    'workspacedownload': 'workspacessh',
+    'workspacereset': 'workspacessh',
+    'workspacebackup': 'workspacessh',
+    'workspacerestore': 'workspacessh',
+
+    // Consolidations: file editing tools -> WorkspaceSSH
+    'readtextfile': 'workspacessh',
+    'writefile': 'workspacessh',
+    'editfilebyline': 'workspacessh',
+    'editfilebysearchandreplace': 'workspacessh',
+
+    // Consolidations: image/video tools -> CreateMedia
+    'generateimage': 'createmedia',
+    'modifyimage': 'createmedia',
+    'generatevideo': 'createmedia',
+
+    // Consolidations: file collection tools -> FileCollection
+    'addfiletocollection': 'filecollection',
+    'searchfilecollection': 'filecollection',
+    'listfilecollection': 'filecollection',
+    'removefilefromcollection': 'filecollection',
+    'updatefilemetadata': 'filecollection',
+
+    // Consolidations: analyze file tools -> AnalyzePDF
+    'analyzetext': 'analyzepdf',
+    'analyzemarkdown': 'analyzepdf',
+    'analyzeimage': 'analyzepdf',
+
+    // Removed tools (null = remove from tool list)
+    'callmodel': null,
+    'createplan': null,
+    'verifyresponse': null,
+};
+
+/**
+ * Migrate an entity's tool list to use current tool names
+ *
+ * @param {string[]} tools - Entity's tool list (may contain old names)
+ * @returns {string[]} - Migrated tool list with current names, deduplicated
+ */
+export function migrateToolList(tools) {
+    if (!tools || !Array.isArray(tools)) return tools;
+
+    // Handle wildcard - no migration needed
+    if (tools.includes('*')) return tools;
+
+    const migrated = new Set();
+    let changed = false;
+
+    for (const tool of tools) {
+        const normalizedTool = tool.toLowerCase();
+
+        if (normalizedTool in TOOL_MIGRATIONS) {
+            const newTool = TOOL_MIGRATIONS[normalizedTool];
+            changed = true;
+            // null means the tool is removed entirely
+            if (newTool !== null) {
+                migrated.add(newTool);
+            }
+        } else {
+            migrated.add(normalizedTool);
+        }
+    }
+
+    // Return original case-normalized array if no migrations applied
+    // Return deduplicated array if migrations were applied
+    return changed ? [...migrated] : tools.map(t => t.toLowerCase());
+}
+
+/**
+ * Check if a tool list needs migration
+ *
+ * @param {string[]} tools - Entity's tool list
+ * @returns {boolean} - True if any tools need migration
+ */
+export function needsMigration(tools) {
+    if (!tools || !Array.isArray(tools) || tools.includes('*')) return false;
+
+    return tools.some(tool => tool.toLowerCase() in TOOL_MIGRATIONS);
+}

--- a/tests/unit/pathways/requestScopedTools.test.js
+++ b/tests/unit/pathways/requestScopedTools.test.js
@@ -1,0 +1,165 @@
+import test from 'ava';
+import {
+    registerConnectMcpServer,
+    registerInspectToolResult,
+    registerRequestScopedTools,
+    registerReauthenticateMcpServer,
+    registerSearchAvailableTools,
+} from '../../../pathways/system/entity/tools/shared/request_scoped_tools.js';
+
+test('registerInspectToolResult adds bounded tool-result inspection tool', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+
+    registerInspectToolResult(entityTools, entityToolsOpenAiFormat);
+
+    t.truthy(entityTools.inspecttoolresult);
+    t.is(entityTools.inspecttoolresult.pathwayName, '_builtin_inspect_tool_result');
+    t.is(entityToolsOpenAiFormat[0].function.name, 'InspectToolResult');
+    t.true(entityToolsOpenAiFormat[0].function.description.includes('without expanding it into the conversation history'));
+    t.truthy(entityToolsOpenAiFormat[0].function.parameters.properties.resultRef);
+    t.truthy(entityToolsOpenAiFormat[0].function.parameters.properties.mode);
+    t.truthy(entityToolsOpenAiFormat[0].function.parameters.properties.query);
+    t.falsy(entityToolsOpenAiFormat[0].function.parameters.properties.userMessage);
+    t.falsy(entityToolsOpenAiFormat[0].function.parameters.properties.icon);
+    t.is(entityTools.inspecttoolresult.definition.icon, '🔎');
+    t.true(entityTools.inspecttoolresult.definition.silent);
+});
+
+test('registerRequestScopedTools includes InspectToolResult', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+    registerRequestScopedTools(entityTools, entityToolsOpenAiFormat, {});
+    t.truthy(entityTools.inspecttoolresult);
+    t.true(entityToolsOpenAiFormat.some(tool => tool.function.name === 'InspectToolResult'));
+});
+
+test('registerRequestScopedTools omits InspectToolResult when compactionEnabled is false', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+    registerRequestScopedTools(entityTools, entityToolsOpenAiFormat, { compactionEnabled: false });
+    t.falsy(entityTools.inspecttoolresult);
+    t.false(entityToolsOpenAiFormat.some(tool => tool.function.name === 'InspectToolResult'));
+});
+
+test('registerSearchAvailableTools adds runtime search tool from connected MCP servers', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+    const logger = { info() {} };
+
+    registerSearchAvailableTools(entityTools, entityToolsOpenAiFormat, {
+        mcpClients: new Map([['jira', {}]]),
+        mcpToolCatalog: {
+            jira__search_issues: {
+                server: 'jira',
+                originalName: 'SearchIssues',
+                description: 'Search JIRA issues by JQL',
+            },
+        },
+        mcpExpiredServers: ['slack'],
+        logger,
+    });
+
+    t.truthy(entityTools.searchavailabletools);
+    t.is(entityTools.searchavailabletools.pathwayName, '_builtin_search_tools');
+    t.true(entityTools.searchavailabletools.definition.silent);
+    t.is(entityTools.searchavailabletools.definition.toolCost, 1);
+    const description = entityToolsOpenAiFormat[0].function.description;
+    t.true(description.includes('in-memory catalog'));
+    t.true(description.includes('[MCP — jira]'));
+    t.true(description.includes('SearchIssues'));
+    t.true(description.includes('Search JIRA issues by JQL'));
+    t.is(entityToolsOpenAiFormat[0].function.name, 'SearchAvailableTools');
+});
+
+test('registerSearchAvailableTools adds runtime search tool from local catalog', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+
+    registerSearchAvailableTools(entityTools, entityToolsOpenAiFormat, {
+        localToolCatalog: {
+            workspacessh: {
+                name: 'workspacessh',
+                originalName: 'WorkspaceSSH',
+                description: 'Execute commands in a workspace',
+                parameters: ['command'],
+            },
+            generateapplet: {
+                name: 'generateapplet',
+                displayName: 'GenerateApplet',
+                originalName: 'GenerateApplet',
+                description: 'Create a file-backed applet from a prompt or workspace path',
+                parameters: ['prompt', 'workspacePath'],
+            },
+        },
+    });
+
+    t.truthy(entityTools.searchavailabletools);
+    t.is(entityToolsOpenAiFormat.length, 1);
+    t.is(entityToolsOpenAiFormat[0].function.name, 'SearchAvailableTools');
+    const description = entityToolsOpenAiFormat[0].function.description;
+    t.true(description.includes('[Local — Cortex]'));
+    t.true(description.includes('WorkspaceSSH'));
+    t.true(description.includes('GenerateApplet'));
+});
+
+test('registerSearchAvailableTools truncates long descriptions and caps per-group entries', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+    const localToolCatalog = {};
+    for (let i = 0; i < 60; i += 1) {
+        localToolCatalog[`tool_${i}`] = {
+            name: `tool_${i}`,
+            originalName: `Tool${i}`,
+            description: 'x'.repeat(200),
+            parameters: [],
+        };
+    }
+
+    registerSearchAvailableTools(entityTools, entityToolsOpenAiFormat, { localToolCatalog });
+
+    const description = entityToolsOpenAiFormat[0].function.description;
+    t.true(description.includes('…and 10 more'));
+    t.true(description.includes('xxxxxxx…'));
+    t.false(description.includes('x'.repeat(100)));
+});
+
+test('registerSearchAvailableTools omits catalog section when empty', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+    registerSearchAvailableTools(entityTools, entityToolsOpenAiFormat, {
+        mcpClients: new Map([['jira', {}]]),
+        mcpToolCatalog: {},
+    });
+    const description = entityToolsOpenAiFormat[0].function.description;
+    t.false(description.includes('Available capabilities'));
+});
+
+test('registerRequestScopedTools adds connect and reauth client-side tools when applicable', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+    const logger = { info() {} };
+
+    registerRequestScopedTools(entityTools, entityToolsOpenAiFormat, {
+        mcpExpiredServers: ['github'],
+        availableServers: [{ id: 'slack', name: 'Slack', description: 'Chat search' }],
+        logger,
+    });
+
+    t.truthy(entityTools.reauthenticatemcpserver);
+    t.truthy(entityTools.connectmcpserver);
+    t.true(entityTools.reauthenticatemcpserver.clientSide);
+    t.true(entityTools.connectmcpserver.clientSide);
+    t.true(entityToolsOpenAiFormat.some(tool => tool.function.name === 'ReauthenticateMcpServer'));
+    t.true(entityToolsOpenAiFormat.some(tool => tool.function.name === 'ConnectMcpServer'));
+});
+
+test('registerConnectMcpServer and registerReauthenticateMcpServer skip empty inputs', (t) => {
+    const entityTools = {};
+    const entityToolsOpenAiFormat = [];
+
+    t.false(registerConnectMcpServer(entityTools, entityToolsOpenAiFormat, { availableServers: [] }));
+    t.false(registerReauthenticateMcpServer(entityTools, entityToolsOpenAiFormat, { mcpExpiredServers: [] }));
+    t.deepEqual(entityTools, {});
+    t.deepEqual(entityToolsOpenAiFormat, []);
+});

--- a/tests/unit/pathways/sysEntityTools.test.js
+++ b/tests/unit/pathways/sysEntityTools.test.js
@@ -1,0 +1,62 @@
+import test from 'ava';
+import {
+    getAlwaysVisibleLocalToolDefinitions,
+    getToolsForEntity,
+} from '../../../pathways/system/entity/tools/shared/sys_entity_tools.js';
+
+const toolEntry = (name) => ({
+    definition: {
+        type: 'function',
+        function: {
+            name,
+            description: `${name} description`,
+            parameters: { type: 'object', properties: {} },
+        },
+    },
+});
+
+test('lazy local tool search keeps WorkspaceSSH always visible', (t) => {
+    const tools = {
+        workspacessh: toolEntry('WorkspaceSSH'),
+        searchinternet: toolEntry('SearchInternet'),
+    };
+
+    const visible = getAlwaysVisibleLocalToolDefinitions(tools);
+
+    t.deepEqual(visible.map(tool => tool.function.name), ['WorkspaceSSH']);
+});
+
+test('default entity does not expose WorkspaceSSH even with wildcard tools', (t) => {
+    const entityConfig = {
+        isDefault: true,
+        tools: ['*'],
+        customTools: {
+            workspacessh: toolEntry('WorkspaceSSH'),
+            searchinternet: toolEntry('SearchInternet'),
+        },
+    };
+
+    const { entityTools, entityToolsOpenAiFormat } = getToolsForEntity(entityConfig);
+    const toolNames = entityToolsOpenAiFormat.map(tool => tool.function.name);
+
+    t.false('workspacessh' in entityTools);
+    t.true(toolNames.includes('SearchInternet'));
+    t.false(toolNames.includes('WorkspaceSSH'));
+    t.deepEqual(getAlwaysVisibleLocalToolDefinitions(entityTools), []);
+});
+
+test('personal entity keeps WorkspaceSSH when explicitly available', (t) => {
+    const entityConfig = {
+        isDefault: false,
+        tools: ['*'],
+        customTools: {
+            workspacessh: toolEntry('WorkspaceSSH'),
+        },
+    };
+
+    const { entityTools, entityToolsOpenAiFormat } = getToolsForEntity(entityConfig);
+    const toolNames = entityToolsOpenAiFormat.map(tool => tool.function.name);
+
+    t.truthy(entityTools.workspacessh);
+    t.true(toolNames.includes('WorkspaceSSH'));
+});


### PR DESCRIPTION
## Summary

- adds request-scoped runtime helpers for tool-result inspection, tool search, and MCP connect/reauth flows
- adds entity tool-list migration helpers for renamed and consolidated tools
- adds focused coverage for request-scoped helper registration and entity tool visibility

## Notes

Stacked on #458, which adds the MCP and pathway tool runtime these helpers integrate with.

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/requestScopedTools.test.js tests/unit/pathways/sysEntityTools.test.js tests/unit/lib/pathwayTools.mcpTools.test.js tests/unit/lib/pathwayTools.clientToolImages.test.js`
- `git diff --cached --check`