### PR TITLE
Port logger formatting updates from aj-cortex

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,24 +1,7 @@
 // logger.js
 import winston from 'winston';
 import { AsyncLocalStorage } from 'async_hooks';
-
-winston.addColors({
-    debug: 'green',
-    verbose: 'blue',
-    http: 'gray',
-    info: 'cyan',
-    warn: 'yellow',
-    error: 'red'
-});
-
-const debugFormat = winston.format.combine(
-    winston.format.colorize({ all: true }),
-    winston.format.cli()
-);
-
-const prodFormat = winston.format.combine(
-    winston.format.simple()
-);
+import { inspect } from 'util';
 
 // AsyncLocalStorage to track per-request logging suppression
 const loggingContext = new AsyncLocalStorage();
@@ -32,26 +15,60 @@ const suppressNonErrorFormat = winston.format((info) => {
     return info; // keep
 });
 
+export const normalizeLogMessage = value => {
+    if (value instanceof Error) {
+        return value.stack || value.message;
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    try {
+        const json = JSON.stringify(value);
+        if (json !== undefined) return json;
+    } catch {
+        // Fall through to inspect below.
+    }
+    return inspect(value, { breakLength: Infinity, compact: true });
+};
+
+export const formatLogLine = info => {
+    const timestamp = info.timestamp || new Date().toISOString();
+    const message = String(normalizeLogMessage(info.stack || info.message) ?? '')
+        .replace(/\r/g, '\\r')
+        .replace(/\n/g, '\\n');
+
+    return `${timestamp} ${info.level}: ${message}`;
+};
+
+const standardFormat = winston.format.combine(
+    suppressNonErrorFormat(),
+    winston.format.errors({ stack: true }),
+    winston.format.splat(),
+    winston.format.timestamp(),
+    winston.format.printf(formatLogLine)
+);
+
 const getTransport = () => {
     switch (process.env.NODE_ENV) {
       case 'production':
-        return new winston.transports.Console({ level: 'info', format: winston.format.combine(suppressNonErrorFormat(), prodFormat) });
+        return new winston.transports.Console({ level: 'info', format: standardFormat });
       case 'development':
-        return new winston.transports.Console({ level: 'verbose', format: winston.format.combine(suppressNonErrorFormat(), debugFormat) });
+        return new winston.transports.Console({ level: 'info', format: standardFormat });
       case 'debug':
       case 'test':
-        return new winston.transports.Console({ level: 'debug', format: winston.format.combine(suppressNonErrorFormat(), debugFormat) });
+        return new winston.transports.Console({ level: 'debug', format: standardFormat });
       default:
         // Default to development settings if NODE_ENV is not set or unknown
         console.warn(`Unknown NODE_ENV: ${process.env.NODE_ENV}. Defaulting to development settings.`);
-        return new winston.transports.Console({ level: 'verbose', format: winston.format.combine(suppressNonErrorFormat(), debugFormat) });
+        return new winston.transports.Console({ level: 'verbose', format: standardFormat });
     }
 };
 
 // Create the logger
 const logger = winston.createLogger({
     level: process.env.NODE_ENV === 'production' ? 'info' : 
-           process.env.NODE_ENV === 'debug' ? 'debug' : 'verbose',
+           process.env.NODE_ENV === 'debug' ? 'debug' :
+           process.env.NODE_ENV === 'development' ? 'info' : 'verbose',
     transports: [getTransport()]
 });
 

--- a/tests/unit/lib/logger.test.js
+++ b/tests/unit/lib/logger.test.js
@@ -1,0 +1,26 @@
+import test from 'ava';
+import { formatLogLine, normalizeLogMessage } from '../../../lib/logger.js';
+
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/;
+
+test('formatLogLine emits plain timestamped single-line logs', t => {
+    const line = formatLogLine({
+        timestamp: '2026-05-06T20:00:00.000Z',
+        level: 'info',
+        message: 'first line\nsecond line',
+    });
+
+    t.is(line, '2026-05-06T20:00:00.000Z info: first line\\nsecond line');
+    t.false(ANSI_ESCAPE_PATTERN.test(line));
+});
+
+test('normalizeLogMessage stringifies structured payloads without ANSI formatting', t => {
+    const message = normalizeLogMessage({
+        event: 'token_usage',
+        request_id: 'resp_123',
+        stream: true,
+    });
+
+    t.is(message, '{"event":"token_usage","request_id":"resp_123","stream":true}');
+    t.false(ANSI_ESCAPE_PATTERN.test(message));
+});


### PR DESCRIPTION
## Summary

- switches logger output to plain timestamped single-line formatting
- normalizes error, string, and structured payload messages before printing
- adds unit coverage for log line formatting and structured message normalization

## Notes

- stacked on `codex/upstream-file-tool-inputs`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/lib/logger.test.js`
