### PR TITLE
Port workspace pathway input updates from aj-cortex

### DIFF
--- a/pathways/system/workspaces/run_workspace_agent.js
+++ b/pathways/system/workspaces/run_workspace_agent.js
@@ -7,10 +7,14 @@ export default {
     inputParameters: {
         model: "oai-gpt41",
         chatHistory: [{role: '', content: []}],
-        researchMode: false,
-        agentContext: [
-            { contextId: "", contextKey: "", default: true }
-        ]
+        reasoningEffort: '',
+        fileAccessPlan: {
+            type: 'array',
+            items: { objType: 'FileAccessTargetInput' },
+            default: [],
+        },
+        contextId: '',
+        contextKey: '',
     },
     timeout: 600,
 
@@ -26,4 +30,3 @@ export default {
         return response;
     }
 }
-

--- a/pathways/system/workspaces/run_workspace_prompt.js
+++ b/pathways/system/workspaces/run_workspace_prompt.js
@@ -1,6 +1,5 @@
 import { config } from '../../../config.js';
 import { chatArgsHasImageUrl, chatArgsHasType, removeOldImageAndFileContent } from '../../../lib/util.js';
-import { getAvailableFiles } from '../../../lib/fileUtils.js';
 import { loadEntityConfig } from '../../../pathways/system/entity/tools/shared/sys_entity_tools.js';
 import { Prompt } from '../../../server/prompt.js';
 
@@ -14,11 +13,17 @@ export default {
         prompt: "",
         systemPrompt: "",
         chatHistory: [{role: '', content: []}],
+        fileAccessPlan: {
+            type: 'array',
+            items: { objType: 'FileAccessTargetInput' },
+            default: [],
+        },
         text: "",
-        entityId: "labeeb",
+        entityId: "jarvis",
         aiName: "Jarvis",
         language: "English",
         model: "oai-gpt41", // Allow user to specify model
+        reasoningEffort: "",
     },
 
     timeout: 600,
@@ -29,7 +34,7 @@ export default {
         // Load input parameters and information into args
         const { entityId, aiName, language, model } = { ...pathwayResolver.pathway.inputParameters, ...args };
         
-        const entityConfig = loadEntityConfig(entityId);
+        const entityConfig = await loadEntityConfig(entityId);
 
         // Initialize chat history if needed
         if (!args.chatHistory || args.chatHistory.length === 0) {
@@ -49,9 +54,6 @@ export default {
             model
         };
 
-        // Extract available files from chat history (syncs to collection if contextId available)
-        const availableFiles = await getAvailableFiles(args.chatHistory, args.contextId, args.contextKey);
-
         // Check for both image and file content (CSV files have type 'file', not 'image_url')
         const hasImageContent = chatArgsHasImageUrl(args);
         const hasFileContent = chatArgsHasType(args, 'file');
@@ -61,7 +63,7 @@ export default {
         visionContentPresent && (args.chatHistory = removeOldImageAndFileContent(args.chatHistory));
 
         const promptMessages = [
-            {"role": "system", "content": `${args.systemPrompt || "Assistant is an expert journalist's assistant for Al Jazeera Media Network. When a user posts a request, Assistant will come up with the best response while upholding the highest journalistic standards."}\n\n{{renderTemplate AI_TOOLS}}\n\n{{renderTemplate AI_AVAILABLE_FILES}}\n\n{{renderTemplate AI_DATETIME}}`},
+            {"role": "system", "content": `${args.systemPrompt || "Assistant is a helpful AI assistant. When a user posts a request, Assistant will come up with the best response."}\n\n{{renderTemplate AI_TOOLS}}\n\n{{renderTemplate AI_DATETIME}}`},
             "{{chatHistory}}"
         ];
 
@@ -83,7 +85,6 @@ export default {
             let response = await runAllPrompts({
                 ...args,
                 chatHistory: currentMessages,
-                availableFiles,
                 model: args.model // Pass the model from args
             });
 

--- a/tests/unit/pathways/workspacePathwayInputs.test.js
+++ b/tests/unit/pathways/workspacePathwayInputs.test.js
@@ -1,0 +1,21 @@
+import test from 'ava';
+
+import runWorkspaceAgent from '../../../pathways/system/workspaces/run_workspace_agent.js';
+import runWorkspacePrompt from '../../../pathways/system/workspaces/run_workspace_prompt.js';
+
+test('workspace prompt uses generic entity defaults and file access plan input', t => {
+    t.is(runWorkspacePrompt.inputParameters.entityId, 'jarvis');
+    t.is(runWorkspacePrompt.inputParameters.aiName, 'Jarvis');
+    t.truthy(runWorkspacePrompt.inputParameters.fileAccessPlan);
+    t.is(runWorkspacePrompt.inputParameters.fileAccessPlan.items.objType, 'FileAccessTargetInput');
+    t.falsy(runWorkspacePrompt.inputParameters.agentContext);
+});
+
+test('workspace agent forwards file access plan input shape', t => {
+    t.truthy(runWorkspaceAgent.inputParameters.fileAccessPlan);
+    t.is(runWorkspaceAgent.inputParameters.fileAccessPlan.items.objType, 'FileAccessTargetInput');
+    t.truthy(Object.hasOwn(runWorkspaceAgent.inputParameters, 'contextId'));
+    t.truthy(Object.hasOwn(runWorkspaceAgent.inputParameters, 'contextKey'));
+    t.falsy(runWorkspaceAgent.inputParameters.agentContext);
+    t.falsy(Object.hasOwn(runWorkspaceAgent.inputParameters, 'researchMode'));
+});


### PR DESCRIPTION
## Summary

- updates workspace prompt and agent pathway inputs to use the file access plan shape
- forwards context identifiers explicitly for workspace agent calls
- awaits entity config loading and keeps the workspace prompt default on Jarvis

## Notes

- stacked on `codex/upstream-search-tool-footguns`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/workspacePathwayInputs.test.js tests/unit/server/typeDef.test.js tests/unit/pathways/fileCollectionAccessPlan.test.js`
