### PR TITLE
[codex] Add media prompt helper pathways

### DIFF
--- a/docs/file-scopes.md
+++ b/docs/file-scopes.md
@@ -1,0 +1,84 @@
+# File Scopes
+
+## Container Rules
+
+- `BASE` = `getDefaultContainerName()`.
+- Current owner-scoped Azure container = `BASE-<sanitize(ownerId)>`.
+- `sanitize(ownerId)`:
+  - lowercases
+  - replaces non-`[a-z0-9-]` with `-`
+  - collapses repeated `-`
+  - trims leading/trailing `-`
+  - keeps at most 50 chars of sanitized suffix
+- Legacy owner-scoped Azure alias = `BASE-<legacySanitize(ownerId)>`.
+- `legacySanitize(ownerId)`:
+  - lowercases
+  - removes non-`[a-z0-9-]`
+  - keeps at most 50 chars of sanitized suffix
+- If there is no owner id, Azure uses `BASE` itself.
+- `blobPath` below means the path inside the chosen Azure container.
+- Redis/FileCollection identity uses the logical context id, not necessarily the physical container owner id.
+
+## Scope Map
+
+| `fileScope` | What it is | Logical context / Redis key | Azure container owner id | Azure blobPath written by this scope |
+| --- | --- | --- | --- | --- |
+| `all` | Container-root read/list scope. Not a distinct write location. | Same as the selected target; `all` does not create a new logical context. | Whatever owner id the caller selected for the request. | N/A for writes; reads list `/` (container root) |
+| `global` | Global files for a user/context. | Usually the user context id. | `contextId \|\| userId` | `global/<filename>` |
+| `media` | Direct named folder scope. | Caller-selected context. | `contextId \|\| userId` | `media/<filename>` |
+| `chat` | Chat-scoped files. | Usually the user context id, with `chatId` carried separately. | `contextId \|\| userId` | `chats/<chatId>/<filename>`; if `chatId` is missing, it falls back to `global/<filename>` |
+| `workspace-user-legacy` | Legacy user-owned workspace/app-private compatibility scope keyed by `workspaceId`. | Usually the user context id, with `workspaceId` carried separately. | `contextId \|\| userId` | `applets/<workspaceId>/<filename>`; if `workspaceId` is missing, it falls back to `global/<filename>` |
+| `applet-user` | Current app-private scope. Logical applet+user context, physical user container. | `applet-user:<appletId>:<userId>` | Plain `userId` parsed from the logical context, or explicit `userId` | `applets/<appletId>/<filename>` |
+| `applet-shared` | Current app-shared scope. | `applet-shared:<appletId>` | `applet-shared:<appletId>` | `applet-shared/<filename>` |
+| `profile` | Direct named folder scope. | Caller-selected context. | `contextId \|\| userId` | `profile/<filename>` |
+| `articles` | Direct named folder scope. | Caller-selected context. | `contextId \|\| userId` | `articles/<filename>` |
+| `applets` | Direct named folder scope. | Caller-selected context. | `contextId \|\| userId` | `applets/<filename>` |
+| `skills` | Direct named folder scope in CFH only. | Caller-selected context. | `contextId \|\| userId` | `skills/<filename>` |
+| `workspace-shared-legacy` | Legacy shared workspace artifact scope. | `workspaceId` | `workspaceId` | `/` in the workspace-owned container |
+
+## Generic Compatibility
+
+- Legacy owner-container naming:
+  - `listFolder` merges current-container results with legacy-alias-container results.
+  - `delete`/`rename`/`setRetention` by `blobPath` falls back to the legacy-alias container if the current container misses.
+- Generic default-root blob self-heal:
+  - Direct `blobPath` lookup, and `checkHash` when Redis misses but a `blobPath` is present, also probe `BASE` (the unscoped default container root).
+  - If a blob is found there, CFH returns it, ensures a fresh GCS backup, and, when the canonical target differs, copies it into the canonical current container/path. Redis metadata is written when a hash was supplied.
+
+## Scope-Specific Compatibility / Migration
+
+- `workspace-user-legacy` has extra legacy compatibility:
+  - On `checkHash`, if the current context misses, CFH also probes the old Redis context `workspaceId:userId`.
+  - If that old Redis record exists, CFH re-uploads the bytes into the current `workspace-user-legacy` location, writes Redis under the current logical context, and removes the old Redis entry.
+  - On blob lookup, CFH also probes the old compound-context Azure container derived from `workspaceId:userId`, then self-heals the blob into the canonical current location.
+- `applet-user` does not have a same-scope CFH migration from the older app-private layout.
+  - Backward compatibility for old app-private files lives in Cortex `fileAccessPlan` expansion: `kind: app-private` reads both `applet-user` and `workspace-user-legacy` when `workspaceId` is available.
+  - Current writes go to `applet-user` when `appletId` is available; otherwise they fall back to `workspace-user-legacy`.
+- `applet-shared` and `workspace-shared-legacy` do not have a CFH migration between them.
+  - Backward compatibility for old shared app/workspace files lives in Cortex `fileAccessPlan` expansion: `kind: app-shared` reads both `applet-shared` and `workspace-shared-legacy`.
+  - Current writes go to `applet-shared` when `appletId` is available; otherwise they fall back to `workspace-shared-legacy`.
+- `global`, `media`, `chat`, `profile`, `articles`, `applets`, `skills`, and `workspace-shared-legacy` have no extra scope-specific migration beyond the generic rules above.
+
+## Current `fileAccessPlan` Expansion
+
+| `kind` | Read targets | Write target |
+| --- | --- | --- |
+| `chat` | `chat` | `chat` |
+| `user-global` | `global` | `global` |
+| `app-private` | `applet-user`, then `workspace-user-legacy` if `workspaceId` exists | `applet-user` if `appletId` exists, else `workspace-user-legacy` |
+| `app-shared` | `applet-shared` container root via `readFileScope=all`, plus `workspace-shared-legacy` container root via `readFileScope=all` if `workspaceId` exists | `applet-shared` if `appletId` exists, else `workspace-shared-legacy` |
+
+## Notes
+
+- `applet-shared` writes into `applet-shared/`, but current `kind: app-shared` reads the whole `applet-shared` container root via `readFileScope=all`.
+- `workspace-shared-legacy` reads and writes the workspace-owned container root.
+- `skills` exists in CFH path construction, but `lib/fileUtils.js` does not currently expose a `skills` case.
+- `media`, `profile`, `articles`, `applets`, and `skills` are direct folder scopes; current `resolveFileAccessTargetCandidates()` does not emit them from `fileAccessPlan` kinds.
+
+## Source of Truth
+
+- `lib/fileUtils.js`
+- `helper-apps/cortex-file-handler/src/blobHandler.js`
+- `helper-apps/cortex-file-handler/src/index.js`
+- `helper-apps/cortex-file-handler/src/utils/legacyWorkspacePrivateResolver.js`
+- `helper-apps/cortex-file-handler/src/constants.js`

