### PR TITLE
Add generic RAG search result formatting

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,7 @@ import logger from "./logger.js";
 import subvibe from '@aj-archipelago/subvibe';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
+import { gpt3Encode, gpt3Decode } from './pathwayTools.js';
 
 
 function getUniqueId(){
@@ -82,6 +83,53 @@ function convertToSingleContentChatHistory(chatHistory){
             chatHistory[i].content = chatHistory[i].content.join("\n");
         }
     }
+}
+
+function normalizeSearchContent(source){
+    if (!source || typeof source !== 'object') return '';
+    const { content, excerpt } = source;
+
+    if (Array.isArray(content)) {
+        const joined = content
+            .filter(item => item !== null && item !== undefined && String(item).trim() !== '')
+            .map(item => String(item))
+            .join('\n');
+        if (joined.trim()) {
+            return joined;
+        }
+    }
+
+    if (typeof content === 'string' && content.trim()) {
+        return content;
+    }
+
+    if (typeof excerpt === 'string' && excerpt.trim()) {
+        return excerpt;
+    }
+
+    return '';
+}
+
+function formatSearchResult(source, index, targetLength, { label = 'source', skipContent = false } = {}) {
+    const { title, url } = source;
+    const content = normalizeSearchContent(source);
+    let result = [];
+    result.push(`[${label} ${index + 1}]`);
+    title && result.push(`title: ${title}`);
+    url && result.push(`url: ${url}`);
+
+    if (content && !skipContent) {
+        let encodedContent = gpt3Encode(content);
+        let currentLength = result.join(" ").length;
+        if (currentLength + encodedContent.length > targetLength) {
+            encodedContent = encodedContent.slice(0, targetLength - currentLength);
+            result.push(`content: ${gpt3Decode(encodedContent)}`);
+        } else {
+            result.push(`content: ${content}`);
+        }
+    }
+
+    return result.join(" ").trim();
 }
 
 //check if args has a type in chatHistory
@@ -368,6 +416,8 @@ export {
     getSearchResultId,
     extractCitationTitle,
     convertToSingleContentChatHistory,
+    normalizeSearchContent,
+    formatSearchResult,
     chatArgsHasImageUrl, 
     chatArgsHasType,
     convertSrtToText,

--- a/pathways/rag.js
+++ b/pathways/rag.js
@@ -4,7 +4,7 @@ import { config } from '../config.js';
 import logger from '../lib/logger.js';
 import { callPathway, gpt3Encode, gpt3Decode } from '../lib/pathwayTools.js';
 import { Prompt } from '../server/prompt.js';
-import { chatArgsHasImageUrl, convertToSingleContentChatHistory } from '../lib/util.js';
+import { chatArgsHasImageUrl, convertToSingleContentChatHistory, normalizeSearchContent } from '../lib/util.js';
 
 const TOKEN_RATIO = 0.75;
 
@@ -152,7 +152,8 @@ export default {
             const targetDocLength = (maxDocsPromptLength / numSearchResults) >> 0;
 
             const getDoc = (doc, index) => {
-                const { title, content, url } = doc;
+                const { title, url } = doc;
+                const content = normalizeSearchContent(doc);
                 let result = [];
                 result.push(`[doc${index + 1}]`);
                 title && result.push(`title: ${title}`);
@@ -189,4 +190,3 @@ export default {
         }
     }
 };
-

--- a/pathways/rag_jarvis.js
+++ b/pathways/rag_jarvis.js
@@ -1,10 +1,10 @@
 // rag_Jarvis.js
 // RAG module that makes use of data and LLM models 
-import { callPathway, gpt3Encode, gpt3Decode } from '../lib/pathwayTools.js';
+import { callPathway, gpt3Encode } from '../lib/pathwayTools.js';
 import { Prompt } from '../server/prompt.js';
 import { config } from '../config.js';
 import logger from '../lib/logger.js';
-import { chatArgsHasImageUrl, convertToSingleContentChatHistory } from '../lib/util.js';
+import { chatArgsHasImageUrl, convertToSingleContentChatHistory, formatSearchResult } from '../lib/util.js';
 
 const TOKEN_RATIO = 0.75;
 
@@ -198,31 +198,7 @@ export default {
             const numSearchResults = Math.min(searchResults.length, maxSearchResults);
             const targetSourceLength = (maxSourcesPromptLength / numSearchResults) >> 0;
 
-            const getSource = (source, index) => {
-                const { title, content, url } = source;
-                let result = [];
-                result.push(`[source ${index + 1}]`);
-                title && result.push(`title: ${title}`);
-                url && result.push(`url: ${url}`);
-
-                if (content) {
-                    let encodedContent = gpt3Encode(content);
-                    let currentLength = result.join(" ").length; // Calculate the length of the current result string
-
-                    if (currentLength + encodedContent.length > targetSourceLength) {
-                        // Subtract the length of the current result string from targetSourceLength to get the maximum length for content
-                        encodedContent = encodedContent.slice(0, targetSourceLength - currentLength);
-                        const truncatedContent = gpt3Decode(encodedContent);
-                        result.push(`content: ${truncatedContent}`);
-                    } else {
-                        result.push(`content: ${content}`);
-                    }
-                }
-
-                return result.join(" ").trim();
-            }
-
-            let sources = searchResults.map(getSource).join(" \n\n ") || "No relevant sources found.";
+            let sources = searchResults.map((s, i) => formatSearchResult(s, i, targetSourceLength)).join(" \n\n ") || "No relevant sources found.";
             dateFilter && sources.trim() && (sources+=`\n\n above sources are date filtered accordingly. \n\n`)
 
             const result = await pathwayResolver.resolve({ ...args, sources, language:languageStr });
@@ -236,4 +212,3 @@ export default {
         }
     }
 };
