### PR TITLE
Add file access GraphQL input type

### DIFF
--- a/server/typeDef.js
+++ b/server/typeDef.js
@@ -58,7 +58,7 @@ const getGraphQlType = (value) => {
       const items = schema.items || {};
       const def = schema.default;
       const defaultArray = Array.isArray(def) ? JSON.stringify(def) : '[]';
-      // Support explicit object type name (e.g., items: { objType: 'AgentContextInput' })
+      // Support explicit object type name (e.g., items: { objType: 'FileAccessTargetInput' })
       if (items.objType) {
         return { type: `[${items.objType}]`, defaultValue: `"${defaultArray.replace(/"/g, '\\"')}"` };
       }
@@ -108,8 +108,12 @@ const getGraphQlType = (value) => {
             return {type: '[MultiMessage]', defaultValue: `"${JSON.stringify(value).replace(/"/g, '\\"')}"`};
           }
           // Check if it's AgentContextInput (has contextId and default properties)
-          else if (value[0] && typeof value[0] === 'object' && 'contextId' in value[0] && 'default' in value[0]) {
+          if (value[0] && typeof value[0] === 'object' && 'contextId' in value[0] && 'default' in value[0]) {
             return {type: '[AgentContextInput]', defaultValue: `"${JSON.stringify(value).replace(/"/g, '\\"')}"`};
+          }
+          // Check if it's FileAccessTargetInput
+          else if (value[0] && typeof value[0] === 'object' && 'kind' in value[0]) {
+            return {type: '[FileAccessTargetInput]', defaultValue: `"${JSON.stringify(value).replace(/"/g, '\\"')}"`};
           }
           else {
             return {type: '[Message]', defaultValue: `"${JSON.stringify(value).replace(/"/g, '\\"')}"`};
@@ -132,8 +136,9 @@ const getMessageTypeDefs = () => {
   const messageType = `input Message { role: String, content: String, name: String }`;
   const multiMessageType = `input MultiMessage { role: String, content: [String], name: String, tool_calls: [String], tool_call_id: String }`;
   const agentContextType = `input AgentContextInput { contextId: String, contextKey: String, default: Boolean }`;
+  const fileAccessTargetType = `input FileAccessTargetInput { kind: String, userContextId: String, workspaceId: String, appletId: String, chatId: String, contextKey: String, write: Boolean }`;
   
-  return `${messageType}\n\n${multiMessageType}\n\n${agentContextType}`;
+  return `${messageType}\n\n${multiMessageType}\n\n${agentContextType}\n\n${fileAccessTargetType}`;
 };
 
 const getPathwayTypeDef = (name, returnType) => {

--- a/tests/unit/server/typeDef.test.js
+++ b/tests/unit/server/typeDef.test.js
@@ -1,0 +1,34 @@
+import test from 'ava';
+
+import { getMessageTypeDefs, typeDef } from '../../../server/typeDef.js';
+
+test('message type defs include file access and legacy agent context inputs', t => {
+    const defs = getMessageTypeDefs();
+
+    t.true(defs.includes('input AgentContextInput'));
+    t.true(defs.includes('input FileAccessTargetInput'));
+    t.true(defs.includes('workspaceId: String'));
+    t.true(defs.includes('write: Boolean'));
+});
+
+test('pathway type defs support fileAccessPlan object arrays', t => {
+    const built = typeDef({
+        name: 'test_file_access',
+        objName: 'test_file_access',
+        inputParameters: {
+            fileAccessPlan: {
+                type: 'array',
+                items: { objType: 'FileAccessTargetInput' },
+                default: [],
+            },
+        },
+    });
+
+    t.true(built.gqlDefinition.includes('fileAccessPlan: [FileAccessTargetInput]'));
+    t.deepEqual(built.restDefinition, [
+        {
+            name: 'fileAccessPlan',
+            type: '[FileAccessTargetInput]',
+        },
+    ]);
+});


### PR DESCRIPTION
## Summary

- adds FileAccessTargetInput to generated GraphQL schema support
- keeps AgentContextInput available for existing pathway parameters
- adds focused type definition coverage for fileAccessPlan arguments

## Notes

Stacked on #462, which moves file collection pathways to fileAccessPlan inputs.

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/server/typeDef.test.js tests/unit/pathways/searchToolFootguns.test.js tests/integration/graphql/features/google/sysToolGoogleSearch.test.js tests/unit/pathways/fileCollectionAccessPlan.test.js`
- `git diff --cached --check`