--- a/docs/media-generation-contract.md
+++ b/docs/media-generation-contract.md
@@ -1,0 +1,87 @@
+# Media Generation Contract
+
+## Veo Video Extension
+
+Veo video extension is exposed through the existing `media_generate` pathway and
+the `CreateMedia` entity tool.
+
+### Model Metadata
+
+`sys_model_metadata(category: "video")` exposes extension-capable Veo models with:
+
+```json
+{
+  "modelId": "veo-3.1-generate",
+  "mediaDefaults": {
+    "inputImages": [0, 3],
+    "inputVideos": [0, 1],
+    "aspectRatio": "16:9",
+    "duration": 8,
+    "resolution": "720p",
+    "generateAudio": true
+  },
+  "videoInputModes": ["extend"],
+  "preferredUrlFormat": "gcs"
+}
+```
+
+`inputVideos: [0, 1]` means callers may attach at most one input video. For Veo,
+that video is treated as an extension source, not as a generic style reference.
+The UI should prefer the models whose `videoInputModes` includes `"extend"`.
+The current Cortex Veo 3.1 models all expose this mode:
+`veo-3.1-generate`, `veo-3.1-fast-generate`, and
+`veo-3.1-lite-generate`.
+
+### `media_generate`
+
+To extend a video directly, call `media_generate` with:
+
+```json
+{
+  "model": "veo-3.1-generate",
+  "text": "Continue the camera move as the subject enters the garden.",
+  "inputVideos": ["gs://bucket/path/base.mp4"],
+  "resolution": "720p"
+}
+```
+
+The provider-facing Veo payload receives:
+
+```json
+{
+  "instances": [
+    {
+      "prompt": "...",
+      "video": {
+        "gcsUri": "gs://bucket/path/base.mp4",
+        "mimeType": "video/mp4"
+      }
+    }
+  ],
+  "parameters": {
+    "resolution": "720p",
+    "generateAudio": true
+  }
+}
+```
+
+`media_generate` also accepts a `data:video/mp4;base64,...` input video and maps
+it to Veo `inlineData`, but GCS input is preferred and is what model metadata
+advertises.
+
+### `CreateMedia`
+
+For agent/tool use, pass one `referenceVideos` item:
+
+```json
+{
+  "type": "video",
+  "prompt": "Continue the clip into a wide shot of the garden.",
+  "referenceVideos": ["base.mp4"],
+  "userMessage": "Extending the video"
+}
+```
+
+`CreateMedia` resolves the file through `fileAccessPlan` with `preferGcs: true`
+and calls `video_veo` using `veo-3.1-generate`. The output is uploaded and added
+to the file collection like normal generated videos.

--- a/lib/entityConstants.js
+++ b/lib/entityConstants.js
@@ -16,37 +16,29 @@ Your responses should be in {{language}} unless the user has expressed another p
 
     AI_CONVERSATION_HISTORY: "# Conversation History\n\n{{{toJSON chatHistory}}}\n",
 
-    AI_EXPERTISE: "# Expertise\n\nYou have access to real-time data and the ability to search the internet, news, wires, look at files or documents, watch and analyze video, examine images, take screenshots, generate images, solve hard math and logic problems, help with coding, and write and execute code in a sandboxed environment that includes access to internal databases and the internet. When the user uploads files for you to work with, some types (e.g. docx, xslx, ppt, etc.) will be converted to either pdf or a text format (e.g. txt, md, csv, etc.) automatically and some will be uploaded as-is (e.g. pdf, images, video, audio, etc.). This is so you can use your tools to work with them. As far as you're concerned, the converted files are equivalent to the original files.",
+    AI_EXPERTISE: "# Expertise\n\nYou have access to real-time data and the ability to search the internet, news, wires, look at files or documents, watch and analyze video, examine images, take screenshots, generate images, solve hard math and logic problems, help with coding, and write and execute code in a sandboxed environment. You have a persistent Linux workspace (Debian container) with Python 3, pip, Node.js, and common tools pre-installed. Use it proactively - whenever a question involves computation, data analysis, file processing, or anything you can verify by running code, use your workspace rather than guessing. For research tasks, you may keep concise scratch notes in /workspace/research-notes.md to reuse facts synthesized from recent tool results instead of re-querying the same sources. You can install any additional packages you need with pip or apt.",
 
     AI_TOOLS: `# Tool Instructions
 
-- Your tools work most efficiently when called in parallel so if you know you will need multiple tool calls try to call them in parallel where possible.
+- IMPORTANT: Call ALL tools you need in a SINGLE response - do not wait for one result before calling another unrelated tool.
 - Always honor user requests to use specific tools.
-- You must always search if you are being asked questions about current events, news, fact-checking, or information requiring citation.
-- Do not make up, hallucinate, or fabricate information - if information cannot be confirmed with rigorous logic or direct sources, do not include it in your response.
-- If a tool fails or has a technical difficulty, try to fix the problem or call a different or backup tool before giving up or reporting the error.
-- Don't settle for the first plausible answer — dig until the data is complete, corroborated, and clear.
+- Search for current events, news, and fact-checks - never fabricate information.
+- When a question involves math, computation, data analysis, or anything you can verify by running code, use your workspace to compute the answer. Compute, don't guess.
+- If a tool fails, retry or switch to a different tool before giving up.
 - Deliver concise, well-structured responses with complete citations.
-- Double-check accuracy, coherence, and alignment with the user request.
 - For simple diagrams and charts, you don't need to call your code execution tool - you can just call your charting tool to generate the chart.
-- For data processing requests (e.g. tell me how many articles were published in the last 30 days), or deep file analysis (chart the trends in this spreadsheet, etc.), you should call your code execution tool to perform the task - especially if the task requires a lot of data, deep analysis, complex filtering, or precision calculations.
-- If you know you are running in non-interactive mode (like processing a digest or applet request), do not call your CodeExecution tool as it creates background tasks that cannot be viewed by the user in that mode.`,            
+- IMPORTANT: When generating slides, charts, or visual content, the generation model CANNOT see your conversation history or files. You MUST include ALL data, text, and values directly in the tool parameters. Never say "use the data above" - spell out every data point.
+- When a tool returns a displayMarkdown field, include it verbatim in your response to show the generated content to the user.
+- NEVER fabricate or guess file URLs. When you create files in /workspace/files/ and need a cloud URL or file metadata, resolve that workspace path explicitly with FileCollection using fileRef: "/workspace/files/...". If a tool returns displayMarkdown, include it verbatim in your response.`,            
 
     AI_SEARCH_RULES: `# Search Instructions
-- When searching, start by making a search plan of all relevant information from multiple sources with multiple queries and then execute multiple tool calls in parallel to execute the searches.
-- Keep searching until you have all the information you need - adjust the plan as needed at every step.
-- If you don't get good results from one query or source, vary the query terms and try different approaches - e.g. broadening the date range or searching for a related set of terms.
-- Confirm that multiple sources tell the same story.
-- Search the same sources multiple times with different terms to get a complete picture.
-- Confirm the publication date.
-- Apply date filters to surface the most recent credible material.
-- If the results are relevant, but not complete, try a different search with different terms.
-
-# Web / Internet / Social searches
-- for news: include explicit date/timeframe and geography for targeted, current coverage (“US news headlines August 20 2025”). Use “summary,” “overview,” “trends,” or “breaking/latest” to control breadth and recency
-- for non-news/company/tech: specify the aspect or attribute needed (“technology overview,” “funding history,” “competitor analysis”), add output preferences (“in bullet points,” “detailed review”), and include date/context for freshness (“2025,” “latest update”)
-- for social and monetized platforms (YouTube, TikTok, Instagram, Reddit, etc.) - try to corroborate the information with multiple posts or at least one authoritative source
-- for high-stakes, complex, or time-sensitive topics, never rely on snippets or summaries - always use your tools to open and read the full article or document
+- CRITICAL: Call ALL your search tools in ONE response. Never call one search, wait for results, then call another.
+- Plan multiple queries across sources before calling tools.
+- Iterate queries if results are weak or incomplete - vary terms, broaden date ranges, try related concepts.
+- Corroborate key facts across multiple sources; check publication dates.
+- Use date filters for recency when relevant.
+- For high-stakes or time-sensitive topics, read full sources - don't rely on snippets.
+- Social/monetized sources (YouTube, Reddit, TikTok) require corroboration with authoritative sources.
 `,
 
     AI_SEARCH_SYNTAX: `# AI Search Syntax

