### PR TITLE
[codex] Add generic analysis pathways

### DIFF
--- a/pathways/benchmark.js
+++ b/pathways/benchmark.js
@@ -1,0 +1,11 @@
+// Simple passthrough pathway for comparing configured model responses.
+
+export default {
+    prompt: `{{text}}`,
+    inputParameters: {
+        model: '',
+        reasoningEffort: '',
+    },
+    useInputChunking: false,
+    enableCache: false,
+};

--- a/pathways/cosine_similarity.js
+++ b/pathways/cosine_similarity.js
@@ -1,0 +1,100 @@
+// Calculates cosine similarity between a text string and candidate strings.
+
+import { callPathway } from '../lib/pathwayTools.js';
+
+export function cosineSimilarity(vecA, vecB) {
+    if (!Array.isArray(vecA) || !Array.isArray(vecB)) {
+        throw new Error('Vectors must be arrays');
+    }
+    if (vecA.length !== vecB.length) {
+        throw new Error('Vectors must have the same length');
+    }
+
+    let dotProduct = 0;
+    let normA = 0;
+    let normB = 0;
+
+    for (let i = 0; i < vecA.length; i++) {
+        dotProduct += vecA[i] * vecB[i];
+        normA += vecA[i] * vecA[i];
+        normB += vecB[i] * vecB[i];
+    }
+
+    normA = Math.sqrt(normA);
+    normB = Math.sqrt(normB);
+
+    if (normA === 0 || normB === 0) {
+        return 0;
+    }
+
+    return dotProduct / (normA * normB);
+}
+
+function parseEmbeddingResponse(response) {
+    const parsed = typeof response === 'string' ? JSON.parse(response) : response;
+    const embedding = Array.isArray(parsed?.[0]) ? parsed[0] : parsed;
+    if (!Array.isArray(embedding)) {
+        throw new Error('Embedding response did not contain a vector');
+    }
+    return embedding;
+}
+
+export async function buildCosineSimilarityResult({
+    text,
+    input,
+    model = 'azure-embeddings',
+    embeddingPathway = callPathway,
+}) {
+    if (!text || !input || !Array.isArray(input)) {
+        throw new Error('Both text and input are required, and input must be an array');
+    }
+
+    const validStrings = input.filter(s => s && s.trim().length > 0);
+    if (validStrings.length === 0) {
+        throw new Error('Input must contain at least one non-empty string');
+    }
+
+    if (text.trim().length === 0) {
+        throw new Error('Text cannot be empty');
+    }
+
+    const embeddingResponses = await Promise.all([
+        embeddingPathway('embeddings', { input: [text], model }),
+        ...validStrings.map(string =>
+            embeddingPathway('embeddings', { input: [string], model })
+        ),
+    ]);
+
+    const textEmbedding = parseEmbeddingResponse(embeddingResponses[0]);
+    const stringEmbeddings = embeddingResponses.slice(1).map(parseEmbeddingResponse);
+
+    const results = stringEmbeddings.map((embedding, index) => ({
+        string: validStrings[index],
+        similarity: cosineSimilarity(textEmbedding, embedding),
+    }));
+
+    results.sort((a, b) => b.similarity - a.similarity);
+
+    return {
+        text,
+        totalStrings: validStrings.length,
+        results,
+    };
+}
+
+export default {
+    name: 'cosine_similarity',
+    description: 'Calculates cosine similarity between a text string and an array of strings using embeddings',
+    inputParameters: {
+        text: '',
+        input: { type: 'array', items: { type: 'string' }, default: [] },
+        model: 'azure-embeddings',
+    },
+    executePathway: async ({ args }) => {
+        try {
+            return JSON.stringify(await buildCosineSimilarityResult(args));
+        } catch (error) {
+            throw new Error(`Cosine similarity calculation failed: ${error.message}`);
+        }
+    },
+};

--- a/pathways/tag_image.js
+++ b/pathways/tag_image.js
@@ -1,0 +1,43 @@
+import { Prompt } from '../server/prompt.js';
+
+export default {
+    prompt: [
+        new Prompt({ messages: [
+            {
+                role: 'system',
+                content: `Instructions:
+You are an AI image analysis and tagging assistant. Given an image, examine it for visible people, objects, locations, events, activities, emotions, and other relevant entities. Identify public figures, landmarks, and recognizable public places when there is enough visual evidence. You know the current date and time - it is {{now}}.
+
+Output Format:
+You must respond with a valid JSON object following this exact structure:
+{
+  "imageTags": {
+    "people": ["name1", "name2"],
+    "objects": ["object1", "object2"],
+    "locations": ["location1", "location2"],
+    "events": ["event1", "event2"],
+    "activities": ["activity1", "activity2"],
+    "emotions": ["emotion1", "emotion2"],
+    "timestamp": "{{now}}",
+    "confidence": 0.95
+  },
+  "description": "Brief description of the image content",
+  "tags": ["tag1", "tag2", "tag3"]
+}
+
+All arrays should contain relevant items found in a category, or an empty array [] when none are visible. The confidence score should be between 0.0 and 1.0. Ensure the JSON is properly formatted and valid.`,
+            },
+            '{{chatHistory}}',
+        ]}),
+    ],
+    inputParameters: {
+        chatHistory: [{ role: '', content: [] }],
+        contextId: '',
+        model: 'oai-gpt4o',
+    },
+    useInputChunking: false,
+    enableDuplicateRequests: false,
+    timeout: 600,
+    manageTokenLength: false,
+    json: true,
+};

