### PR TITLE
[codex] Add entity management pathways

### DIFF
--- a/pathways/system/entity/sys_entity_update.js
+++ b/pathways/system/entity/sys_entity_update.js
@@ -1,0 +1,149 @@
+// Pathway to update entity settings.
+
+import { getEntityStore } from '../../../lib/MongoEntityStore.js';
+import { encrypt, decrypt } from '../../../lib/crypto.js';
+import { syncSecretsToWorkspace } from './tools/shared/workspace_client.js';
+import logger from '../../../lib/logger.js';
+
+const VALID_REASONING_EFFORTS = ['none', 'low', 'medium', 'high'];
+const ENCRYPTION_KEY = process.env.REDIS_ENCRYPTION_KEY || null;
+
+const decryptSecretsForWorkspace = (secrets, entityId) => {
+    const decrypted = {};
+
+    for (const [key, value] of Object.entries(secrets || {})) {
+        const plain = decrypt(value, ENCRYPTION_KEY);
+        if (plain === null || plain === undefined) {
+            logger.warn(`Skipping secret '${key}' for entity ${entityId}: decryption failed`);
+            continue;
+        }
+        decrypted[key] = plain;
+    }
+
+    return decrypted;
+};
+
+export default {
+    prompt: [],
+    inputParameters: {
+        entityId: '',
+        contextId: '',
+        name: '',
+        secrets: '',
+        reasoningEffort: '',
+    },
+    model: 'oai-gpt41-mini',
+    executePathway: async ({ args }) => {
+        const { entityId, contextId, name, secrets: secretsJson, reasoningEffort } = args;
+
+        if (!entityId) {
+            return JSON.stringify({ error: 'entityId is required' });
+        }
+        if (!contextId) {
+            return JSON.stringify({ error: 'contextId is required' });
+        }
+
+        try {
+            const entityStore = getEntityStore();
+            const entity = await entityStore.getEntity(entityId, { fresh: true });
+
+            if (!entity) {
+                return JSON.stringify({ error: 'Entity not found' });
+            }
+
+            if (!entity.assocUserIds || !entity.assocUserIds.includes(contextId)) {
+                return JSON.stringify({ error: 'Not authorized to update this entity' });
+            }
+
+            const originalEntity = JSON.parse(JSON.stringify(entity));
+            const result = { success: true };
+            let nextWorkspaceSecrets = null;
+            const shouldSyncRunningWorkspace =
+                Boolean(secretsJson) &&
+                entity.workspace?.url &&
+                entity.workspace?.status === 'running';
+
+            const trimmedName = String(name || '').trim();
+            if (trimmedName) {
+                entity.name = trimmedName;
+                result.name = trimmedName;
+            }
+
+            if (secretsJson) {
+                let incoming;
+                try {
+                    incoming = JSON.parse(secretsJson);
+                } catch {
+                    return JSON.stringify({ error: 'Invalid secrets JSON' });
+                }
+
+                const existing = entity.secrets || {};
+                const merged = { ...existing };
+
+                for (const [key, value] of Object.entries(incoming)) {
+                    if (value === null) {
+                        delete merged[key];
+                    } else {
+                        const encrypted = encrypt(String(value), ENCRYPTION_KEY);
+                        if (encrypted === null) {
+                            return JSON.stringify({ error: `Failed to encrypt secret ${key}` });
+                        }
+                        merged[key] = encrypted;
+                    }
+                }
+
+                entity.secrets = Object.keys(merged).length > 0 ? merged : null;
+                result.secretKeys = Object.keys(merged);
+                nextWorkspaceSecrets = decryptSecretsForWorkspace(entity.secrets || {}, entityId);
+            }
+
+            if (reasoningEffort) {
+                if (!VALID_REASONING_EFFORTS.includes(reasoningEffort)) {
+                    return JSON.stringify({
+                        error: `Invalid reasoningEffort: ${reasoningEffort}. Must be one of: ${VALID_REASONING_EFFORTS.join(', ')}`,
+                    });
+                }
+                entity.reasoningEffort = reasoningEffort;
+                result.reasoningEffort = reasoningEffort;
+            }
+
+            if (shouldSyncRunningWorkspace) {
+                const syncResult = await syncSecretsToWorkspace(entityId, nextWorkspaceSecrets || {});
+                if (!syncResult?.success) {
+                    return JSON.stringify({
+                        error: syncResult?.error || 'Failed to sync secrets to workspace',
+                    });
+                }
+
+                const refreshedEntity = await entityStore.getEntity(entityId, { fresh: true });
+                if (refreshedEntity?.workspace) {
+                    entity.workspace = refreshedEntity.workspace;
+                }
+            }
+
+            const upsertedId = await entityStore.upsertEntity(entity);
+            if (!upsertedId) {
+                if (shouldSyncRunningWorkspace) {
+                    try {
+                        await syncSecretsToWorkspace(
+                            entityId,
+                            decryptSecretsForWorkspace(originalEntity.secrets || {}, entityId),
+                        );
+                    } catch (rollbackError) {
+                        logger.error(
+                            `Failed to roll back workspace secrets for ${entityId}: ${rollbackError.message}`,
+                        );
+                    }
+                }
+                return JSON.stringify({ error: 'Failed to persist entity update' });
+            }
+
+            return JSON.stringify(result);
+        } catch (error) {
+            logger.error(`Error in sys_entity_update: ${error.message}`);
+            return JSON.stringify({ error: error.message });
+        }
+    },
+    json: true,
+    manageTokenLength: false,
+};