--- a/pathways/media_prompt_assistant.js
+++ b/pathways/media_prompt_assistant.js
@@ -1,0 +1,173 @@
+import { Prompt } from '../server/prompt.js';
+
+const MEDIA_TYPE_GUIDANCE = {
+  image: `Generic image guidance:
+- Write a detailed still-image prompt with subject, environment, composition, camera/lens or design style, lighting, mood, and intended use.
+- Prefer positive instructions over negative lists.
+- If references are present, describe how they should be used without claiming to know unseen details.`,
+  video: `Generic video guidance:
+- Write like a director: subject, action, environment, camera motion, visual style, pacing, and temporal change.
+- Keep the prompt concise enough for video generation while specifying motion separately from camera movement.
+- If references are present, make their role explicit as visual, motion, timing, or style references without inventing unseen contents.`,
+  audio: `Generic audio guidance:
+- Write a ready-to-submit music or sound prompt using genre/style, mood, instrumentation, tempo/rhythm, arrangement, soundscape, and production quality.
+- Use musical language, not hidden model settings or JSON.
+- If references are present, describe them as inspiration for mood, pacing, texture, or rhythm without claiming to know unseen contents.`,
+  tts: `Generic text-to-speech guidance:
+- Write a ready-to-submit speech synthesis prompt whose output is spoken audio, not music or sound design.
+- Preserve the exact words the user wants spoken unless they explicitly ask for rewriting.
+- Separate performance direction from the spoken transcript so the model knows what to synthesize and what not to read aloud.
+- Use natural-language performance direction for style, tone, accent, pace, emotion, pronunciation, and pauses.`,
+};
+
+const MODEL_RULES = [
+  {
+    match: /gemini.*image|image_gemini|gemini-flash-25-image|gemini-flash-31-image|gemini-pro-3-image/i,
+    guidance: `Gemini image guidance:
+- Expand vague requests into highly specific professional image prompts.
+- Include subject, action/expression, setting, lighting, mood, camera/composition, visual details, and output intent.
+- For editing or reference-image requests, preserve the user's requested relationship to the provided image and avoid over-describing the unseen reference.
+- Use positive semantic language and clear step-by-step composition when the scene is complex.`,
+  },
+  {
+    match: /lyria|music_lyria|google-lyria/i,
+    guidance: `Lyria guidance:
+- Return one natural-language music prompt only.
+- Use genre/style, mood, instrumentation, tempo/rhythm, arrangement, soundscape, and production quality.
+- Preserve requested facts, editorial purpose, language, vocals, lyrics, and constraints.
+- Do not invent artist names, copyrighted songs, hidden controls, labels, JSON, markdown, or metadata.`,
+  },
+  {
+    match: /google-gemini-3\.1-flash-tts|gemini.*flash.*tts|gemini.*tts|tts_gemini/i,
+    guidance: `Gemini TTS guidance:
+- Return one ready-to-submit Gemini TTS prompt only. The prompt may include labeled sections when they help separate performance direction from transcript, but do not add explanations outside the prompt.
+- Start with a clear synthesis instruction such as "Synthesize the spoken audio for the transcript below." This prevents the model from reading director's notes aloud or rejecting vague prompts.
+- Clearly label the actual spoken text with "TRANSCRIPT:" or "#### TRANSCRIPT" and put only words intended to be spoken in that section.
+- For simple single-speaker requests, include concise direction before the transcript for tone, style, accent, pace, emotion, and delivery.
+- For richer voice work, use the Gemini TTS structure: AUDIO PROFILE, SCENE, DIRECTOR'S NOTES, SAMPLE CONTEXT if useful, and TRANSCRIPT.
+- Use audio tags in square brackets where helpful, such as [whispers], [laughs], [short pause], [long pause], [excitedly], [serious], [slow], or [fast]. Use English tags even when the transcript is in another language.
+- For multi-speaker prompts, keep speaker names exactly consistent between the transcript and configured speakers. Use at most two speakers.
+- Keep the written tone, character profile, and selected voice compatible so the requested performance does not fight the voice.
+- Avoid over-specifying every detail; prioritize the few performance directions that matter most.
+- Do not include model settings, response modalities, voiceName values, JSON, file instructions, base64, sample rate, or post-processing commands in the prompt text.`,
+  },
+  {
+    match: /replicate-qwen3-tts|qwen.*tts|tts_replicate/i,
+    guidance: `Qwen3 TTS guidance:
+- Return speakable transcript text for Qwen3 TTS, not JSON or API field names.
+- Preserve the exact words the user wants spoken unless they explicitly ask for rewriting.
+- Keep performance direction concise and compatible with the separate style_instruction, speaker, language, and voice mode controls. If the user gives style direction in the prompt, fold only essential delivery cues into natural speech-safe wording.
+- For custom_voice mode, do not name a speaker inside the transcript unless the words should be spoken aloud.
+- For voice_clone mode, do not describe the reference audio in the transcript; use the transcript only for the new speech content.
+- For voice_design mode, keep voice-description material out of the spoken transcript unless the user explicitly wants it read aloud.
+- Do not include model settings, mode, speaker, language, reference_audio, reference_text, style_instruction, voice_description, URLs, base64, sample rate, or post-processing commands in the prompt text.`,
+  },
+  {
+    match: /seedance.*2|replicate-seedance-2/i,
+    guidance: `Seedance 2.0 guidance:
+- Write a concise director-style video prompt with subject, action, environment, camera movement, pacing, style, and safety-conscious constraints.
+- Keep the wording neutral, consent-safe, non-graphic, and non-deceptive.
+- Avoid real-person impersonation, named public figures, copyrighted character claims, sexualized framing, graphic violence, political persuasion, sensitive identity claims, and instructions that appear to bypass moderation.
+- If the user's permitted intent is ambiguous, rewrite toward a generic fictional subject, staged scene, or consent-cleared actor/character.
+- Avoid loaded words that could be misread as violent, adult, exploitative, or deceptive when neutral production language will do.
+- Preserve the creative goal, but make the prompt safer and clearer rather than evasive.`,
+  },
+];
+
+function normalizeMediaType(mediaType = '') {
+  const value = String(mediaType || '').toLowerCase();
+  if (value === 'image' || value === 'video' || value === 'audio' || value === 'tts') return value;
+  return 'image';
+}
+
+function getModelGuidance(model = '') {
+  const modelId = String(model || '');
+  return MODEL_RULES.filter((rule) => rule.match.test(modelId))
+    .map((rule) => rule.guidance)
+    .join('\n\n');
+}
+
+function buildReferenceSummary(input) {
+  const references = Array.isArray(input.references) ? input.references : [];
+  const referenceRoles = Array.isArray(input.referenceRoles) ? input.referenceRoles : [];
+  const count = references.length || Number(input.referenceCount || 0);
+  if (count > 0) {
+    const roles = [...new Set(referenceRoles.filter(Boolean))];
+    const roleText = roles.length > 0 ? ` Roles: ${roles.join(', ')}.` : '';
+    return `The user has selected ${count} media reference${count === 1 ? '' : 's'}.${roleText}`;
+  }
+  if (input.hasInputImages) {
+    return 'The user has selected one or more image references.';
+  }
+  return 'The user has not selected media references.';
+}
+
+export default {
+  prompt: [],
+
+  executePathway: async ({ args, runAllPrompts, resolver }) => {
+    const input = { ...resolver.pathway.inputParameters, ...args };
+    const prompt = String(input.prompt || input.userPrompt || '').trim();
+    const mediaType = normalizeMediaType(input.mediaType || input.task || input.category);
+    const model = String(input.model || '').trim();
+    const referenceSummary = buildReferenceSummary(input);
+    const action = prompt ? 'optimize' : 'generate';
+    const modelGuidance = getModelGuidance(model);
+
+    const systemContent = `You are a media prompt assistant for image, video, audio, and text-to-speech generation.
+
+Your job is to ${action === 'optimize' ? 'rewrite the user prompt into a stronger ready-to-submit generation prompt' : 'create one ready-to-submit prompt from scratch'}.
+
+Return only the final prompt text. Do not return explanations, JSON, bullet points, or quotes. Do not use labels or markdown unless the model-specific guidance explicitly asks for labeled prompt sections.
+
+General rules:
+- Preserve the user's permitted intent.
+- Do not add hidden settings, unsupported parameters, seed values, or UI instructions.
+- Do not include policy-bypass language or instructions to evade safety systems.
+- Be specific, concrete, and production-ready.
+- Keep references abstract unless their content is described by the user.
+
+${MEDIA_TYPE_GUIDANCE[mediaType]}
+
+${modelGuidance || 'No model-specific guidance is configured for this model; use the generic media guidance.'}
+
+Context:
+- Media type: ${mediaType}
+- Model: ${model || 'unknown'}
+- References: ${referenceSummary}
+- Current date and time: {{now}}`;
+
+    const userContent = prompt
+      ? `Optimize this ${mediaType} prompt for ${model || 'the selected model'}:\n\n${prompt}`
+      : `Generate a strong starter ${mediaType} prompt for ${model || 'the selected model'}.`;
+
+    resolver.pathwayPrompt = [
+      new Prompt({
+        messages: [
+          { role: 'system', content: systemContent },
+          { role: 'user', content: userContent },
+        ],
+      }),
+    ];
+
+    return await runAllPrompts({ ...args });
+  },
+
+  inputParameters: {
+    prompt: '',
+    userPrompt: '',
+    mediaType: '',
+    task: '',
+    category: '',
+    model: '',
+    references: { type: 'array', items: { type: 'string' } },
+    referenceRoles: { type: 'array', items: { type: 'string' } },
+    hasInputImages: false,
+    referenceCount: 0,
+  },
+  max_tokens: 2048,
+  model: 'oai-gpt4o',
+  useInputChunking: false,
+  enableDuplicateRequests: false,
+  timeout: 30,
+};

