### PR TITLE
Port plugin log summary updates from aj-cortex

### DIFF
--- a/server/plugins/apptekTranslatePlugin.js
+++ b/server/plugins/apptekTranslatePlugin.js
@@ -47,7 +47,7 @@ class ApptekTranslatePlugin extends ModelPlugin {
         // Check if source and target languages are the same
         if (to && sourceLanguage && sourceLanguage !== 'auto' && sourceLanguage === to) {
             const logMessage = `ApptekTranslatePlugin: Source language (${sourceLanguage}) matches target language (${to}). Skipping translation.`;
-            logger.verbose(logMessage)
+            logger.info(logMessage)
             return text;
         }
 
@@ -67,7 +67,7 @@ class ApptekTranslatePlugin extends ModelPlugin {
             cortexRequest.url = url.toString();
             
             const glossaryLogMessage = `ApptekTranslatePlugin: Using glossary ID: ${requestParameters.params.glossaryId}`;
-            logger.verbose(glossaryLogMessage)
+            logger.info(glossaryLogMessage)
         }
 
         return this.executeRequest(cortexRequest);
@@ -111,7 +111,7 @@ class ApptekTranslatePlugin extends ModelPlugin {
                     text,
                 });
                 
-                logger.verbose(`Successfully used language pathway as fallback: ${JSON.stringify({ detectedLanguage })}`);
+                logger.info(`Successfully used language pathway as fallback: ${JSON.stringify({ detectedLanguage })}`);
                 if (!detectedLanguage) {
                     throw new Error('Language detection failed using fallback language pathway');
                 }
@@ -132,8 +132,11 @@ class ApptekTranslatePlugin extends ModelPlugin {
 
     // Override the logging function to display the request and response
     logRequestData(data, responseData, prompt) {
-        logger.verbose(`Input: ${data}`);
-        logger.verbose(`Output: ${this.parseResponse(responseData)}`);
+        const requestLength = this.getLength(data || '');
+        logger.info(`[AppTek Translate request sent containing ${requestLength.length} ${requestLength.units}]`);
+        const responseText = this.parseResponse(responseData);
+        const responseLength = this.getLength(responseText || '');
+        logger.info(`[AppTek Translate response received containing ${responseLength.length} ${responseLength.units}]`);
 
         if (prompt?.debugInfo) {
             prompt.debugInfo += `\nInput: ${data}\nOutput: ${responseData}`;

--- a/server/plugins/azureFoundryAgentsPlugin.js
+++ b/server/plugins/azureFoundryAgentsPlugin.js
@@ -324,9 +324,6 @@ class AzureFoundryAgentsPlugin extends ModelPlugin {
                         return JSON.stringify(item);
                     }).join(', ') : message.content);
                 const { length, units } = this.getLength(content);
-                const displayContent = this.shortenContent(content);
-
-                logger.verbose(`message ${index + 1}: role: ${message.role}, ${units}: ${length}, content: "${displayContent}"`);
                 totalLength += length;
                 totalUnits = units;
             });
@@ -338,7 +335,6 @@ class AzureFoundryAgentsPlugin extends ModelPlugin {
             }).join(', ') : message.content;
             const { length, units } = this.getLength(content);
             logger.info(`[Azure Foundry Agent request sent containing ${length} ${units}]`);