-

--- a/tests/unit/core/util.test.js
+++ b/tests/unit/core/util.test.js
@@ -6,10 +6,43 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import sinon from 'sinon';
-import { removeOldImageAndFileContent } from '../../../lib/util.js';
+import { formatSearchResult, normalizeSearchContent, removeOldImageAndFileContent } from '../../../lib/util.js';
 import { computeFileHash, computeBufferHash, generateFileMessageContent, injectFileIntoChatHistory } from '../../../lib/fileUtils.js';
 
 // Test removeOldImageAndFileContent function
+
+test('normalizeSearchContent joins array content before excerpt fallback', t => {
+    t.is(normalizeSearchContent({ content: ['first', '', null, 'second'], excerpt: 'fallback' }), 'first\nsecond');
+    t.is(normalizeSearchContent({ content: [], excerpt: 'fallback' }), 'fallback');
+    t.is(normalizeSearchContent({ content: 'direct content', excerpt: 'fallback' }), 'direct content');
+    t.is(normalizeSearchContent({ content: '   ', excerpt: 'fallback' }), 'fallback');
+    t.is(normalizeSearchContent(null), '');
+});
+
+test('formatSearchResult uses normalized content and supports labels', t => {
+    const result = formatSearchResult({
+        title: 'Example',
+        url: 'https://example.com/item',
+        content: ['alpha', 'beta'],
+    }, 1, 1000, { label: 'doc' });
+
+    t.true(result.includes('[doc 2]'));
+    t.true(result.includes('title: Example'));
+    t.true(result.includes('url: https://example.com/item'));
+    t.true(result.includes('content: alpha\nbeta'));
+});
+
+test('formatSearchResult can omit content', t => {
+    const result = formatSearchResult({
+        title: 'Example',
+        url: 'https://example.com/item',
+        content: 'body text',
+    }, 0, 1000, { skipContent: true });
+
+    t.true(result.includes('[source 1]'));
+    t.true(result.includes('title: Example'));
+    t.false(result.includes('content:'));
+});
 
 test('removeOldImageAndFileContent should return original chat history if empty', t => {
     const chatHistory = [];
@@ -330,7 +363,7 @@ test('injectFileIntoChatHistory should not inject duplicate file by URL', t => {
     t.is(result[0].content.length, 1);
 });
 
-test('injectFileIntoChatHistory should not inject duplicate file by GCS URL', t => {
+test('injectFileIntoChatHistory should allow files with same GCS but different URL', t => {
     const chatHistory = [
         {
             role: 'user',
@@ -347,15 +380,14 @@ test('injectFileIntoChatHistory should not inject duplicate file by GCS URL', t 
         type: 'file',
         file: 'https://example.com/other.pdf',
         url: 'https://example.com/other.pdf',
-        gcs: 'gs://bucket/test.pdf', // Same GCS URL
+        gcs: 'gs://bucket/test.pdf', // Same GCS URL but different primary URL
         originalFilename: 'other.pdf'
     };
-    
+
     const result = injectFileIntoChatHistory(chatHistory, fileContent);
-    
-    // Should be unchanged (no duplicate added)
-    t.is(result.length, 1);
-    t.is(result[0].content.length, 1);
+
+    // Dedup is by url and hash only, not GCS - different url means different file
+    t.is(result.length, 2);
 });
 
 test('injectFileIntoChatHistory should not inject duplicate file by hash', t => {


### PR DESCRIPTION
## Summary

- adds generic helpers for normalizing and formatting search result content
- uses the shared formatter in RAG source rendering
- updates file injection expectations to match URL/hash-based deduplication

## Notes

- stacked on `codex/upstream-grok-live-search-model`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/core/util.test.js tests/unit/pathways/searchToolFootguns.test.js`