--- a/pathways/media_prompt_tags.js
+++ b/pathways/media_prompt_tags.js
@@ -1,0 +1,35 @@
+import { Prompt } from '../server/prompt.js';
+
+export default {
+    prompt: [
+        new Prompt({
+            messages: [
+                {
+                    role: 'system',
+                    content: `You generate concise organization tags for AI-generated media prompts.
+
+Return only a valid JSON array of 3 to 8 strings.
+
+Rules:
+- Tags must be lowercase.
+- Prefer concrete subjects, style, location, mood, medium, and key objects.
+- Each tag must be 1 to 3 words.
+- Do not include generic tags like "image", "video", "media", "prompt", or "generation".
+- Do not include markdown, commentary, or an object wrapper.`,
+                },
+                {
+                    role: 'user',
+                    content: `Prompt:\n{{{text}}}`,
+                },
+            ],
+        }),
+    ],
+    inputParameters: {
+        text: '',
+        model: 'oai-gpt4o',
+    },
+    json: true,
+    temperature: 0,
+    enableDuplicateRequests: false,
+    timeout: 60,
+};

--- a/tests/unit/core/fileAccessRouting.test.js
+++ b/tests/unit/core/fileAccessRouting.test.js
@@ -1,0 +1,106 @@
+import test from 'ava';
+
+process.env.WHISPER_MEDIA_API_URL = 'http://media-helper.test';
+
+let requestExecutorModulePromise;
+let fileUtilsModulePromise;
+
+async function loadRequestExecutor() {
+    if (!requestExecutorModulePromise) {
+        requestExecutorModulePromise = import('../../../lib/requestExecutor.js');
+    }
+    return await requestExecutorModulePromise;
+}
+
+async function loadFileUtils() {
+    if (!fileUtilsModulePromise) {
+        fileUtilsModulePromise = import('../../../lib/fileUtils.js');
+    }
+    return await fileUtilsModulePromise;
+}
+
+test.serial('listFilesForContext forwards applet-user routing hints to CFH', async t => {
+    const { axios } = await loadRequestExecutor();
+    const { listFilesForContext } = await loadFileUtils();
+    const originalGet = axios.get;
+    let capturedUrl = null;
+
+    axios.get = async (url) => {
+        capturedUrl = url;
+        return { data: { files: [] } };
+    };
+
+    try {
+        const files = await listFilesForContext(
+            'applet-user:applet-123:user-456',
+            {
+                userId: 'user-456',
+                appletId: 'applet-123',
+                fileScope: 'applet-user',
+            },
+        );
+
+        t.deepEqual(files, []);
+        t.truthy(capturedUrl);
+
+        const url = new URL(capturedUrl);
+        t.is(url.searchParams.get('listFolder'), 'true');
+        t.is(url.searchParams.get('contextId'), 'applet-user:applet-123:user-456');
+        t.is(url.searchParams.get('userId'), 'user-456');
+        t.is(url.searchParams.get('appletId'), 'applet-123');
+        t.is(url.searchParams.get('fileScope'), 'applet-user');
+    } finally {
+        axios.get = originalGet;
+    }
+});
+
+test.serial('user-files file access target lists the full user file share read-only', async t => {
+    const { axios } = await loadRequestExecutor();
+    const { getWriteFileAccessTarget, listFilesForFileAccessPlan } = await loadFileUtils();
+    const originalGet = axios.get;
+    let capturedUrl = null;
+
+    axios.get = async (url) => {
+        capturedUrl = url;
+        return {
+            data: {
+                files: [
+                    {
+                        name: 'frog-copy.png',
+                        hash: 'frog-hash',
+                        url: 'https://files.test/media/frog-copy.png',
+                    },
+                ],
+            },
+        };
+    };
+
+    const fileAccessPlan = [
+        { kind: 'chat', userContextId: 'user-456', chatId: 'chat-123', write: true },
+        { kind: 'user-files', userContextId: 'user-456' },
+    ];
+
+    try {
+        const writeTarget = getWriteFileAccessTarget(fileAccessPlan);
+        t.is(writeTarget.kind, 'chat');
+        t.is(writeTarget.writeFileScope, 'chat');
+
+        const files = await listFilesForFileAccessPlan([
+            { kind: 'user-files', userContextId: 'user-456' },
+        ]);
+
+        t.is(files.length, 1);
+        t.is(files[0]._fileAccessKind, 'user-files');
+        t.is(files[0]._readFileScope, 'all');
+        t.false(files[0]._writeTarget);
+        t.truthy(capturedUrl);
+
+        const url = new URL(capturedUrl);
+        t.is(url.searchParams.get('listFolder'), 'true');
+        t.is(url.searchParams.get('contextId'), 'user-456');
+        t.is(url.searchParams.get('userId'), 'user-456');
+        t.is(url.searchParams.get('fileScope'), 'all');
+    } finally {
+        axios.get = originalGet;
+    }
+});

