### PR TITLE
Port key-value decryption guard from aj-cortex

### DIFF
--- a/lib/keyValueStorageClient.js
+++ b/lib/keyValueStorageClient.js
@@ -74,7 +74,7 @@ async function getvWithDoubleDecryption(key, contextKey) {
     }
     
     // If contextKey exists and is not empty, try to decrypt the result with it
-    if (contextKey && contextKey.trim() !== '') {
+    if (contextKey && contextKey.trim() !== '' && typeof result === 'string') {
         try {
             // Try to decrypt with context key
             const decrypted = decrypt(result, contextKey);

--- a/tests/unit/core/crypto.test.js
+++ b/tests/unit/core/crypto.test.js
@@ -104,3 +104,18 @@ test('decrypt should handle plain text that looks like encrypted format (3 parts
     // Should return as-is because it doesn't match expected format
     t.is(result, plainText);
 });
+
+test('decrypt should return already-deserialized objects without warning', t => {
+    const plainObject = { message: 'test', number: 42 };
+    t.deepEqual(decrypt(plainObject, systemKey), plainObject);
+});
+
+test('decrypt should return null for null and undefined without warning', t => {
+    t.is(decrypt(null, systemKey), null);
+    t.is(decrypt(undefined, systemKey), null);
+});
+
+test('decrypt should return numbers and booleans as-is', t => {
+    t.is(decrypt(42, systemKey), 42);
+    t.is(decrypt(true, systemKey), true);
+});

--- a/tests/unit/core/keyValueStorageClient.test.js
+++ b/tests/unit/core/keyValueStorageClient.test.js
@@ -1,0 +1,16 @@
+import test from 'ava';
+
+import {
+    getvWithDoubleDecryption,
+    keyValueStorageClient,
+} from '../../../lib/keyValueStorageClient.js';
+
+const contextKey = 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+test('getvWithDoubleDecryption returns deserialized non-string values as-is', async t => {
+    const key = `key-value-object-${Date.now()}`;
+    const value = { message: 'already parsed', count: 2 };
+
+    await keyValueStorageClient.set(key, value);
+    t.deepEqual(await getvWithDoubleDecryption(key, contextKey), value);
+});


### PR DESCRIPTION
## Summary

- skips context-key decryption for already-deserialized key-value storage results
- adds crypto coverage for already-deserialized values, nullish values, and primitive values
- adds key-value storage coverage for non-string double-decryption reads

## Notes

- stacked on `codex/upstream-plugin-log-summaries`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/core/crypto.test.js tests/unit/core/keyValueStorageClient.test.js`
