### PR TITLE
Add request monitor ping latency regression test

### DIFF
--- a/tests/unit/core/requestMonitor.test.js
+++ b/tests/unit/core/requestMonitor.test.js
@@ -34,6 +34,21 @@ test('RequestMonitor: getAverageCallDuration', async t => {
   t.truthy(average > 1400 && average < 1600);
 });
 
+test('RequestMonitor: keeps ping latency separate from live latency', t => {
+  const rm = new RequestMonitor();
+
+  rm.recordTTFB(100, 'ping');
+  rm.recordTTFB(1000, 'live');
+  rm.callStartTimes.set('ping-call', new Date(Date.now() - 10));
+  rm.endCall('ping-call', 'ping');
+
+  t.is(rm.getAverageTTFB('ping'), 100);
+  t.is(rm.getAverageTTFB(), 1000);
+  t.true(rm.getAverageCallDuration('ping') > 0);
+  t.is(rm.getAverageCallDuration(), 0);
+  t.true(Number.isFinite(rm.getSampleAge('ping')));
+});
+
 test('RequestMonitor: incrementError429Count', t => {
   const rm = new RequestMonitor();
 


### PR DESCRIPTION
## Summary

- adds regression coverage for keeping ping latency samples separate from live traffic samples
- verifies TTFB, call duration, and sample age behavior for ping monitoring

## Notes

- stacked on `codex/upstream-rag-source-formatting`

## Validation

- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/core/requestMonitor.test.js`