-            logger.verbose(`${this.shortenContent(content)}`);
         }
     
         if (stream) {
@@ -348,7 +344,6 @@ class AzureFoundryAgentsPlugin extends ModelPlugin {
             if (responseText && typeof responseText === 'string') {
                 const { length, units } = this.getLength(responseText);
                 logger.info(`[Azure Foundry Agent response received containing ${length} ${units}]`);
-                logger.verbose(`${this.shortenContent(responseText)}`);
             } else {
                 logger.info(`[Azure Foundry Agent response received: ${JSON.stringify(responseData)}]`);
             }
@@ -358,4 +353,4 @@ class AzureFoundryAgentsPlugin extends ModelPlugin {
     }
 }
 
-export default AzureFoundryAgentsPlugin; 
+export default AzureFoundryAgentsPlugin;

--- a/server/plugins/azureTranslatePlugin.js
+++ b/server/plugins/azureTranslatePlugin.js
@@ -47,8 +47,11 @@ class AzureTranslatePlugin extends ModelPlugin {
     logRequestData(data, responseData, prompt) {
         const modelInput = data[0].Text;
     
-        logger.verbose(`${modelInput}`);
-        logger.verbose(`${this.parseResponse(responseData)}`);
+        const requestLength = this.getLength(modelInput || '');
+        logger.info(`[Azure Translate request sent containing ${requestLength.length} ${requestLength.units}]`);
+        const responseText = this.parseResponse(responseData);
+        const responseLength = this.getLength(responseText || '');
+        logger.info(`[Azure Translate response received containing ${responseLength.length} ${responseLength.units}]`);
     
         prompt && prompt.debugInfo && (prompt.debugInfo += `\n${JSON.stringify(data)}`);
     }

--- a/server/plugins/googleCsePlugin.js
+++ b/server/plugins/googleCsePlugin.js
@@ -90,8 +90,9 @@ class GoogleCsePlugin extends ModelPlugin {
     }
 
     logRequestData(data, responseData, prompt) {
-        // Keep verbose logging consistent
-        logger.verbose(`${this.parseResponse(responseData)}`);
+        const responseText = this.parseResponse(responseData);
+        const { length, units } = this.getLength(responseText || '');
+        logger.info(`[Google CSE response received containing ${length} ${units}]`);
         prompt && prompt.debugInfo && (prompt.debugInfo += `\n${JSON.stringify(data)}`);
     }
 }

--- a/server/plugins/googleTranslatePlugin.js
+++ b/server/plugins/googleTranslatePlugin.js
@@ -109,8 +109,10 @@ class GoogleTranslatePlugin extends ModelPlugin {
         const modelInput = data.q ? data.q[0] : (data.contents ? data.contents[0] : '');
         const translatedText = this.parseResponse(responseData);
         
-        logger.verbose(`Input: ${modelInput}`);
-        logger.verbose(`Output: ${translatedText}`);
+        const requestLength = this.getLength(modelInput || '');
+        logger.info(`[Google Translate request sent containing ${requestLength.length} ${requestLength.units}]`);
+        const responseLength = this.getLength(translatedText || '');
+        logger.info(`[Google Translate response received containing ${responseLength.length} ${responseLength.units}]`);
 
         if (prompt?.debugInfo) {
             prompt.debugInfo += `\nInput: ${modelInput}\nOutput: ${translatedText}`;

--- a/tests/unit/plugins/pluginLogSummaries.test.js
+++ b/tests/unit/plugins/pluginLogSummaries.test.js
@@ -1,0 +1,102 @@
+import test from 'ava';
+
+import logger from '../../../lib/logger.js';
+import ApptekTranslatePlugin from '../../../server/plugins/apptekTranslatePlugin.js';
+import AzureFoundryAgentsPlugin from '../../../server/plugins/azureFoundryAgentsPlugin.js';
+import AzureTranslatePlugin from '../../../server/plugins/azureTranslatePlugin.js';
+import GoogleCsePlugin from '../../../server/plugins/googleCsePlugin.js';
+import GoogleTranslatePlugin from '../../../server/plugins/googleTranslatePlugin.js';
+
+function stubLogger() {
+    const calls = [];
+    const original = {
+        info: logger.info,
+        verbose: logger.verbose,
+    };
+
+    logger.info = (message) => calls.push({ level: 'info', message });
+    logger.verbose = (message) => calls.push({ level: 'verbose', message });
+
+    return {
+        calls,
+        restore() {
+            logger.info = original.info;
+            logger.verbose = original.verbose;
+        },
+    };
+}
+
+function makePlugin(PluginClass, parseResponse = data => data) {
+    const plugin = Object.create(PluginClass.prototype);
+    plugin.getLength = text => ({ length: String(text ?? '').length, units: 'characters' });
+    plugin.parseResponse = parseResponse;
+    return plugin;
+}
+
+test('translation plugins log content lengths instead of raw payloads', t => {
+    const loggerStub = stubLogger();
+    t.teardown(() => loggerStub.restore());
+
+    const azurePlugin = makePlugin(AzureTranslatePlugin, () => 'translated secret output');
+    azurePlugin.logRequestData(
+        [{ Text: 'sensitive source text' }],
+        [{ translations: [{ text: 'translated secret output' }] }],
+        {},
+    );
+
+    const googlePlugin = makePlugin(GoogleTranslatePlugin, () => 'translated google output');
+    googlePlugin.logRequestData(
+        { q: ['google source text'] },
+        { data: { translations: [{ translatedText: 'translated google output' }] } },
+        {},
+    );
+
+    const apptekPlugin = makePlugin(ApptekTranslatePlugin, data => data);
+    apptekPlugin.logRequestData('apptek source text', 'apptek output text', {});
+
+    t.true(loggerStub.calls.every(call => call.level === 'info'));
+    t.true(loggerStub.calls.some(call => call.message.includes('Azure Translate request sent containing')));
+    t.true(loggerStub.calls.some(call => call.message.includes('Google Translate response received containing')));
+    t.true(loggerStub.calls.some(call => call.message.includes('AppTek Translate request sent containing')));
+
+    const combinedMessages = loggerStub.calls.map(call => call.message).join('\n');
+    t.false(combinedMessages.includes('sensitive source text'));
+    t.false(combinedMessages.includes('translated secret output'));
+    t.false(combinedMessages.includes('google source text'));
+    t.false(combinedMessages.includes('apptek source text'));
+});
+
+test('search and agent plugins summarize logged payload sizes', t => {
+    const loggerStub = stubLogger();
+    t.teardown(() => loggerStub.restore());
+
+    const googleCsePlugin = makePlugin(GoogleCsePlugin, data => JSON.stringify(data));
+    googleCsePlugin.logRequestData(
+        { q: 'search query' },
+        { items: [{ title: 'private result text' }] },
+        {},
+    );
+
+    const foundryPlugin = makePlugin(AzureFoundryAgentsPlugin);
+    foundryPlugin.logRequestData(
+        {
+            thread: {
+                messages: [
+                    { role: 'user', content: 'agent request secret' },
+                    { role: 'assistant', content: 'agent context secret' },
+                ],
+            },
+        },
+        'agent response secret',
+        {},
+    );
+
+    const combinedMessages = loggerStub.calls.map(call => call.message).join('\n');
+    t.true(combinedMessages.includes('Google CSE response received containing'));
+    t.true(combinedMessages.includes('Azure Foundry Agent request sent containing 2 messages'));
+    t.true(combinedMessages.includes('Azure Foundry Agent response received containing'));
+    t.false(combinedMessages.includes('private result text'));
+    t.false(combinedMessages.includes('agent request secret'));
+    t.false(combinedMessages.includes('agent response secret'));
+    t.true(loggerStub.calls.every(call => call.level === 'info'));
+});


### PR DESCRIPTION
## Summary

- logs request and response sizes for translation/search plugins instead of raw payloads
- removes verbose content dumps from Azure Foundry Agent request and response logging
- adds unit coverage that verifies payload summaries are emitted without raw content

## Notes

- stacked on `codex/upstream-pathway-manager-normalization`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/plugins/pluginLogSummaries.test.js tests/unit/lib/logger.test.js`