--- a/tests/unit/lib/modelRequestLog.test.js
+++ b/tests/unit/lib/modelRequestLog.test.js
@@ -1,0 +1,132 @@
+import test from 'ava';
+import {
+    buildModelRequestPayloadLog,
+    buildProviderStreamEventLog,
+    buildModelRequestErrorSummary,
+    buildModelRequestLogBase,
+    buildModelRequestPayloadSummary,
+} from '../../../lib/modelRequestLog.js';
+
+test('buildModelRequestLogBase summarizes OpenAI Responses requests without prompt payloads', t => {
+    const summary = buildModelRequestLogBase({
+        url: 'https://example.openai.azure.com/openai/v1/responses',
+        data: {
+            model: 'gpt-5.4',
+            stream: true,
+            input: [{ role: 'user', content: 'secret prompt body' }],
+            tools: [
+                { type: 'function', name: 'WorkspaceSSH', description: 'long schema text' },
+                { type: 'function', function: { name: 'SearchInternet' } },
+            ],
+        },
+        traceFields: {
+            requestId: 'req_123',
+            pathway: 'sys_entity_agent',
+            model: 'oai-gpt54',
+            modelType: 'OPENAI-RESPONSES',
+            endpoint: 'EUS2',
+            retry: 0,
+            duplicateIndex: 0,
+        },
+        axiosConfigObj: {
+            responseType: 'stream',
+        },
+    });
+
+    t.like(summary, {
+        requestId: 'req_123',
+        pathway: 'sys_entity_agent',
+        model: 'oai-gpt54',
+        modelType: 'OPENAI-RESPONSES',
+        endpointHost: 'example.openai.azure.com',
+        endpointPath: '/openai/v1/responses',
+        apiFamily: 'openai_responses',
+        stream: true,
+        inputCount: 1,
+        toolCount: 2,
+    });
+    t.deepEqual(summary.toolNames, ['WorkspaceSSH', 'SearchInternet']);
+    t.false(JSON.stringify(summary).includes('secret prompt body'));
+    t.false(JSON.stringify(summary).includes('long schema text'));
+});
+
+test('buildModelRequestPayloadSummary captures shape for chat payloads', t => {
+    const summary = buildModelRequestPayloadSummary({
+        model: 'gpt-5.4',
+        messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    t.deepEqual(summary.payloadKeys, ['messages', 'model']);
+    t.is(summary.messageCount, 1);
+    t.is(summary.stream, false);
+});
+
+test('buildModelRequestErrorSummary extracts provider error fields', t => {
+    const summary = buildModelRequestErrorSummary({
+        status: 400,
+        error: new Error('fallback message'),
+        responseData: {
+            error: {
+                message: "Unknown parameter: 'stream_options.include_usage'.",
+                type: 'invalid_request_error',
+                param: 'stream_options.include_usage',
+                code: 'unknown_parameter',
+            },
+        },
+    });
+
+    t.like(summary, {
+        status: 400,
+        errorCode: 'unknown_parameter',
+        errorType: 'invalid_request_error',
+        errorParam: 'stream_options.include_usage',
+        message: "Unknown parameter: 'stream_options.include_usage'.",
+    });
+});
+
+test('buildModelRequestPayloadLog formats full debug payloads as structured events', t => {
+    const log = buildModelRequestPayloadLog({
+        method: 'POST',
+        url: 'https://example.openai.azure.com/openai/v1/responses?api-key=secret&api-version=2025-03-01-preview',
+        data: {
+            input: [{ role: 'user', content: 'full prompt body' }],
+        },
+    });
+
+    t.like(log, {
+        event: 'model_request_payload',
+        method: 'POST',
+        endpointHost: 'example.openai.azure.com',
+        endpointPath: '/openai/v1/responses',
+    });
+    t.is(log.data.input[0].content, 'full prompt body');
+    t.true(log.url.includes('api-key=******'));
+    t.true(log.url.includes('api-version=2025-03-01-preview'));
+});
+
+test('buildProviderStreamEventLog formats raw stream events as structured events', t => {
+    const log = buildProviderStreamEventLog({
+        requestId: 'root_req',
+        resolverRequestId: 'resolver_req',
+        pathway: 'sys_entity_agent',
+        model: 'oai-gpt55',
+        event: {
+            type: 'event',
+            id: 'evt_123',
+            name: 'response.completed',
+            data: '{"usage":{"input_tokens":10}}',
+        },
+    });
+
+    t.deepEqual(log, {
+        event: 'provider_stream_event',
+        requestId: 'root_req',
+        resolverRequestId: 'resolver_req',
+        pathway: 'sys_entity_agent',
+        model: 'oai-gpt55',
+        parserEventType: 'event',
+        streamEventId: 'evt_123',
+        streamEventName: 'response.completed',
+        data: '{"usage":{"input_tokens":10}}',
+    });
+});

--- a/tests/unit/pathways/mediaPromptAssistant.test.js
+++ b/tests/unit/pathways/mediaPromptAssistant.test.js
@@ -1,0 +1,129 @@
+import test from "ava";
+import mediaPromptAssistant from "../../../pathways/media_prompt_assistant.js";
+
+function createResolver() {
+  return {
+    pathway: {
+      inputParameters: mediaPromptAssistant.inputParameters,
+    },
+  };
+}
+
+test("media prompt assistant uses the default OpenAI vision model", (t) => {
+  t.is(mediaPromptAssistant.model, "oai-gpt4o");
+});
+
+test("media prompt assistant optimizes supplied prompts with model and reference context", async (t) => {
+  const resolver = createResolver();
+
+  const result = await mediaPromptAssistant.executePathway({
+    args: {
+      prompt: "make this more cinematic",
+      mediaType: "video",
+      model: "replicate-seedance-2.0",
+      references: ["https://example.com/reference.jpg"],
+      referenceRoles: ["start_frame"],
+    },
+    resolver,
+    runAllPrompts: async () => "optimized prompt",
+  });
+
+  t.is(result, "optimized prompt");
+  const [systemMessage, userMessage] = resolver.pathwayPrompt[0].messages;
+  t.regex(systemMessage.content, /Media type: video/);
+  t.regex(systemMessage.content, /Model: replicate-seedance-2\.0/);
+  t.regex(systemMessage.content, /Roles: start_frame/);
+  t.regex(systemMessage.content, /Seedance 2\.0 guidance/);
+  t.regex(systemMessage.content, /evade safety systems/);
+  t.regex(userMessage.content, /Optimize this video prompt/);
+  t.regex(userMessage.content, /make this more cinematic/);
+});
+
+test("media prompt assistant generates a starter prompt when prompt is empty", async (t) => {
+  const resolver = createResolver();
+
+  await mediaPromptAssistant.executePathway({
+    args: {
+      prompt: "",
+      mediaType: "audio",
+      model: "google-lyria-3-music",
+      hasInputImages: true,
+    },
+    resolver,
+    runAllPrompts: async () => "starter prompt",
+  });
+
+  const [systemMessage, userMessage] = resolver.pathwayPrompt[0].messages;
+  t.regex(systemMessage.content, /Generic audio guidance/);
+  t.regex(systemMessage.content, /Lyria guidance/);
+  t.regex(systemMessage.content, /one or more image references/);
+  t.regex(userMessage.content, /Generate a strong starter audio prompt/);
+});
+
+test("media prompt assistant applies Gemini TTS prompting conventions", async (t) => {
+  const resolver = createResolver();
+
+  await mediaPromptAssistant.executePathway({
+    args: {
+      prompt: "read this as an urgent news explainer: the talks resumed at dawn",
+      mediaType: "tts",
+      model: "google-gemini-3.1-flash-tts",
+    },
+    resolver,
+    runAllPrompts: async () => "tts prompt",
+  });
+
+  const [systemMessage, userMessage] = resolver.pathwayPrompt[0].messages;
+  t.regex(systemMessage.content, /Media type: tts/);
+  t.regex(systemMessage.content, /Generic text-to-speech guidance/);
+  t.regex(systemMessage.content, /Gemini TTS guidance/);
+  t.regex(systemMessage.content, /Synthesize the spoken audio for the transcript below/);
+  t.regex(systemMessage.content, /TRANSCRIPT/);
+  t.regex(systemMessage.content, /AUDIO PROFILE/);
+  t.regex(systemMessage.content, /DIRECTOR'S NOTES/);
+  t.regex(systemMessage.content, /\[whispers\]/);
+  t.regex(systemMessage.content, /Use at most two speakers/);
+  t.regex(systemMessage.content, /Do not include model settings/);
+  t.regex(userMessage.content, /Optimize this tts prompt/);
+});
+
+test("media prompt assistant infers Gemini TTS guidance even when category is generic audio", async (t) => {
+  const resolver = createResolver();
+
+  await mediaPromptAssistant.executePathway({
+    args: {
+      prompt: "",
+      category: "audio",
+      model: "tts_gemini",
+    },
+    resolver,
+    runAllPrompts: async () => "starter prompt",
+  });
+
+  const [systemMessage] = resolver.pathwayPrompt[0].messages;
+  t.regex(systemMessage.content, /Generic audio guidance/);
+  t.regex(systemMessage.content, /Gemini TTS guidance/);
+  t.notRegex(systemMessage.content, /Lyria guidance/);
+});
+
+test("media prompt assistant applies Qwen3 TTS prompting guidance", async (t) => {
+  const resolver = createResolver();
+
+  await mediaPromptAssistant.executePathway({
+    args: {
+      prompt: "say hello in an excited preset voice",
+      mediaType: "tts",
+      model: "replicate-qwen3-tts",
+    },
+    resolver,
+    runAllPrompts: async () => "qwen tts prompt",
+  });
+
+  const [systemMessage, userMessage] = resolver.pathwayPrompt[0].messages;
+  t.regex(systemMessage.content, /Generic text-to-speech guidance/);
+  t.regex(systemMessage.content, /Qwen3 TTS guidance/);
+  t.regex(systemMessage.content, /style_instruction, speaker, language, and voice mode controls/);
+  t.regex(systemMessage.content, /Do not include model settings/);
+  t.notRegex(systemMessage.content, /Gemini TTS guidance/);
+  t.regex(userMessage.content, /Optimize this tts prompt/);
+});

--- a/tests/unit/pathways/mediaPromptTags.test.js
+++ b/tests/unit/pathways/mediaPromptTags.test.js
@@ -1,0 +1,17 @@
+import test from "ava";
+import mediaPromptTags from "../../../pathways/media_prompt_tags.js";
+
+test("media prompt tags uses an upstream configured default model", (t) => {
+  t.is(mediaPromptTags.inputParameters.model, "oai-gpt4o");
+});
+
+test("media prompt tags requests concise JSON tag arrays", (t) => {
+  t.true(mediaPromptTags.json);
+  t.is(mediaPromptTags.temperature, 0);
+
+  const [systemMessage, userMessage] = mediaPromptTags.prompt[0].messages;
+  t.regex(systemMessage.content, /valid JSON array/);
+  t.regex(systemMessage.content, /3 to 8 strings/);
+  t.regex(systemMessage.content, /Tags must be lowercase/);
+  t.regex(userMessage.content, /Prompt:/);
+});

--- a/tests/unit/rest/anthropicMessagesStreaming.test.js
+++ b/tests/unit/rest/anthropicMessagesStreaming.test.js
@@ -1,0 +1,657 @@
+// anthropicMessagesStreaming.test.js
+// Unit tests for Anthropic Messages API streaming + conversion fixes
+
+import test from 'ava';
+import pubsub from '../../../server/pubsub.js';
+import { requestState } from '../../../server/requestState.js';
+import {
+    processIncomingAnthropicStream,
+    convertOpenAIResultToAnthropicMessage,
+    convertAnthropicMessagesToOpenAI,
+    mapStopReason,
+    convertAnthropicToolsToOpenAI,
+    isServerSideTool,
+} from '../../../server/rest/anthropicMessagesRoute.js';
+
+// --- Helpers ---
+
+const createMockRes = () => {
+    const writes = [];
+    return {
+        writes,
+        writableEnded: false,
+        setHeader() {},
+        flushHeaders() {},
+        write(chunk) { writes.push(chunk); },
+        end() { this.writableEnded = true; },
+    };
+};
+
+const createMockReq = () => ({
+    path: '/v1/messages',
+    body: {}
+});
+
+const parseSSEEvents = (writes) => {
+    const raw = writes.join('');
+    const frames = raw.split(/\n\n/).filter(f => f.trim());
+    const events = [];
+    for (const frame of frames) {
+        const lines = frame.split('\n');
+        let eventName = null;
+        const dataLines = [];
+        for (const line of lines) {
+            if (line.startsWith('event: ')) eventName = line.slice('event: '.length);
+            else if (line.startsWith('data: ')) dataLines.push(line.slice('data: '.length));
+        }
+        if (dataLines.length) {
+            try {
+                events.push({ event: eventName, data: JSON.parse(dataLines.join('\n')) });
+            } catch (_) {
+                events.push({ event: eventName, data: dataLines.join('\n') });
+            }
+        }
+    }
+    return events;
+};
+
+const seedRequestState = (requestId) => {
+    requestState[requestId] = {
+        resolver: () => {},
+        args: {},
+        useRedis: false,
+        started: false,
+    };
+};
+
+const cleanupRequestState = (requestId) => {
+    delete requestState[requestId];
+};
+
+const simulateEvent = async (requestId, progress, data) => {
+    const payload = typeof data === 'string' ? data : JSON.stringify(data);
+    await pubsub.publish('REQUEST_PROGRESS', {
+        requestProgress: { requestId, progress, data: payload },
+    });
+};
+
+const tick = () => new Promise(r => setTimeout(r, 20));
+
+// ============================================================================
+// 1) Text streaming baseline
+// ============================================================================
+
+test.serial('text streaming: emits correct Anthropic SSE event sequence', async (t) => {
+    const requestId = 'test-anth-text-' + Date.now();
+    const req = createMockReq();
+    const res = createMockRes();
+    seedRequestState(requestId);
+
+    processIncomingAnthropicStream(requestId, req, res, {}, 'claude-3-sonnet');
+    await tick();
+
+    // Send text deltas via OpenAI choices format
+    await simulateEvent(requestId, 0, {
+        choices: [{ delta: { content: 'Hello' }, finish_reason: null }],
+    });
+    await tick();
+    await simulateEvent(requestId, 0, {
+        choices: [{ delta: { content: ' world' }, finish_reason: null }],
+    });
+    await tick();
+
+    // Complete with finish_reason
+    await simulateEvent(requestId, 1, {
+        choices: [{ delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+    await tick();
+
+    const events = parseSSEEvents(res.writes);
+    const eventTypes = events.map(e => e.event);
+
+    // Verify ordering: message_start -> content_block_start -> deltas -> content_block_stop -> message_delta -> message_stop
+    t.true(eventTypes.includes('message_start'), 'should have message_start');
+    t.true(eventTypes.includes('content_block_start'), 'should have content_block_start');
+    t.true(eventTypes.includes('content_block_delta'), 'should have content_block_delta');
+    t.true(eventTypes.includes('content_block_stop'), 'should have content_block_stop');
+    t.true(eventTypes.includes('message_delta'), 'should have message_delta');
+    t.true(eventTypes.includes('message_stop'), 'should have message_stop');
+
+    const startIdx = eventTypes.indexOf('message_start');
+    const stopIdx = eventTypes.lastIndexOf('message_stop');
+    t.true(startIdx < stopIdx);
+
+    // Verify message_start structure
+    const msgStart = events.find(e => e.event === 'message_start');
+    t.is(msgStart.data.message.role, 'assistant');
+    t.is(msgStart.data.message.model, 'claude-3-sonnet');
+
+    // Verify text deltas
+    const deltas = events.filter(e => e.event === 'content_block_delta' && e.data.delta?.type === 'text_delta');
+    const accumulated = deltas.map(e => e.data.delta.text).join('');
+    t.is(accumulated, 'Hello world');
+
+    // Verify content_block_start is text type
+    const blockStart = events.find(e => e.event === 'content_block_start');
+    t.is(blockStart.data.content_block.type, 'text');
+
+    t.true(res.writableEnded);
+    cleanupRequestState(requestId);
+});
+
+// ============================================================================
+// 2) Tool use streaming
+// ============================================================================
+
+test.serial('tool use streaming: emits tool_use content blocks from delta.tool_calls', async (t) => {
+    const requestId = 'test-anth-tool-' + Date.now();
+    const req = createMockReq();
+    const res = createMockRes();
+    seedRequestState(requestId);
+
+    processIncomingAnthropicStream(requestId, req, res, {}, 'claude-3-sonnet');
+    await tick();
+
+    // Send tool call start
+    await simulateEvent(requestId, 0, {
+        choices: [{
+            delta: {
+                tool_calls: [{
+                    index: 0,
+                    id: 'call_abc',
+                    type: 'function',
+                    function: { name: 'get_weather', arguments: '' },
+                }],
+            },
+            finish_reason: null,
+        }],
+    });
+    await tick();
+
+    // Send tool call arguments
+    await simulateEvent(requestId, 0, {
+        choices: [{
+            delta: {
+                tool_calls: [{
+                    index: 0,
+                    function: { arguments: '{"location":"Boston"}' },
+                }],
+            },
+            finish_reason: null,
+        }],
+    });
+    await tick();
+
+    // Complete with tool_calls finish_reason
+    await simulateEvent(requestId, 1, {
+        choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+    await tick();
+
+    const events = parseSSEEvents(res.writes);
+    const eventTypes = events.map(e => e.event);
+
+    // Should have tool_use content_block_start
+    const blockStarts = events.filter(e => e.event === 'content_block_start');
+    const toolBlockStart = blockStarts.find(e => e.data.content_block.type === 'tool_use');
+    t.truthy(toolBlockStart, 'should have tool_use content_block_start');
+    t.is(toolBlockStart.data.content_block.name, 'get_weather');
+
+    // Should have input_json_delta
+    const jsonDeltas = events.filter(e =>
+        e.event === 'content_block_delta' && e.data.delta?.type === 'input_json_delta'
+    );
+    t.true(jsonDeltas.length > 0, 'should have input_json_delta');
+
+    // message_delta should have stop_reason "tool_use"
+    const msgDelta = events.find(e => e.event === 'message_delta');
+    t.is(msgDelta.data.delta.stop_reason, 'tool_use');
+
+    t.true(res.writableEnded);
+    cleanupRequestState(requestId);
+});
+
+// ============================================================================
+// 3) Stop reason mapping
+// ============================================================================
+
+test.serial('stop reason mapping: maps finish reasons correctly', (t) => {
+    t.is(mapStopReason('tool_calls'), 'tool_use');
+    t.is(mapStopReason('function_call'), 'tool_use');
+    t.is(mapStopReason('length'), 'max_tokens');
+    t.is(mapStopReason('max_tokens'), 'max_tokens');
+    t.is(mapStopReason('stop_sequence'), 'stop_sequence');
+    t.is(mapStopReason('stop'), 'end_turn');
+    t.is(mapStopReason(undefined), 'end_turn');
+    t.is(mapStopReason(null), 'end_turn');
+});
+
+test.serial('stop reason mapping in streaming: "length" maps to "max_tokens"', async (t) => {
+    const requestId = 'test-anth-stopreason-' + Date.now();
+    const req = createMockReq();
+    const res = createMockRes();
+    seedRequestState(requestId);
+
+    processIncomingAnthropicStream(requestId, req, res, {}, 'claude-3-sonnet');
+    await tick();
+
+    await simulateEvent(requestId, 0, {
+        choices: [{ delta: { content: 'Hello' }, finish_reason: null }],
+    });
+    await tick();
+
+    // Finish with "length" (OpenAI format for max tokens)
+    await simulateEvent(requestId, 1, {
+        choices: [{ delta: {}, finish_reason: 'length' }],
+        usage: { prompt_tokens: 10, completion_tokens: 4096 },
+    });
+    await tick();
+
+    const events = parseSSEEvents(res.writes);
+    const msgDelta = events.find(e => e.event === 'message_delta');
+    t.is(msgDelta.data.delta.stop_reason, 'max_tokens');
+
+    t.true(res.writableEnded);
+    cleanupRequestState(requestId);
+});
+
+// ============================================================================
+// 5) Usage in message_delta
+// ============================================================================
+
+test.serial('streaming usage: includes input_tokens and output_tokens in message_delta', async (t) => {
+    const requestId = 'test-anth-usage-' + Date.now();
+    const req = createMockReq();
+    const res = createMockRes();
+    seedRequestState(requestId);
+
+    processIncomingAnthropicStream(requestId, req, res, {}, 'claude-3-sonnet');
+    await tick();
+
+    await simulateEvent(requestId, 0, {
+        choices: [{ delta: { content: 'Hi' }, finish_reason: null }],
+    });
+    await tick();
+
+    // Complete with full usage including cache tokens
+    await simulateEvent(requestId, 1, {
+        choices: [{ delta: {}, finish_reason: 'stop' }],
+        usage: {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            cache_creation_input_tokens: 80,
+            cache_read_input_tokens: 20,
+        },
+    });
+    await tick();
+
+    const events = parseSSEEvents(res.writes);
+    const msgDelta = events.find(e => e.event === 'message_delta');
+    t.truthy(msgDelta.data.usage, 'message_delta should have usage');
+    t.is(msgDelta.data.usage.input_tokens, 100);
+    t.is(msgDelta.data.usage.output_tokens, 50);
+    t.is(msgDelta.data.usage.cache_creation_input_tokens, 80);
+    t.is(msgDelta.data.usage.cache_read_input_tokens, 20);
+
+    t.true(res.writableEnded);
+    cleanupRequestState(requestId);
+});
+
+// ============================================================================
+// 6) Error [ERROR] prefix
+// ============================================================================
+
+test.serial('error handling: [ERROR] requestId emits error text and closes stream', async (t) => {
+    const requestId = '[ERROR] Something went wrong';
+    const req = createMockReq();
+    const res = createMockRes();
+
+    processIncomingAnthropicStream(requestId, req, res, {}, 'claude-3-sonnet');
+    await tick();
+
+    const events = parseSSEEvents(res.writes);
+    const eventTypes = events.map(e => e.event);
+
+    t.true(eventTypes.includes('message_start'));
+    t.true(eventTypes.includes('content_block_start'));
+    t.true(eventTypes.includes('content_block_delta'));
+    t.true(eventTypes.includes('content_block_stop'));
+    t.true(eventTypes.includes('message_delta'));
+    t.true(eventTypes.includes('message_stop'));
+
+    // Error text should be in the delta
+    const textDeltas = events.filter(e =>
+        e.event === 'content_block_delta' && e.data.delta?.type === 'text_delta'
+    );
+    const text = textDeltas.map(e => e.data.delta.text).join('');
+    t.true(text.includes('[ERROR]'));
+
+    t.true(res.writableEnded);
+});
+
+// ============================================================================
+// 7) Non-streaming usage (convertOpenAIResultToAnthropicMessage)
+// ============================================================================
+
+test.serial('non-streaming: convertOpenAIResultToAnthropicMessage includes usage data', (t) => {
+    const result = convertOpenAIResultToAnthropicMessage({
+        messageContent: 'Hello world',
+        toolCalls: null,
+        functionCall: null,
+        finishReason: 'stop',
+        model: 'claude-3-sonnet',
+        usage: { input_tokens: 100, output_tokens: 50 },
+    });
+
+    t.is(result.type, 'message');
+    t.is(result.role, 'assistant');
+    t.is(result.model, 'claude-3-sonnet');
+    t.is(result.usage.input_tokens, 100);
+    t.is(result.usage.output_tokens, 50);
+    t.is(result.stop_reason, 'end_turn');
+
+    // Content should have text block
+    t.is(result.content.length, 1);
+    t.is(result.content[0].type, 'text');
+    t.is(result.content[0].text, 'Hello world');
+});
+
+test.serial('non-streaming: without usage defaults to zeros', (t) => {
+    const result = convertOpenAIResultToAnthropicMessage({
+        messageContent: 'Test',
+        toolCalls: null,
+        functionCall: null,
+        finishReason: 'stop',
+        model: 'claude-3-sonnet',
+    });
+
+    t.deepEqual(result.usage, { input_tokens: 0, output_tokens: 0 });
+});
+
+test.serial('non-streaming: tool_calls finish reason maps to tool_use', (t) => {
+    const result = convertOpenAIResultToAnthropicMessage({
+        messageContent: '',
+        toolCalls: [{
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'get_weather', arguments: '{"location":"Boston"}' },
+        }],
+        functionCall: null,
+        finishReason: 'tool_calls',
+        model: 'claude-3-sonnet',
+        usage: { input_tokens: 10, output_tokens: 5 },
+    });
+
+    t.is(result.stop_reason, 'tool_use');
+    const toolBlock = result.content.find(c => c.type === 'tool_use');
+    t.truthy(toolBlock);
+    t.is(toolBlock.name, 'get_weather');
+    t.deepEqual(toolBlock.input, { location: 'Boston' });
+});
+
+test.serial('non-streaming: length finish reason maps to max_tokens', (t) => {
+    const result = convertOpenAIResultToAnthropicMessage({
+        messageContent: 'Truncated...',
+        toolCalls: null,
+        functionCall: null,
+        finishReason: 'length',
+        model: 'claude-3-sonnet',
+        usage: { input_tokens: 10, output_tokens: 4096 },
+    });
+
+    t.is(result.stop_reason, 'max_tokens');
+});
+
+// ============================================================================
+// 8) Image block conversion (convertAnthropicMessagesToOpenAI)
+// ============================================================================
+
+test.serial('image blocks: base64 image converted to OpenAI image_url format', (t) => {
+    const messages = [{
+        role: 'user',
+        content: [
+            { type: 'text', text: 'What is in this image?' },
+            {
+                type: 'image',
+                source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: 'iVBORw0KGgoAAAANSUhEUg==',
+                },
+            },
+        ],
+    }];
+
+    const result = convertAnthropicMessagesToOpenAI(messages);
+
+    t.is(result.length, 1);
+    const msg = result[0];
+    t.is(msg.role, 'user');
+
+    // Content should be an array of parts (multimodal)
+    t.true(Array.isArray(msg.content));
+    t.is(msg.content.length, 2);
+
+    // First part is text
+    t.is(msg.content[0].type, 'text');
+    t.is(msg.content[0].text, 'What is in this image?');
+
+    // Second part is image_url
+    t.is(msg.content[1].type, 'image_url');
+    t.true(msg.content[1].image_url.url.startsWith('data:image/png;base64,'));
+});
+
+test.serial('image blocks: URL image converted to OpenAI image_url format', (t) => {
+    const messages = [{
+        role: 'user',
+        content: [
+            { type: 'text', text: 'Describe this.' },
+            {
+                type: 'image',
+                source: {
+                    type: 'url',
+                    url: 'https://example.com/image.png',
+                },
+            },
+        ],
+    }];
+
+    const result = convertAnthropicMessagesToOpenAI(messages);
+
+    t.is(result.length, 1);
+    const msg = result[0];
+    t.true(Array.isArray(msg.content));
+
+    const imagePart = msg.content.find(p => p.type === 'image_url');
+    t.truthy(imagePart);
+    t.is(imagePart.image_url.url, 'https://example.com/image.png');
+});
+
+test.serial('image blocks: text-only messages remain as string content', (t) => {
+    const messages = [{
+        role: 'user',
+        content: [
+            { type: 'text', text: 'Hello' },
+        ],
+    }];
+
+    const result = convertAnthropicMessagesToOpenAI(messages);
+
+    t.is(result.length, 1);
+    // Should be a plain string, not an array
+    t.is(typeof result[0].content, 'string');
+    t.is(result[0].content, 'Hello');
+});
+
+// ============================================================================
+// 9) message_start carries initial usage (input_tokens)
+// ============================================================================
+
+test.serial('streaming: message_start.message.usage reflects initial usage from first event', async (t) => {
+    const requestId = 'test-anth-initusage-' + Date.now();
+    const req = createMockReq();
+    const res = createMockRes();
+    seedRequestState(requestId);
+
+    processIncomingAnthropicStream(requestId, req, res, {}, 'claude-3-sonnet');
+    await tick();
+
+    // First event carries initial usage (like Claude message_start → plugin forwards input_tokens)
+    await simulateEvent(requestId, 0, {
+        choices: [{ delta: { role: 'assistant', content: '' }, finish_reason: null }],
+        usage: { input_tokens: 150, output_tokens: 0 },
+    });
+    await tick();
+
+    // Text delta
+    await simulateEvent(requestId, 0, {
+        choices: [{ delta: { content: 'Hello' }, finish_reason: null }],
+    });
+    await tick();
+
+    // Final event with output usage
+    await simulateEvent(requestId, 1, {
+        choices: [{ delta: {}, finish_reason: 'stop' }],
+        usage: { output_tokens: 25 },
+    });
+    await tick();
+
+    const events = parseSSEEvents(res.writes);
+
+    // message_start should have the real input_tokens from the first event
+    const msgStart = events.find(e => e.event === 'message_start');
+    t.is(msgStart.data.message.usage.input_tokens, 150, 'message_start should carry real input_tokens');
+    t.is(msgStart.data.message.usage.output_tokens, 0);
+
+    // message_delta should have the final output_tokens
+    const msgDelta = events.find(e => e.event === 'message_delta');
+    t.truthy(msgDelta.data.usage, 'message_delta should have usage');
+    t.is(msgDelta.data.usage.output_tokens, 25);
+
+    t.true(res.writableEnded);
+    cleanupRequestState(requestId);
+});
+
+// ============================================================================
+// 10) stop_sequence preserved end-to-end
+// ============================================================================
+
+test.serial('stop reason: stop_sequence is preserved through streaming', async (t) => {
+    const requestId = 'test-anth-stopseq-' + Date.now();
+    const req = createMockReq();
+    const res = createMockRes();
+    seedRequestState(requestId);
+
+    processIncomingAnthropicStream(requestId, req, res, {}, 'claude-3-sonnet');
+    await tick();
+
+    await simulateEvent(requestId, 0, {
+        choices: [{ delta: { content: 'Hello' }, finish_reason: null }],
+    });
+    await tick();
+
+    // Finish with stop_sequence (as the plugin would now emit it)
+    await simulateEvent(requestId, 1, {
+        choices: [{ delta: {}, finish_reason: 'stop_sequence' }],
+        usage: { input_tokens: 10, output_tokens: 3 },
+    });
+    await tick();
+
+    const events = parseSSEEvents(res.writes);
+    const msgDelta = events.find(e => e.event === 'message_delta');
+    t.is(msgDelta.data.delta.stop_reason, 'stop_sequence');
+
+    t.true(res.writableEnded);
+    cleanupRequestState(requestId);
+});
+
+// ============================================================================
+// 11) Server-side tool filtering and passthrough
+// ============================================================================
+
+test.serial('server-side tools: isServerSideTool identifies web_search_20250305', (t) => {
+    t.true(isServerSideTool({ type: 'web_search_20250305', name: 'web_search', max_uses: 5 }));
+    t.false(isServerSideTool({ type: 'function', name: 'get_weather' }));
+    t.false(isServerSideTool({ name: 'regular_tool', input_schema: {} }));
+    t.false(isServerSideTool(null));
+    t.false(isServerSideTool(undefined));
+});
+
+test.serial('server-side tools: convertAnthropicToolsToOpenAI excludes server-side tools', (t) => {
+    const tools = [
+        { type: 'web_search_20250305', name: 'web_search', max_uses: 5 },
+        { name: 'get_weather', description: 'Get weather info', input_schema: { type: 'object', properties: { location: { type: 'string' } } } },
+    ];
+
+    const result = convertAnthropicToolsToOpenAI(tools);
+
+    // Should only have get_weather, not web_search
+    t.is(result.length, 1);
+    t.is(result[0].type, 'function');
+    t.is(result[0].function.name, 'get_weather');
+});
+
+test.serial('server-side tools: convertAnthropicToolsToOpenAI returns undefined when only server-side tools', (t) => {
+    const tools = [
+        { type: 'web_search_20250305', name: 'web_search', max_uses: 5 },
+    ];
+
+    const result = convertAnthropicToolsToOpenAI(tools);
+    t.is(result, undefined);
+});
+
+test.serial('server-side tools: server_tool_use content blocks are ignored in message conversion (passthrough handles them)', (t) => {
+    const messages = [{
+        role: 'assistant',
+        content: [
+            { type: 'text', text: 'Let me search for that.' },
+            {
+                type: 'server_tool_use',
+                id: 'srvtoolu_123',
+                name: 'web_search',
+                input: { query: 'latest news' },
+            },
+        ],
+    }];
+
+    const result = convertAnthropicMessagesToOpenAI(messages);
+
+    // The assistant message should be converted, server_tool_use ignored
+    t.is(result.length, 1);
+    const msg = result[0];
+    t.is(msg.role, 'assistant');
+    t.is(msg.content, 'Let me search for that.');
+    // No _anthropicServerToolBlocks - passthrough handles server tools directly
+    t.falsy(msg._anthropicServerToolBlocks);
+});
+
+test.serial('server-side tools: web_search_tool_result content blocks are ignored in message conversion (passthrough handles them)', (t) => {
+    const messages = [{
+        role: 'user',
+        content: [
+            { type: 'text', text: 'Here are the results:' },
+            {
+                type: 'web_search_tool_result',
+                tool_use_id: 'srvtoolu_123',
+                content: [
+                    { type: 'web_search_result', title: 'News Article', url: 'https://example.com', snippet: 'Latest news...' },
+                ],
+            },
+        ],
+    }];
+
+    const result = convertAnthropicMessagesToOpenAI(messages);
+
+    // The user message should be converted, web_search_tool_result ignored
+    t.is(result.length, 1);
+    const msg = result[0];
+    t.is(msg.content, 'Here are the results:');
+    // No _anthropicServerToolBlocks - passthrough handles server tools directly
+    t.falsy(msg._anthropicServerToolBlocks);
+});
+
+// Note: Server-side tool streaming via _anthropic metadata is no longer needed.
+// Claude clients now use native passthrough which handles thinking blocks,
+// server_tool_use, and web_search_tool_result directly without conversion.


### PR DESCRIPTION
## Summary
- add the shared media_prompt_assistant pathway used by Gemini image prompt optimization
- add media_prompt_tags for concise JSON tag generation from media prompts
- add unit coverage for model-specific media prompt guidance and tag prompt constraints

## Validation
- `CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/mediaPromptAssistant.test.js tests/unit/pathways/mediaPromptTags.test.js`
