### PR TITLE
Port search tool footgun fixes from aj-cortex

### DIFF
--- a/pathways/system/entity/tools/sys_tool_google_search.js
+++ b/pathways/system/entity/tools/sys_tool_google_search.js
@@ -11,9 +11,9 @@ import { getSearchResultId } from '../../../../lib/util.js';
  * @returns {string|null} - Error message if validation fails, null if valid
  */
 function validateParameters(args) {
-    // Validate required parameter: q
+    // Validate required parameter: q. Accept query as a model-friendly alias.
     if (!args.q || typeof args.q !== 'string' || args.q.trim() === '') {
-        return "Parameter 'q' (query) is required and must be a non-empty string.";
+        return "Parameter 'q' or alias 'query' is required and must be a non-empty string.";
     }
 
     // Validate num: must be integer between 1-10
@@ -103,6 +103,10 @@ export default {
                         type: "string",
                         description: "The complete query to pass to Google CSE using Google's search syntax."
                     },
+                    query: {
+                        type: "string",
+                        description: "Alias for q. Use either q or query for the search string."
+                    },
                     num: {
                         type: "integer",
                         description: "Number of results to return (1-10). Default 10."
@@ -172,14 +176,19 @@ export default {
                         description: "A user-friendly message that describes what you're doing with this tool"
                     }
                 },
-                required: ["q", "userMessage"]
+                required: []
             }
         }
     },
 
     executePathway: async ({args, runAllPrompts, resolver}) => {
+        const normalizedArgs = {
+            ...args,
+            q: args.q || args.query
+        };
+
         // Validate parameters before proceeding
-        const validationError = validateParameters(args);
+        const validationError = validateParameters(normalizedArgs);
         if (validationError) {
             logger.error(`Google CSE parameter validation failed: ${validationError}`);
             return JSON.stringify({ 
@@ -203,8 +212,8 @@ export default {
         try {
             // Pass-through: call Google CSE with provided args
             const response = await callPathway('google_cse', { 
-                ...args,
-                text: args.q
+                ...normalizedArgs,
+                text: normalizedArgs.q
             }, resolver);
 
             if (resolver.errors && resolver.errors.length > 0) {

--- a/pathways/system/entity/tools/sys_tool_grok_x_search.js
+++ b/pathways/system/entity/tools/sys_tool_grok_x_search.js
@@ -134,8 +134,7 @@ export default {
                 x_search: Object.keys(xSearchConfig).length > 0 ? xSearchConfig : true
             };
 
-            // Call the Grok Live Search pathway with new tools format
-            // Use the new Responses API model for X search
+            // Call the Grok Live Search pathway with the current 4.20-backed Responses wrapper.
             const { model, text, ...restArgs } = args;
             
             // Construct a prompt that asks for structured output with rich metadata
@@ -158,7 +157,7 @@ Return posts as a numbered list. Keep metadata fields clean without inline citat
             const result = await callPathway('grok_live_search', { 
                 ...restArgs,
                 text: structuredPrompt,
-                model: 'xai-grok-4-1-fast-responses',
+                model: 'xai-grok-4-20-responses',
                 tools: JSON.stringify(tools),
                 inline_citations: true
             }, resolver);

--- a/pathways/system/entity/tools/sys_tool_validate_url.js
+++ b/pathways/system/entity/tools/sys_tool_validate_url.js
@@ -5,9 +5,10 @@ import logger from '../../../../lib/logger.js';
 export default {
     prompt: [],
     timeout: 30,
-    toolDefinition: { 
+    toolDefinition: {
         type: "function",
         icon: "🔗",
+        toolCost: 1,
         function: {
             name: "ValidateUrl",
             description: "This tool validates URLs by performing a HEAD request to check if they are accessible and return valid responses. Use this to verify that links and image URLs are valid before including them in responses.",
@@ -134,4 +135,3 @@ export default {
         }
     }
 };
-

--- a/tests/unit/pathways/searchToolFootguns.test.js
+++ b/tests/unit/pathways/searchToolFootguns.test.js
@@ -1,0 +1,27 @@
+import test from 'ava';
+
+import googleSearchTool from '../../../pathways/system/entity/tools/sys_tool_google_search.js';
+import grokXSearchTool from '../../../pathways/system/entity/tools/sys_tool_grok_x_search.js';
+import validateUrlTool from '../../../pathways/system/entity/tools/sys_tool_validate_url.js';
+
+test('SearchInternet schema accepts q or query alias', t => {
+    const definition = googleSearchTool.toolDefinition.function;
+    const source = googleSearchTool.executePathway.toString();
+
+    t.truthy(definition.parameters.properties.q);
+    t.truthy(definition.parameters.properties.query);
+    t.deepEqual(definition.parameters.required, []);
+    t.true(source.includes('q: args.q || args.query'));
+    t.true(source.includes("text: normalizedArgs.q"));
+});
+
+test('SearchXPlatform uses current Grok Responses model', t => {
+    const source = grokXSearchTool.executePathway.toString();
+
+    t.true(source.includes("model: 'xai-grok-4-20-responses'"));
+    t.false(source.includes("model: 'xai-grok-4-1-fast-responses'"));
+});
+
+test('ValidateUrl has explicit low tool cost', t => {
+    t.is(validateUrlTool.toolDefinition.toolCost, 1);
+});


### PR DESCRIPTION
## Summary

- lets SearchInternet accept query as an alias for q before dispatching to Google CSE
- points SearchXPlatform at the current Grok 4.20 Responses model
- gives ValidateUrl an explicit low tool cost
- adds focused pathway contract coverage for the search and URL tools

## Notes

Stacked on #463, which adds the GraphQL file access input type needed by the file-access-plan layer.

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/server/typeDef.test.js tests/unit/pathways/searchToolFootguns.test.js tests/integration/graphql/features/google/sysToolGoogleSearch.test.js tests/unit/pathways/fileCollectionAccessPlan.test.js`
- `git diff --cached --check`