--- a/pathways/system/entity/sys_entity_upsert_personal.js
+++ b/pathways/system/entity/sys_entity_upsert_personal.js
@@ -1,0 +1,48 @@
+// Ensures a personal entity exists for a user.
+
+import { getEntityStore } from '../../../lib/MongoEntityStore.js';
+import { loadEntityConfig } from './tools/shared/sys_entity_tools.js';
+import logger from '../../../lib/logger.js';
+
+export default {
+    prompt: [],
+    inputParameters: {
+        userId: '',
+        name: '',
+    },
+    model: 'oai-gpt41-mini',
+    executePathway: async ({ args }) => {
+        const { userId, name } = args;
+
+        if (!userId) {
+            return JSON.stringify({ error: 'userId is required' });
+        }
+
+        try {
+            const entityStore = getEntityStore();
+            const defaultEntity = await loadEntityConfig(null);
+
+            const entityDefaults = {
+                name: name || 'Jarvis',
+                tools: defaultEntity?.tools || ['*'],
+                useMemory: defaultEntity?.useMemory ?? true,
+                description: defaultEntity?.description || '',
+                identity: defaultEntity?.identity || '',
+                customTools: defaultEntity?.customTools || {},
+                assocUserIds: [userId],
+            };
+
+            const result = await entityStore.findOrCreatePersonalEntity(userId, entityDefaults);
+            if (!result) {
+                return JSON.stringify({ error: 'Failed to find or create personal entity' });
+            }
+
+            return JSON.stringify({ id: result.id, name: result.name });
+        } catch (error) {
+            logger.error(`Error in sys_entity_upsert_personal: ${error.message}`);
+            return JSON.stringify({ error: error.message });
+        }
+    },
+    json: true,
+    manageTokenLength: false,
+};

