### PR TITLE
Align Grok live search default model

### DIFF
--- a/pathways/grok_live_search.js
+++ b/pathways/grok_live_search.js
@@ -9,9 +9,9 @@ export default {
             ]}),
         ],
 
-    // Default to the new Responses API model (xai-grok-4-1-fast-responses)
-    // The legacy xai-grok-4-fast-non-reasoning model with search_parameters is deprecated
-    model: 'xai-grok-4-1-fast-responses',
+    // Default to the current Responses API search wrapper.
+    // Legacy Grok search model ids now redirect to this 4.20-backed pathway.
+    model: 'xai-grok-4-20-responses',
     useInputChunking: false,
     inputParameters: {
         stream: true,

--- a/tests/unit/pathways/searchToolFootguns.test.js
+++ b/tests/unit/pathways/searchToolFootguns.test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 
 import googleSearchTool from '../../../pathways/system/entity/tools/sys_tool_google_search.js';
+import grokLiveSearch from '../../../pathways/grok_live_search.js';
 import grokXSearchTool from '../../../pathways/system/entity/tools/sys_tool_grok_x_search.js';
 import validateUrlTool from '../../../pathways/system/entity/tools/sys_tool_validate_url.js';
 
@@ -20,6 +21,10 @@ test('SearchXPlatform uses current Grok Responses model', t => {
 
     t.true(source.includes("model: 'xai-grok-4-20-responses'"));
     t.false(source.includes("model: 'xai-grok-4-1-fast-responses'"));
+});
+
+test('grok_live_search defaults to current Grok Responses model', t => {
+    t.is(grokLiveSearch.model, 'xai-grok-4-20-responses');
 });
 
 test('ValidateUrl has explicit low tool cost', t => {


### PR DESCRIPTION
## Summary

- updates grok_live_search to default to the current Grok Responses model
- adds unit coverage so the pathway and X search tool stay on the same model family

## Notes

- stacked on `codex/upstream-entity-partial-update-tests`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/searchToolFootguns.test.js tests/unit/plugins/openAiResponsesPlugin.test.js`
