### PR TITLE
Port sys_get_entities option handling

### DIFF
--- a/pathways/system/entity/sys_get_entities.js
+++ b/pathways/system/entity/sys_get_entities.js
@@ -5,11 +5,21 @@ import { getAvailableEntities } from './tools/shared/sys_entity_tools.js';
 
 export default {
     prompt: [],
-    inputParameters: {},
+    inputParameters: {
+        userId: '',
+        fresh: '',
+    },
     model: 'oai-gpt41-mini',
     executePathway: async ({ args }) => {
         try {
-            const entities = getAvailableEntities();
+            const options = {};
+            if (args.userId) {
+                options.userId = args.userId;
+            }
+            if (args.fresh === true || args.fresh === 'true' || args.fresh === '1') {
+                options.fresh = true;
+            }
+            const entities = await getAvailableEntities(options);
             return JSON.stringify(entities);
         } catch (error) {
             return JSON.stringify(error);
@@ -17,4 +27,4 @@ export default {
     },
     json: true, // We want JSON output
     manageTokenLength: false, // No need to manage token length for this simple operation
-}; 
+};

--- a/tests/unit/pathways/sysGetEntities.test.js
+++ b/tests/unit/pathways/sysGetEntities.test.js
@@ -1,0 +1,19 @@
+import test from 'ava';
+import sysGetEntities from '../../../pathways/system/entity/sys_get_entities.js';
+
+test('sys_get_entities returns an entity list result', async t => {
+    const result = await sysGetEntities.executePathway({ args: {} });
+
+    t.is(result, '[]');
+});
+
+test('sys_get_entities accepts optional user and fresh inputs', async t => {
+    const result = await sysGetEntities.executePathway({
+        args: {
+            userId: 'Test-User',
+            fresh: 'true',
+        }
+    });
+
+    t.is(result, '[]');
+});


### PR DESCRIPTION
## Summary

- adds userId and fresh inputs to the sys_get_entities pathway
- awaits the async entity listing helper before JSON serialization
- covers the pathway result shape when entity storage is unavailable

## Notes

- stacked on `codex/upstream-rest-reasoning-effort-tests`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/sysGetEntities.test.js tests/unit/pathways/workspacePathwayInputs.test.js`