--- a/pathways/system/entity/tools/sys_tool_store_secret.js
+++ b/pathways/system/entity/tools/sys_tool_store_secret.js
@@ -1,0 +1,169 @@
+import { getEntityStore } from '../../../../lib/MongoEntityStore.js';
+import { config } from '../../../../config.js';
+import { encrypt, decrypt } from '../../../../lib/crypto.js';
+import { syncSecretsToWorkspace } from './shared/workspace_client.js';
+import logger from '../../../../lib/logger.js';
+
+const decryptSecretsForWorkspace = (secrets, systemKey) => {
+    const plainSecrets = {};
+
+    for (const [key, encryptedValue] of Object.entries(secrets || {})) {
+        const plain = decrypt(encryptedValue, systemKey);
+        if (plain === null || plain === undefined) {
+            logger.warn(`Skipping secret '${key}' during workspace sync: decryption failed`);
+            continue;
+        }
+        plainSecrets[key] = plain;
+    }
+
+    return plainSecrets;
+};
+
+export default {
+    inputParameters: {
+        name: '',
+        value: '',
+        entityId: '',
+    },
+
+    toolDefinition: [{
+        type: 'function',
+        category: 'system',
+        icon: 'key',
+        toolCost: 1,
+        function: {
+            name: 'StoreSecret',
+            description: `Securely store an API key, token, or credential. The secret is encrypted and made available in the entity workspace as an environment variable and in /workspace/.env.
+
+Use this when a user gives you an API key or token so future workspace commands can reference it by name. Set value to null to delete a secret.
+
+Secret names must be UPPER_SNAKE_CASE, for example GITHUB_TOKEN or API_KEY.`,
+            parameters: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
+                        description: 'Secret name in UPPER_SNAKE_CASE',
+                    },
+                    value: {
+                        type: 'string',
+                        description: 'The secret value to store, or null to delete an existing secret',
+                    },
+                    userMessage: {
+                        type: 'string',
+                        description: 'Brief message to display while this action runs',
+                    },
+                },
+                required: ['name', 'userMessage'],
+            },
+        },
+    }],
+
+    executePathway: async ({ args, resolver }) => {
+        const { name, value, entityId } = args;
+
+        try {
+            if (!entityId) {
+                return JSON.stringify({ success: false, error: 'entityId is required' });
+            }
+
+            if (!name || !/^[A-Z_][A-Z0-9_]*$/i.test(name)) {
+                return JSON.stringify({
+                    success: false,
+                    error: `Invalid secret name: "${name}". Use UPPER_SNAKE_CASE.`,
+                });
+            }
+
+            const entityStore = getEntityStore();
+            const entity = await entityStore.getEntity(entityId, { fresh: true });
+            if (!entity) {
+                return JSON.stringify({ success: false, error: 'Entity not found' });
+            }
+
+            const systemKey = config.get('redisEncryptionKey');
+            const originalSecrets = JSON.parse(JSON.stringify(entity.secrets || {}));
+            const merged = { ...(entity.secrets || {}) };
+            const shouldSyncRunningWorkspace =
+                entity.workspace?.url && entity.workspace?.status === 'running';
+
+            if (value === null || value === undefined || value === '') {
+                if (!merged[name]) {
+                    return JSON.stringify({
+                        success: true,
+                        message: `Secret "${name}" was not set`,
+                    });
+                }
+                delete merged[name];
+            } else {
+                merged[name] = encrypt(String(value), systemKey);
+            }
+
+            const nextEntity = {
+                ...entity,
+                secrets: Object.keys(merged).length > 0 ? merged : null,
+            };
+
+            if (shouldSyncRunningWorkspace) {
+                const syncResult = await syncSecretsToWorkspace(
+                    entityId,
+                    decryptSecretsForWorkspace(nextEntity.secrets || {}, systemKey),
+                );
+                if (!syncResult?.success) {
+                    return JSON.stringify({
+                        success: false,
+                        error: syncResult?.error || 'Failed to sync secrets to workspace',
+                    });
+                }
+
+                const refreshedEntity = await entityStore.getEntity(entityId, { fresh: true });
+                if (refreshedEntity?.workspace) {
+                    nextEntity.workspace = refreshedEntity.workspace;
+                }
+            }
+
+            const persistedId = await entityStore.upsertEntity(nextEntity);
+            if (!persistedId) {
+                if (shouldSyncRunningWorkspace) {
+                    try {
+                        await syncSecretsToWorkspace(
+                            entityId,
+                            decryptSecretsForWorkspace(originalSecrets, systemKey),
+                        );
+                    } catch (rollbackError) {
+                        logger.error(
+                            `Failed to roll back workspace secrets for ${entityId}: ${rollbackError.message}`,
+                        );
+                    }
+                }
+
+                return JSON.stringify({
+                    success: false,
+                    error: 'Failed to persist secret update',
+                });
+            }
+
+            if (resolver) {
+                resolver.tool = JSON.stringify({
+                    toolUsed: 'StoreSecret',
+                    action: value === null ? 'delete' : 'store',
+                    name,
+                });
+            }
+
+            const action = (value === null || value === undefined || value === '') ? 'deleted' : 'stored';
+            logger.info(`Secret "${name}" ${action} for entity ${entityId}`);
+
+            return JSON.stringify({
+                success: true,
+                message: `Secret "${name}" ${action} successfully. Available as $${name} in your workspace.`,
+                secretKeys: Object.keys(merged),
+            });
+        } catch (error) {
+            logger.error(`StoreSecret failed: ${error.message}`);
+            return JSON.stringify({
+                success: false,
+                error: `Failed to store secret: ${error.message}`,
+            });
+        }
+    },
+};

