### PR TITLE
Port pathway manager normalization from aj-cortex

### DIFF
--- a/lib/pathwayManager.js
+++ b/lib/pathwayManager.js
@@ -269,9 +269,10 @@ class PathwayManager {
       const loadedPathwayDefinitions = await this.storage.load();
       const pathways = {};
       for (const [userId, def] of Object.entries(loadedPathwayDefinitions)) {
-        pathways[userId] = {};
+        const normalizedUserId = userId.toLowerCase();
+        pathways[normalizedUserId] = pathways[normalizedUserId] || {};
         for (const [key, pathway] of Object.entries(def)) {
-          pathways[userId][key] = { ...this.basePathway, name: key, objName: key.charAt(0).toUpperCase() + key.slice(1), ...pathway };
+          pathways[normalizedUserId][key] = { ...this.basePathway, name: key, objName: key.charAt(0).toUpperCase() + key.slice(1), ...pathway };
         }
       }
       return pathways;
@@ -300,13 +301,15 @@ class PathwayManager {
     if (!pathwayName || typeof pathwayName !== 'string') {
       throw new Error('pathwayName must be a non-empty string');
     }
-    
+
+    const normalizedUserId = userId.toLowerCase();
+
     // Check if the pathway exists
-    if (!this.pathways[userId] || !this.pathways[userId][pathwayName]) {
+    if (!this.pathways[normalizedUserId] || !this.pathways[normalizedUserId][pathwayName]) {
       throw new Error(`Pathway '${pathwayName}' not found for user '${userId}'`);
     }
-    
-    const prompts = this.pathways[userId][pathwayName].prompt;
+
+    const prompts = this.pathways[normalizedUserId][pathwayName].prompt;
     
     if (!Array.isArray(prompts)) {
       throw new Error('prompts must be an array');
@@ -349,7 +352,7 @@ class PathwayManager {
     const promptName = typeof promptItem === 'string' ? defaultName : (promptItem.name || defaultName);
     const promptFiles = typeof promptItem === 'string' ? [] : (promptItem.files || []);
     const cortexPathwayName = typeof promptItem === 'string' ? null : (promptItem.cortexPathwayName || null);
-    const researchMode = typeof promptItem === 'string' ? undefined : (promptItem.researchMode !== undefined ? promptItem.researchMode : undefined);
+    const reasoningEffort = typeof promptItem === 'string' ? undefined : (promptItem.reasoningEffort || undefined);
     
     const messages = [];
 
@@ -384,9 +387,9 @@ class PathwayManager {
       prompt.cortexPathwayName = cortexPathwayName;
     }
 
-    // Preserve researchMode if present
-    if (researchMode !== undefined) {
-      prompt.researchMode = researchMode;
+    // Preserve reasoningEffort if present
+    if (reasoningEffort !== undefined) {
+      prompt.reasoningEffort = reasoningEffort;
     }
 
     return prompt;
@@ -425,32 +428,34 @@ class PathwayManager {
       throw new Error('Both userId and secret are mandatory for adding or updating a pathway');
     }
 
+    const normalizedUserId = userId.toLowerCase();
     await this.getLatestPathways();
-    this.pathways[userId] = this.pathways[userId] || {};
+    this.pathways[normalizedUserId] = this.pathways[normalizedUserId] || {};
 
-    if (this.pathways[userId][name] && this.pathways[userId][name].secret !== secret) {
+    if (this.pathways[normalizedUserId][name] && this.pathways[normalizedUserId][name].secret !== secret) {
       throw new Error('Pathway already exists and the key didn\'t match the existing secret. Please use a different name for the pathway.');
     }
 
-    this.pathways[userId][name] = { ...pathway, secret, displayName: displayName || pathway.displayName || name };
+    this.pathways[normalizedUserId][name] = { ...pathway, secret, displayName: displayName || pathway.displayName || name };
     await this.savePathways(this.pathways);
     await this.loadPathways();
     return name;
   }
 
   async removePathway(name, userId, secret) {
+    const normalizedUserId = userId.toLowerCase();
     await this.getLatestPathways();
 
-    if (!this.pathways[userId] || !this.pathways[userId][name]) {
+    if (!this.pathways[normalizedUserId] || !this.pathways[normalizedUserId][name]) {
       return;
     }
 
-    if (this.pathways[userId][name].secret !== secret) {
+    if (this.pathways[normalizedUserId][name].secret !== secret) {
       throw new Error('Invalid secret');
     }
-    delete this.pathways[userId][name];
-    if (Object.keys(this.pathways[userId]).length === 0) {
-      delete this.pathways[userId];
+    delete this.pathways[normalizedUserId][name];
+    if (Object.keys(this.pathways[normalizedUserId]).length === 0) {
+      delete this.pathways[normalizedUserId];
     }
 
     await this.savePathways(this.pathways);
@@ -466,7 +471,7 @@ class PathwayManager {
       prompt: String!
       files: [String!]
       cortexPathwayName: String
-      researchMode: Boolean
+      reasoningEffort: String
     }
     
     input PathwayInput {
@@ -550,13 +555,14 @@ class PathwayManager {
   }
 
   async getPathway(userId, pathwayName) {
+    const normalizedUserId = userId.toLowerCase();
     const pathways = await this.getLatestPathways();
 
-    if (!pathways[userId] || !pathways[userId][pathwayName]) {
+    if (!pathways[normalizedUserId] || !pathways[normalizedUserId][pathwayName]) {
       throw new Error(`Pathway '${pathwayName}' not found for user '${userId}'`);
     }
 
-    return this.transformPrompts(pathways[userId][pathwayName]);
+    return this.transformPrompts(pathways[normalizedUserId][pathwayName]);
   }
 
   /**

--- a/tests/unit/core/pathwayManager.test.js
+++ b/tests/unit/core/pathwayManager.test.js
@@ -550,7 +550,7 @@ test('isLegacyPromptFormat identifies legacy format (array of strings)', t => {
     
     // Set up pathway with legacy prompts
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: [
                     'First prompt text',
@@ -571,7 +571,7 @@ test('isLegacyPromptFormat identifies new format (array of objects)', t => {
     
     // Set up pathway with new format prompts
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: [
                     { name: 'First Prompt', prompt: 'First prompt text' },
@@ -592,7 +592,7 @@ test('isLegacyPromptFormat handles empty array (defaults to new format)', t => {
     
     // Set up pathway with empty prompts array
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: []
             }
@@ -609,7 +609,7 @@ test('isLegacyPromptFormat handles mixed format (treats as legacy)', t => {
     
     // Set up pathway with mixed format prompts
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: [
                     'Legacy string prompt',
@@ -647,7 +647,7 @@ test('isLegacyPromptFormat handles objects with missing prompt property (treats 
     
     // Set up pathway with invalid objects
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: [
                     { name: 'Missing prompt property' },
@@ -667,7 +667,7 @@ test('isLegacyPromptFormat handles objects with null prompt property (treats as 
     
     // Set up pathway with null prompt properties
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: [
                     { name: 'Null prompt', prompt: null },
@@ -687,7 +687,7 @@ test('isLegacyPromptFormat handles array with null elements (treats as legacy)',
     
     // Set up pathway with null elements
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: [
                     null,
@@ -708,7 +708,7 @@ test('isLegacyPromptFormat handles single string element', t => {
     
     // Set up pathway with single string element
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: ['Only prompt']
             }
@@ -725,7 +725,7 @@ test('isLegacyPromptFormat handles single object element', t => {
     
     // Set up pathway with single object element
     t.context.pathwayManager.pathways = {
-        [userId]: {
+        [userId.toLowerCase()]: {
             [pathwayName]: {
                 prompt: [{ name: 'Only prompt', prompt: 'Only prompt text' }]
             }
@@ -746,6 +746,58 @@ test('isLegacyPromptFormat throws error when pathway not found', t => {
     t.throws(() => {
         t.context.pathwayManager.isLegacyPromptFormat(userId, pathwayName);
     }, { message: `Pathway 'nonExistentPathway' not found for user 'testUser'` });
+});
+
+test('case-insensitive userId lookup in isLegacyPromptFormat', t => {
+    t.context.pathwayManager.pathways = {
+        'user@example.com': {
+            testPathway: {
+                prompt: ['Some prompt']
+            }
+        }
+    };
+
+    t.true(t.context.pathwayManager.isLegacyPromptFormat('User@Example.com', 'testPathway'));
+    t.true(t.context.pathwayManager.isLegacyPromptFormat('user@example.com', 'testPathway'));
+    t.true(t.context.pathwayManager.isLegacyPromptFormat('USER@EXAMPLE.COM', 'testPathway'));
+});
+
+test('case-insensitive userId lookup in getPathway', async t => {
+    t.context.pathwayManager.pathways = {
+        'user@example.com': {
+            myPathway: {
+                prompt: [{ name: 'test', prompt: 'test prompt' }],
+                systemPrompt: 'system'
+            }
+        }
+    };
+
+    t.context.pathwayManager.getLatestPathways = async () => t.context.pathwayManager.pathways;
+
+    const result = await t.context.pathwayManager.getPathway('User@Example.com', 'myPathway');
+    t.truthy(result);
+});
+
+test('putPathway normalizes userId to lowercase', async t => {
+    t.context.pathwayManager.getLatestPathways = async () => t.context.pathwayManager.pathways;
+    t.context.pathwayManager.savePathways = async () => {};
+    t.context.pathwayManager.loadPathways = async () => t.context.pathwayManager.pathways;
+
+    await t.context.pathwayManager.putPathway('myPathway', { prompt: ['test'] }, 'TestUser@Example.com', 'secret123');
+
+    t.truthy(t.context.pathwayManager.pathways['testuser@example.com']);
+    t.truthy(t.context.pathwayManager.pathways['testuser@example.com']['myPathway']);
+    t.falsy(t.context.pathwayManager.pathways['TestUser@Example.com']);
+});
+
+test('_createPromptObject preserves reasoningEffort metadata', t => {
+    const prompt = t.context.pathwayManager._createPromptObject(
+        { name: 'Reasoning Prompt', prompt: 'Think carefully', reasoningEffort: 'high' },
+        'system',
+    );
+
+    t.is(prompt.reasoningEffort, 'high');
+    t.is(prompt.researchMode, undefined);
 });
 
 test('getPathways throws error for non-array promptNames', async t => {


### PR DESCRIPTION
## Summary

- normalizes custom pathway user IDs to lowercase during load, lookup, publish, and removal
- carries `reasoningEffort` prompt metadata through transformed prompts and GraphQL input
- adds unit coverage for case-insensitive pathway lookup and normalized publish storage

## Notes

- stacked on `codex/upstream-logger-formatting`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/core/pathwayManager.test.js`
