### PR TITLE
Port file tool input updates from aj-cortex

### DIFF
--- a/pathways/system/entity/tools/sys_tool_analyzefile.js
+++ b/pathways/system/entity/tools/sys_tool_analyzefile.js
@@ -47,83 +47,7 @@ export default {
                         items: {
                             type: "string"
                         },
-                        description: "Array of files to analyze (from ListFileCollection or SearchFileCollection): each can be the hash, the filename, the URL, or the GCS URL. You can find available files in the availableFiles section."
-                    },
-                    userMessage: {
-                        type: "string",
-                        description: "A user-friendly message that describes what you're doing with this tool"
-                    }
-                },
-                required: ["detailedInstructions", "userMessage"]
-            }
-        }
-    },
-    {
-        type: "function",
-        enabled: false,
-        icon: "📝",
-        function: {
-            name: "AnalyzeText",
-            description: "Use specifically for reading, analyzing, and answering questions about text files (including csv, json, html, etc.).",
-            parameters: {
-                type: "object",
-                properties: {
-                    detailedInstructions: {
-                        type: "string",
-                        description: "Detailed instructions about what you need the tool to do - questions you need answered about the files, etc."
-                        },
-                    userMessage: {
-                        type: "string",
-                        description: "A user-friendly message that describes what you're doing with this tool"
-                        }
-                },
-                required: ["detailedInstructions", "userMessage"]
-            }
-        }
-    },
-    {
-        type: "function",
-        enabled: false,
-        icon: "📝",
-        function: {
-            name: "AnalyzeMarkdown",
-            description: "Use specifically for reading, analyzing, and answering questions about markdown files.",
-            parameters: {
-                type: "object",
-                properties: {
-                    detailedInstructions: {
-                        type: "string",
-                        description: "Detailed instructions about what you need the tool to do - questions you need answered about the files, etc."
-                        },
-                    userMessage: {
-                        type: "string",
-                        description: "A user-friendly message that describes what you're doing with this tool"
-                        }
-                },
-                required: ["detailedInstructions", "userMessage"]
-            }
-        }
-    },   
-    {
-        type: "function",
-        enabled: false,
-        icon: "🖼️",
-        function: {
-            name: "AnalyzeImage",
-            description: "Use specifically for reading, analyzing, and answering questions about image files (jpg, gif, bmp, png, etc). This cannot be used for creating or transforming images.",
-            parameters: {
-                type: "object",
-                properties: {
-                    detailedInstructions: {
-                        type: "string",
-                        description: "Detailed instructions about what you need the tool to do - questions you need answered about the files, etc."
-                    },
-                    files: {
-                        type: "array",
-                        items: {
-                            type: "string"
-                        },
-                        description: "Array of files to analyze (from ListFileCollection or SearchFileCollection): each can be the hash, the filename, the URL, or the GCS URL. You can find available files in the availableFiles section."
+                        description: "Array of files to analyze. Prefer blobPath, workspacePath like /workspace/files/..., URL, or GCS URL from the file object. Legacy hashes and filenames are supported as fallbacks."
                     },
                     userMessage: {
                         type: "string",
@@ -152,7 +76,7 @@ export default {
                         items: {
                             type: "string"
                         },
-                        description: "Array of files to analyze. Each can be: (1) A YouTube URL (youtube.com/watch?v=..., youtu.be/..., youtube.com/shorts/..., youtube.com/embed/...), (2) A direct video/audio file URL, (3) A file from the collection (hash, filename, URL, or GCS URL from ListFileCollection or SearchFileCollection). You can find available files in the availableFiles section."
+                        description: "Array of files to analyze. Each can be: (1) A YouTube URL (youtube.com/watch?v=..., youtu.be/..., youtube.com/shorts/..., youtube.com/embed/...), (2) a direct video/audio file URL, (3) a file reference such as blobPath, workspacePath like /workspace/files/..., URL, GCS URL, legacy hash, or filename."
                     },
                     userMessage: {
                         type: "string",
@@ -177,15 +101,12 @@ export default {
                 : (args.file ? [args.file] : []);
             
             if (filesToProcess.length > 0) {
-                // Use agentContext if available, otherwise fall back to creating it from contextId/contextKey
-                const agentContext = args.agentContext || (args.contextId ? [{
-                    contextId: args.contextId,
-                    contextKey: args.contextKey || null,
-                    default: true
-                }] : null);
-                
-                if (!agentContext || !Array.isArray(agentContext) || agentContext.length === 0) {
-                    const errorMessage = `Files not found: agentContext is required to look up files in the collection.`;
+                const fileAccessPlan = Array.isArray(args.fileAccessPlan)
+                    ? args.fileAccessPlan
+                    : null;
+
+                if (!fileAccessPlan || fileAccessPlan.length === 0) {
+                    const errorMessage = `Files not found: fileAccessPlan is required to look up files in the collection.`;
                     resolver.tool = JSON.stringify({ toolUsed: "vision" });
                     return JSON.stringify({ 
                         error: errorMessage,
@@ -198,7 +119,7 @@ export default {
                 const errors = [];
                 
                 for (const fileParam of filesToProcess) {
-                    const fileContent = await generateFileMessageContent(fileParam, agentContext);
+                    const fileContent = await generateFileMessageContent(fileParam, fileAccessPlan);
                     if (!fileContent) {
                         errors.push(`File not found: "${fileParam}"`);
                         continue;
@@ -210,7 +131,7 @@ export default {
                 if (fileContents.length === 0) {
                     const errorMessage = errors.length > 0 
                         ? errors.join('; ')
-                        : 'No files found. Use ListFileCollection or SearchFileCollection to find available files.';
+                        : 'No files found. Use FileCollection to find available files.';
                     resolver.tool = JSON.stringify({ toolUsed: "vision" });
                     return JSON.stringify({ 
                         error: errorMessage,

--- a/pathways/system/entity/tools/sys_tool_mermaid.js
+++ b/pathways/system/entity/tools/sys_tool_mermaid.js
@@ -80,7 +80,7 @@ export default {
         icon: "📊",
         function: {
             name: "CreateChart",
-            description: "Creates a single chart or diagram that will render in the UI to visualize data or concepts. You can create all the standard Mermaid chart types (flowcharts, sequence diagrams, gantt charts, etc.) as well as bar charts and line and scatter plots. This tool also validates the syntax and ensures proper formatting. Call this tool any time you need to create a chart outside of your coding agent. If you need to create multiple charts, you can call this tool multiple times in parallel to create multiple charts.",
+            description: "Creates a single chart or diagram that will render in the UI to visualize data or concepts. You can create all the standard Mermaid chart types (flowcharts, sequence diagrams, gantt charts, etc.) as well as bar charts and line and scatter plots. This tool also validates the syntax and ensures proper formatting. Call this tool any time you need to create a chart. If you need to create multiple charts, you can call this tool multiple times in parallel to create multiple charts.",
             parameters: {
                 type: "object",
                 properties: {
@@ -228,4 +228,4 @@ Focus only on fixing the syntax issues mentioned in the error details. Return on
         // Return a fallback response
         return `Failed to generate valid mermaid chart after ${maxRetries} attempts. Last error: ${lastError}`;
     }
-} 
+}

--- a/pathways/system/entity/tools/sys_tool_view_image.js
+++ b/pathways/system/entity/tools/sys_tool_view_image.js
@@ -1,15 +1,28 @@
 // sys_tool_view_image.js
 // Tool pathway that allows agents to view image files from the file collection
 import logger from '../../../../lib/logger.js';
-import { loadFileCollection, findFileInCollection, ensureShortLivedUrl } from '../../../../lib/fileUtils.js';
+import {
+    ensureShortLivedUrl,
+    findFileInFileAccessPlan,
+    normalizeFileAccessPlan,
+} from '../../../../lib/fileUtils.js';
 import { config } from '../../../../config.js';
+
+const IMAGE_EXT_RE = /\.(jpg|jpeg|png|gif|bmp|webp|svg)(?:$|[?#])/i;
+
+function isImageLike(fileRef, fileObj = {}) {
+    const mimeType = fileObj.mimeType || fileObj.contentType || '';
+    return mimeType.startsWith('image/') ||
+        IMAGE_EXT_RE.test(fileObj.filename || fileObj.displayFilename || fileRef || fileObj.url || fileObj.gcs || '');
+}
 
 export default {
     prompt: [],
     timeout: 30,
-    toolDefinition: { 
+    toolDefinition: {
         type: "function",
         icon: "👀",
+        toolCost: 1,
         function: {
             name: "ViewImages",
             description: "View one or more image files from your file collection. This injects the images into the conversation so you can see them. Use this when you need to look at image files that are in your collection but not currently visible in the conversation.",
@@ -21,7 +34,7 @@ export default {
                         items: {
                             type: "string"
                         },
-                        description: "Array of files to view (from ListFileCollection or SearchFileCollection): each can be the hash, the filename, the URL, or the GCS URL. You can find available files in the availableFiles section."
+                        description: "Array of files to view. Prefer blobPath, workspacePath like /workspace/files/..., or URL from the file object. Hashes and filenames are supported as legacy fallbacks when no direct path/URL is available."
                     },
                     userMessage: {
                         type: "string",
@@ -40,22 +53,21 @@ export default {
             throw new Error("Files parameter is required and must be a non-empty array");
         }
 
-        if (!args.agentContext || !Array.isArray(args.agentContext) || args.agentContext.length === 0) {
-            throw new Error("agentContext is required");
+        const fileAccessPlan = normalizeFileAccessPlan(args.fileAccessPlan);
+        if (fileAccessPlan.length === 0) {
+            throw new Error("fileAccessPlan is required");
         }
 
         try {
-            // Load the file collection from all agentContext contexts
-            const collection = await loadFileCollection(args.agentContext);
-            
+            const fileHandlerUrl = config.get('whisperMediaApiUrl');
+
             const imageUrls = [];
             const errors = [];
             const foundFilenames = [];
 
             // Process each file
             for (const file of files) {
-                // Find the file in the collection
-                const foundFile = findFileInCollection(file, collection);
+                const foundFile = await findFileInFileAccessPlan(file, fileAccessPlan, { fileHandlerUrl });
                 
                 if (!foundFile) {
                     errors.push(`File not found: ${file}`);
@@ -64,8 +76,7 @@ export default {
 
                 // Check if it's an image by MIME type
                 const mimeType = foundFile.mimeType || foundFile.contentType || '';
-                const isImage = mimeType.startsWith('image/') || 
-                              /\.(jpg|jpeg|png|gif|bmp|webp|svg)$/i.test(foundFile.filename || '');
+                const isImage = isImageLike(file, foundFile);
 
                 if (!isImage) {
                     errors.push(`File "${foundFile.filename || file}" is not an image file (MIME type: ${mimeType || 'unknown'})`);
@@ -73,8 +84,11 @@ export default {
                 }
 
                 // Resolve to short-lived URL if possible
-                const fileHandlerUrl = config.get('whisperMediaApiUrl');
-                const fileWithShortLivedUrl = await ensureShortLivedUrl(foundFile, fileHandlerUrl, args.contextId || null);
+                const fileWithShortLivedUrl = await ensureShortLivedUrl(
+                    foundFile,
+                    fileHandlerUrl,
+                    foundFile._contextId || null,
+                );
 
                 // Add to imageUrls array
                 imageUrls.push({
@@ -82,7 +96,8 @@ export default {
                     url: fileWithShortLivedUrl.url,
                     gcs: fileWithShortLivedUrl.gcs,
                     image_url: { url: fileWithShortLivedUrl.url },
-                    hash: fileWithShortLivedUrl.hash
+                    hash: fileWithShortLivedUrl.hash,
+                    originalFilename: foundFile.filename || file
                 });
 
                 foundFilenames.push(foundFile.filename || file);
@@ -115,4 +130,3 @@ export default {
         }
     }
 };
-

--- a/tests/unit/pathways/fileToolInputContracts.test.js
+++ b/tests/unit/pathways/fileToolInputContracts.test.js
@@ -1,0 +1,49 @@
+import test from 'ava';
+
+import analyzeFileTool from '../../../pathways/system/entity/tools/sys_tool_analyzefile.js';
+import mermaidTool from '../../../pathways/system/entity/tools/sys_tool_mermaid.js';
+import viewImageTool from '../../../pathways/system/entity/tools/sys_tool_view_image.js';
+
+test('analyze file exposes unified file analysis tools', t => {
+    const names = analyzeFileTool.toolDefinition.map(tool => tool.function.name);
+
+    t.deepEqual(names, ['AnalyzePDF', 'AnalyzeVideo']);
+});
+
+test('analyze file requires fileAccessPlan for file lookup', async t => {
+    const result = await analyzeFileTool.executePathway({
+        args: {
+            files: ['report.pdf'],
+            detailedInstructions: 'summarize this file',
+        },
+        runAllPrompts: () => {
+            throw new Error('runAllPrompts should not be called');
+        },
+        resolver: {},
+    });
+
+    const parsed = JSON.parse(result);
+    t.true(parsed.error.includes('fileAccessPlan is required'));
+});
+
+test('view images requires fileAccessPlan for file lookup', async t => {
+    await t.throwsAsync(
+        viewImageTool.executePathway({
+            args: {
+                files: ['diagram.png'],
+            },
+        }),
+        { message: 'fileAccessPlan is required' },
+    );
+});
+
+test('view images declares tool cost and file access wording', t => {
+    t.is(viewImageTool.toolDefinition.toolCost, 1);
+    const filesDescription = viewImageTool.toolDefinition.function.parameters.properties.files.description;
+    t.true(filesDescription.includes('blobPath'));
+    t.false(filesDescription.includes('availableFiles'));
+});
+
+test('mermaid tool description is not tied to coding agent context', t => {
+    t.false(mermaidTool.toolDefinition[0].function.description.includes('outside of your coding agent'));
+});


### PR DESCRIPTION
## Summary

- updates file analysis and image viewing tools to use file access plans for lookup
- streamlines AnalyzeFile tool variants around PDF and video/audio handling
- refreshes file-reference descriptions and chart tool wording
- adds unit coverage for the file-tool input contracts

## Notes

- stacked on `codex/upstream-workspace-pathway-inputs`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/fileToolInputContracts.test.js tests/unit/pathways/fileCollectionAccessPlan.test.js tests/unit/pathways/workspacePathwayInputs.test.js`