--- a/tests/unit/pathways/entityManagementPathways.test.js
+++ b/tests/unit/pathways/entityManagementPathways.test.js
@@ -1,0 +1,164 @@
+import test from 'ava';
+import { config } from '../../../config.js';
+import { getEntityStore } from '../../../lib/MongoEntityStore.js';
+import sysEntityUpdate from '../../../pathways/system/entity/sys_entity_update.js';
+import sysEntityUpsertPersonal from '../../../pathways/system/entity/sys_entity_upsert_personal.js';
+import storeSecret from '../../../pathways/system/entity/tools/sys_tool_store_secret.js';
+
+const stubEntityStore = (overrides = {}) => {
+    const entityStore = getEntityStore();
+    const originals = {};
+    for (const key of Object.keys(overrides)) {
+        originals[key] = entityStore[key];
+        entityStore[key] = overrides[key];
+    }
+    return () => {
+        for (const [key, value] of Object.entries(originals)) {
+            entityStore[key] = value;
+        }
+    };
+};
+
+const stubConfigGet = (handler) => {
+    const originalGet = config.get;
+    config.get = handler;
+    return () => {
+        config.get = originalGet;
+    };
+};
+
+test.serial('sys_entity_update updates owned entity name, reasoning effort, and secrets', async t => {
+    let persisted;
+    const restore = stubEntityStore({
+        getEntity: async () => ({
+            id: 'entity-1',
+            name: 'Jarvis',
+            assocUserIds: ['user-1'],
+            secrets: { OLD_TOKEN: 'keep', REMOVE_ME: 'delete' },
+            workspace: { status: 'stopped' },
+        }),
+        upsertEntity: async (entity) => {
+            persisted = entity;
+            return entity.id;
+        },
+    });
+    t.teardown(restore);
+
+    const result = JSON.parse(await sysEntityUpdate.executePathway({
+        args: {
+            entityId: 'entity-1',
+            contextId: 'user-1',
+            name: 'Jarvis Prime',
+            reasoningEffort: 'high',
+            secrets: JSON.stringify({ API_TOKEN: 'new-value', REMOVE_ME: null }),
+        },
+    }));
+
+    t.true(result.success);
+    t.is(result.name, 'Jarvis Prime');
+    t.is(result.reasoningEffort, 'high');
+    t.deepEqual(result.secretKeys, ['OLD_TOKEN', 'API_TOKEN']);
+    t.like(persisted, {
+        name: 'Jarvis Prime',
+        reasoningEffort: 'high',
+    });
+    t.deepEqual(persisted.secrets, {
+        OLD_TOKEN: 'keep',
+        API_TOKEN: 'new-value',
+    });
+});
+
+test.serial('sys_entity_update rejects updates from non-associated users', async t => {
+    const restore = stubEntityStore({
+        getEntity: async () => ({
+            id: 'entity-1',
+            assocUserIds: ['owner-1'],
+        }),
+    });
+    t.teardown(restore);
+
+    const result = JSON.parse(await sysEntityUpdate.executePathway({
+        args: {
+            entityId: 'entity-1',
+            contextId: 'other-user',
+            name: 'Nope',
+        },
+    }));
+
+    t.is(result.error, 'Not authorized to update this entity');
+});
+
+test.serial('sys_entity_upsert_personal creates a Jarvis personal entity by default', async t => {
+    let capturedDefaults;
+    const restore = stubEntityStore({
+        isConfigured: () => true,
+        getDefaultEntity: async () => null,
+        findOrCreatePersonalEntity: async (userId, defaults) => {
+            capturedDefaults = { userId, defaults };
+            return { id: 'personal-1', name: defaults.name };
+        },
+    });
+    t.teardown(restore);
+
+    const result = JSON.parse(await sysEntityUpsertPersonal.executePathway({
+        args: { userId: 'user-1' },
+    }));
+
+    t.deepEqual(result, { id: 'personal-1', name: 'Jarvis' });
+    t.is(capturedDefaults.userId, 'user-1');
+    t.deepEqual(capturedDefaults.defaults.assocUserIds, ['user-1']);
+    t.is(capturedDefaults.defaults.name, 'Jarvis');
+    t.deepEqual(capturedDefaults.defaults.tools, ['*']);
+});
+
+test.serial('StoreSecret stores a secret on the entity and annotates resolver tool usage', async t => {
+    let persisted;
+    const restoreConfig = stubConfigGet((key) => {
+        if (key === 'redisEncryptionKey') return null;
+        return undefined;
+    });
+    t.teardown(restoreConfig);
+
+    const restoreEntityStore = stubEntityStore({
+        getEntity: async () => ({
+            id: 'entity-1',
+            secrets: { EXISTING_TOKEN: 'old' },
+            workspace: { status: 'stopped' },
+        }),
+        upsertEntity: async (entity) => {
+            persisted = entity;
+            return entity.id;
+        },
+    });
+    t.teardown(restoreEntityStore);
+
+    const resolver = {};
+    const result = JSON.parse(await storeSecret.executePathway({
+        args: {
+            entityId: 'entity-1',
+            name: 'API_TOKEN',
+            value: 'secret-value',
+        },
+        resolver,
+    }));
+
+    t.true(result.success);
+    t.deepEqual(result.secretKeys, ['EXISTING_TOKEN', 'API_TOKEN']);
+    t.deepEqual(persisted.secrets, {
+        EXISTING_TOKEN: 'old',
+        API_TOKEN: 'secret-value',
+    });
+    t.deepEqual(JSON.parse(resolver.tool), {
+        toolUsed: 'StoreSecret',
+        action: 'store',
+        name: 'API_TOKEN',
+    });
+});
+
+test('StoreSecret tool definition is explicitly system-scoped', t => {
+    const [definition] = storeSecret.toolDefinition;
+    t.is(definition.category, 'system');
+    t.is(definition.function.name, 'StoreSecret');
+    t.true(definition.function.description.includes('/workspace/.env'));
+    t.deepEqual(definition.function.parameters.required, ['name', 'userMessage']);
+});


### PR DESCRIPTION
## Summary
- Add entity update and personal-entity upsert pathways.
- Add a system-scoped StoreSecret tool for persisting workspace environment secrets on entities.
- Add unit coverage for owned updates, authorization, Jarvis personal defaults, secret persistence, and tool definition shape.

## Validation
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/entityManagementPathways.test.js