--- a/tests/unit/pathways/genericAnalysisPathways.test.js
+++ b/tests/unit/pathways/genericAnalysisPathways.test.js
@@ -1,0 +1,80 @@
+import test from 'ava';
+import benchmark from '../../../pathways/benchmark.js';
+import tagImage from '../../../pathways/tag_image.js';
+import {
+    buildCosineSimilarityResult,
+    cosineSimilarity,
+} from '../../../pathways/cosine_similarity.js';
+
+test('benchmark pathway passes text through without caching', t => {
+    t.is(benchmark.prompt, '{{text}}');
+    t.false(benchmark.useInputChunking);
+    t.false(benchmark.enableCache);
+    t.deepEqual(Object.keys(benchmark.inputParameters), ['model', 'reasoningEffort']);
+});
+
+test('cosineSimilarity handles identical, orthogonal, and zero vectors', t => {
+    t.is(cosineSimilarity([1, 2, 3], [1, 2, 3]), 1);
+    t.is(cosineSimilarity([1, 0], [0, 1]), 0);
+    t.is(cosineSimilarity([0, 0], [1, 2]), 0);
+    t.throws(() => cosineSimilarity([1], [1, 2]), {
+        message: 'Vectors must have the same length',
+    });
+});
+
+test('buildCosineSimilarityResult ranks candidates using injected embeddings', async t => {
+    const embeddings = new Map([
+        ['alpha', [[1, 0]]],
+        ['near alpha', [[0.9, 0.1]]],
+        ['beta', [[0, 1]]],
+        ['empty', [[0, 0]]],
+    ]);
+    const calls = [];
+
+    const result = await buildCosineSimilarityResult({
+        text: 'alpha',
+        input: ['beta', 'near alpha', '', 'empty'],
+        embeddingPathway: async (pathwayName, args) => {
+            calls.push({ pathwayName, args });
+            return JSON.stringify(embeddings.get(args.input[0]));
+        },
+    });
+
+    t.is(result.text, 'alpha');
+    t.is(result.totalStrings, 3);
+    t.deepEqual(result.results.map(item => item.string), ['near alpha', 'beta', 'empty']);
+    t.true(result.results[0].similarity > result.results[1].similarity);
+    t.true(calls.every(call => call.pathwayName === 'embeddings'));
+    t.deepEqual(calls.map(call => call.args.model), [
+        'azure-embeddings',
+        'azure-embeddings',
+        'azure-embeddings',
+        'azure-embeddings',
+    ]);
+});
+
+test('buildCosineSimilarityResult rejects empty inputs before embedding calls', async t => {
+    await t.throwsAsync(
+        buildCosineSimilarityResult({
+            text: 'alpha',
+            input: ['   '],
+            embeddingPathway: async () => {
+                throw new Error('should not be called');
+            },
+        }),
+        { message: 'Input must contain at least one non-empty string' },
+    );
+});
+
+test('tag_image uses generic image tagging instructions and JSON output', t => {
+    t.true(tagImage.json);
+    t.false(tagImage.useInputChunking);
+    t.is(tagImage.inputParameters.model, 'oai-gpt4o');
+
+    const [systemMessage, chatHistoryTemplate] = tagImage.prompt[0].messages;
+    t.regex(systemMessage.content, /AI image analysis and tagging assistant/);
+    t.regex(systemMessage.content, /valid JSON object/);
+    t.regex(systemMessage.content, /Identify public figures/);
+    t.is(chatHistoryTemplate, '{{chatHistory}}');
+    t.false(/news agency/i.test(systemMessage.content));
+});


### PR DESCRIPTION
## Summary
- Add a benchmark passthrough pathway for comparing configured models.
- Add a cosine similarity pathway with reusable vector scoring and injectable embedding calls.
- Add a generic image tagging pathway that returns structured JSON tags.
- Add unit coverage for pathway configuration, vector scoring, similarity ranking, validation, and image-tagging prompt shape.

## Validation
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/genericAnalysisPathways.test.js