### PR TITLE
[codex] Remove stale available files prompt surface

### DIFF
--- a/FILE_SYSTEM_DOCUMENTATION.md
+++ b/FILE_SYSTEM_DOCUMENTATION.md
@@ -1002,7 +1002,7 @@ Loads merged file collection from one or more contexts.
   3. For each additional context, loads collection via `loadFileCollectionAll()` with its `contextKey`
   4. Deduplicates: earlier contexts take precedence if same file exists in multiple
   5. Returns merged collection (with `_contextId` stripped before returning)
-- **Used by**: `syncAndStripFilesFromChatHistory`, `getAvailableFiles`, `resolveFileParameter`, file tools
+- **Used by**: `syncAndStripFilesFromChatHistory`, `resolveFileParameter`, file tools
 
 #### `saveFileCollection(contextId, contextKey, collection)`
 Saves file collection to Redis hash map (optimized - only updates changed entries).
@@ -1055,19 +1055,16 @@ Adds file to collection via atomic operation.
   5. Merges with existing CFH data if hash already exists
 - **Used by**: WriteFile, Image tools, FileCollection tool
 
-#### `syncAndStripFilesFromChatHistory(chatHistory, agentContext)`
-Processes chat history files based on collection membership.
+#### `syncAndStripFilesFromChatHistory(chatHistory, fileAccessPlan)`
+Replaces file-like chat history payloads with compact placeholders when file access is available.
 - **Parameters**:
   - `chatHistory`: Chat history array to process
-  - `agentContext`: Array of context objects, each with `{ contextId, contextKey, default }` (required)
-- **Returns**: `{ chatHistory, availableFiles }` - processed chat history and formatted file list
+  - `fileAccessPlan`: Array of resolved file access targets (required)
+- **Returns**: `{ chatHistory }` - processed chat history
 - **Process**:
-  1. Loads merged file collection from all contexts in `agentContext`
-  2. For each file in chat history:
-     - If in collection: strip from message, update lastAccessed and inCollection in owning context (using that context's key)
-     - If not in collection: leave in message as-is
-  3. Returns processed history and available files string
-  4. Uses atomic operations per file, updating the context that owns each file (identified by `_contextId` tag)
+  1. Verifies a file access plan is available
+  2. Replaces user-message file and image payloads with compact placeholders
+  3. Leaves non-file content unchanged
 - **Used by**: `sys_entity_agent` to process incoming chat history
 
 ### File Resolution
@@ -1124,18 +1121,6 @@ Extracts file metadata from chat history messages.
   2. Extracts from `image_url`, `file`, or direct URL objects
   3. Returns normalized format
 - **Used by**: File extraction utilities
-
-#### `getAvailableFiles(chatHistory, agentContext)`
-Gets formatted list of available files from collection.
-- **Parameters**:
-  - `chatHistory`: Unused (kept for API compatibility)
-  - `agentContext`: Array of context objects, each with `{ contextId, contextKey, default }` (required)
-- **Returns**: Formatted string of available files (last 10 most recent)
-- **Process**:
-  1. Loads merged file collection from all contexts in `agentContext`
-  2. Formats files via `formatFilesForTemplate()`
-  3. Returns compact one-line format per file
-- **Used by**: Template rendering to show available files
 
 ### Utility Functions
 
@@ -1262,4 +1247,3 @@ All file operations flow through `lib/fileUtils.js`, ensuring consistency, maint
 - **File Collection System**: Redis hash maps for user file metadata
 - **Atomic Operations**: Thread-safe via Redis HSET/HDEL/HGET operations
 - **Context Isolation**: Per-context hash maps for multi-tenant support
-

--- a/lib/entityConstants.js
+++ b/lib/entityConstants.js
@@ -61,8 +61,6 @@ term~N                 (Match terms similar to "term", edit distance N)
 
     AI_GROUNDING_INSTRUCTIONS: "# Grounding Responses\n\nIf you base part or all of your response on one or more search results, you MUST cite the source using a custom markdown directive of the form :cd_source[searchResultId]. There is NO other valid way to cite a source and a good UX depends on you using this directive correctly. Do not include other clickable links to the source when using the :cd_source[searchResultId] directive. Every search result has a unique searchResultId. You must include it verbatim, copied directly from the search results. Place the directives at the end of the phrase, sentence or paragraph that is grounded in that particular search result. If you are citing multiple search results, use multiple individual :cd_source[searchResultId] directives (e.g. :cd_source[searchResultId1] :cd_source[searchResultId2] :cd_source[searchResultId3] etc.)",
 
-    AI_AVAILABLE_FILES: "{{#if availableFiles}}# Available Files (Last 10 Most Recently Used)\n\nThe following files are available for you to use in your tool calls or responses. This shows the last 10 most recently used files. More files may be available in your collection - use ListFileCollection or SearchFileCollection to see all files.\n\n{{{availableFiles}}}\n{{/if}}",
-
     AI_MEMORY_INSTRUCTIONS: `# Memory Instructions
 
 - You have a memory system that contains important details, instructions, and context. Consult your memories when formulating a response to ensure your answers reflect previous learnings and context.

--- a/pathways/system/entity/tools/sys_tool_codingagent.js
+++ b/pathways/system/entity/tools/sys_tool_codingagent.js
@@ -63,7 +63,7 @@ export default {
                         items: {
                             type: "string"
                         },
-                        description: "A list of input files (from Available Files section or ListFileCollection or SearchFileCollection) that the coding agent must use to complete the task. Each file should be the hash or filename. Omit this parameter if no input files are needed."
+                        description: "A list of input files (from ListFileCollection or SearchFileCollection) that the coding agent must use to complete the task. Each file should be the hash or filename. Omit this parameter if no input files are needed."
                     },
                     userMessage: {
                         type: "string",

--- a/pathways/system/entity/tools/sys_tool_editfile.js
+++ b/pathways/system/entity/tools/sys_tool_editfile.js
@@ -85,7 +85,7 @@ export default {
                     properties: {
                         file: {
                             type: "string",
-                            description: "The file to modify: can be the file ID, filename, URL, or hash from your file collection. You can find available files in the Available Files section or ListFileCollection or SearchFileCollection."
+                            description: "The file to modify: can be the file ID, filename, URL, or hash from your file collection. Use ListFileCollection or SearchFileCollection to find available files."
                         },
                         startLine: {
                             type: "number",
@@ -119,7 +119,7 @@ export default {
                     properties: {
                         file: {
                             type: "string",
-                            description: "The file to modify: can be the file ID, filename, URL, or hash from your file collection. You can find available files in the Available Files section or ListFileCollection or SearchFileCollection."
+                            description: "The file to modify: can be the file ID, filename, URL, or hash from your file collection. Use ListFileCollection or SearchFileCollection to find available files."
                         },
                         oldString: {
                             type: "string",

--- a/pathways/system/entity/tools/sys_tool_image.js
+++ b/pathways/system/entity/tools/sys_tool_image.js
@@ -59,7 +59,7 @@ export default {
                         items: {
                             type: "string"
                         },
-                        description: "An array of images from your available files (from Available Files section or ListFileCollection or SearchFileCollection) to use as references for the image modification. You can provide up to 3 images. Each image should be the hash or filename."
+                        description: "An array of images from your file collection (use ListFileCollection or SearchFileCollection) to use as references for the image modification. You can provide up to 3 images. Each image should be the hash or filename."
                     },
                     detailedInstructions: {
                         type: "string",

--- a/pathways/system/entity/tools/sys_tool_image_gemini.js
+++ b/pathways/system/entity/tools/sys_tool_image_gemini.js
@@ -62,7 +62,7 @@ export default {
                         items: {
                             type: "string"
                         },
-                        description: "An array of images from your available files (from Available Files section or ListFileCollection or SearchFileCollection) to use as references for the image modification. You can provide up to 3 images. Each image should be the hash or filename."
+                        description: "An array of images from your file collection (use ListFileCollection or SearchFileCollection) to use as references for the image modification. You can provide up to 3 images. Each image should be the hash or filename."
                     },
                     detailedInstructions: {
                         type: "string",

--- a/pathways/system/entity/tools/sys_tool_readfile.js
+++ b/pathways/system/entity/tools/sys_tool_readfile.js
@@ -101,7 +101,7 @@ export default {
                 properties: {
                     file: {
                         type: "string",
-                        description: "The file to read: can be the file ID, filename, URL, or hash from your file collection. You can find available files in the Available Files section or ListFileCollection or SearchFileCollection."
+                        description: "The file to read: can be the file ID, filename, URL, or hash from your file collection. Use ListFileCollection or SearchFileCollection to find available files."
                     },
                     startChar: {
                         type: "number",

--- a/pathways/system/entity/tools/sys_tool_video_veo.js
+++ b/pathways/system/entity/tools/sys_tool_video_veo.js
@@ -91,7 +91,7 @@ export default {
                     },
                     inputImage: {
                         type: "string",
-                        description: "Optional: A reference image from your available files (from Available Files section or ListFileCollection or SearchFileCollection) to use as the starting frame or style reference for the video. The video will be generated to animate or extend from this image. Provide the hash or filename of the image."
+                        description: "Optional: A reference image from your file collection (use ListFileCollection or SearchFileCollection) to use as the starting frame or style reference for the video. The video will be generated to animate or extend from this image. Provide the hash or filename of the image."
                     },
                     filenamePrefix: {
                         type: "string",

--- a/tests/integration/features/tools/fileCollection.test.js
+++ b/tests/integration/features/tools/fileCollection.test.js
@@ -984,10 +984,10 @@ test('updateFileMetadata should allow updating inCollection', async (t) => {
         t.is(success3, true);
         
         // Verify file still exists but inCollection is undefined (not in collection)
-        // When loading without chatIds, undefined files are included (Labeeb uploads, etc.)
+        // When loading without chatIds, undefined files are included (direct uploads, etc.)
         const collection4 = await loadFileCollection(contextId, { useCache: false });
         const file4 = collection4.find(f => f.id === fileId);
-        t.truthy(file4, 'File should still exist (false → undefined, treated same as Labeeb uploads)');
+        t.truthy(file4, 'File should still exist (false → undefined, treated same as direct uploads)');
         t.falsy(file4.inCollection, 'File should have undefined inCollection (not in collection)');
         
         // Not in chat-specific collection (undefined files don't match any chatId)
@@ -1086,7 +1086,8 @@ test('File collection: syncAndStripFilesFromChatHistory only strips collection f
         ];
         
         // Process chat history
-        const { chatHistory: processed, availableFiles } = await syncAndStripFilesFromChatHistory(chatHistory, createAgentContext(contextId));
+        const result = await syncAndStripFilesFromChatHistory(chatHistory, createAgentContext(contextId));
+        const { chatHistory: processed } = result;
         
         // Verify only collection file was stripped
         const content = processed[0].content;
@@ -1105,32 +1106,31 @@ test('File collection: syncAndStripFilesFromChatHistory only strips collection f
         const collection = await loadFileCollection(contextId, { useCache: false });
         t.is(collection.length, 1);
         
-        // Available files should list the collection file
-        t.true(availableFiles.includes('in-collection.jpg'));
+        t.false('availableFiles' in result, 'available files are discovered through file tools, not chat-history sync');
     } finally {
         await cleanup(contextId);
     }
 });
 
-test('File collection: syncAndStripFilesFromChatHistory finds and syncs files without inCollection (Labeeb uploads)', async t => {
+test('File collection: syncAndStripFilesFromChatHistory finds and syncs files without inCollection (direct uploads)', async t => {
     const contextId = createTestContext();
     const chatId = `test-chat-${Date.now()}`;
     
     try {
         const { syncAndStripFilesFromChatHistory, writeFileDataToRedis, getRedisClient, loadFileCollection } = await import('../../../../lib/fileUtils.js');
         
-        // Create 3 files directly in Redis without inCollection set (simulating Labeeb uploads)
+        // Create 3 files directly in Redis without inCollection set (simulating direct uploads)
         const redisClient = await getRedisClient();
         t.truthy(redisClient, 'Redis client should be available');
         
         const contextMapKey = `FileStoreMap:ctx:${contextId}`;
         
         const file1 = {
-            url: 'https://example.com/labeeb-file-1.txt',
-            gcs: 'gs://bucket/labeeb-file-1.txt',
-            hash: 'hash-labeeb-1',
-            filename: 'labeeb-file-1.txt',
-            displayFilename: 'labeeb-file-1.txt',
+            url: 'https://example.com/direct-file-1.txt',
+            gcs: 'gs://bucket/direct-file-1.txt',
+            hash: 'hash-direct-1',
+            filename: 'direct-file-1.txt',
+            displayFilename: 'direct-file-1.txt',
             mimeType: 'text/plain',
             addedDate: new Date().toISOString(),
             lastAccessed: new Date().toISOString(),
@@ -1141,11 +1141,11 @@ test('File collection: syncAndStripFilesFromChatHistory finds and syncs files wi
         };
         
         const file2 = {
-            url: 'https://example.com/labeeb-file-2.txt',
-            gcs: 'gs://bucket/labeeb-file-2.txt',
-            hash: 'hash-labeeb-2',
-            filename: 'labeeb-file-2.txt',
-            displayFilename: 'labeeb-file-2.txt',
+            url: 'https://example.com/direct-file-2.txt',
+            gcs: 'gs://bucket/direct-file-2.txt',
+            hash: 'hash-direct-2',
+            filename: 'direct-file-2.txt',
+            displayFilename: 'direct-file-2.txt',
             mimeType: 'text/plain',
             addedDate: new Date().toISOString(),
             lastAccessed: new Date().toISOString(),
@@ -1156,11 +1156,11 @@ test('File collection: syncAndStripFilesFromChatHistory finds and syncs files wi
         };
         
         const file3 = {
-            url: 'https://example.com/labeeb-file-3.txt',
-            gcs: 'gs://bucket/labeeb-file-3.txt',
-            hash: 'hash-labeeb-3',
-            filename: 'labeeb-file-3.txt',
-            displayFilename: 'labeeb-file-3.txt',
+            url: 'https://example.com/direct-file-3.txt',
+            gcs: 'gs://bucket/direct-file-3.txt',
+            hash: 'hash-direct-3',
+            filename: 'direct-file-3.txt',
+            displayFilename: 'direct-file-3.txt',
             mimeType: 'text/plain',
             addedDate: new Date().toISOString(),
             lastAccessed: new Date().toISOString(),

--- a/tests/integration/graphql/async/stream/file_operations_agent.test.js
+++ b/tests/integration/graphql/async/stream/file_operations_agent.test.js
@@ -1,6 +1,6 @@
 // file_operations_agent.test.js
 // End-to-end integration tests for file operations with sys_entity_agent
-// Tests scenarios where files are uploaded directly to file handler (like Labeeb does)
+// Tests scenarios where files are uploaded directly to file handler (like a client does)
 // and then processed by sys_entity_agent
 
 import test from 'ava';
@@ -39,7 +39,7 @@ function getFileHandlerUrl() {
     return 'http://localhost:7071';
 }
 
-// Helper to upload file directly to file handler (like Labeeb does)
+// Helper to upload file directly to file handler (like a client does)
 async function uploadFileToHandler(content, filename, contextId) {
     const fileHandlerUrl = getFileHandlerUrl();
     if (!fileHandlerUrl || fileHandlerUrl === 'null') {
@@ -55,7 +55,7 @@ async function uploadFileToHandler(content, filename, contextId) {
     fs.writeFileSync(tempFilePath, content);
 
     try {
-        // Compute hash from content (client-side, like Labeeb does)
+        // Compute hash from content (client-side, like a client does)
         const contentBuffer = Buffer.from(content);
         const hash = await computeBufferHash(contentBuffer);
         
@@ -241,7 +241,7 @@ test('sys_entity_agent processes multiple files uploaded directly to file handle
     const chatId = `test-chat-${Date.now()}`;
     
     try {
-        // Upload 3 files directly to file handler (like Labeeb does)
+        // Upload 3 files directly to file handler (like a client does)
         // These will have contextId but no inCollection set
         const file1 = await uploadFileToHandler(
             'File 1 Content\nThis is the first test file with some content.',
@@ -468,7 +468,7 @@ test('sys_entity_agent processes files from compound context (user + workspace)'
         }
 
         // Create files in user context (encrypted)
-        // No inCollection set initially (like Labeeb uploads)
+        // No inCollection set initially (like direct uploads)
         const userFile1 = {
             id: `user-file-1-${Date.now()}`,
             url: 'https://example.com/user-document.pdf',
@@ -496,7 +496,7 @@ test('sys_entity_agent processes files from compound context (user + workspace)'
         };
         
         // Create files in workspace context (unencrypted)
-        // No inCollection set initially (like Labeeb uploads)
+        // No inCollection set initially (like direct uploads)
         const workspaceFile1 = {
             id: `workspace-file-1-${Date.now()}`,
             url: 'https://example.com/workspace-shared.pdf',
@@ -602,7 +602,7 @@ test('sys_entity_agent processes files from compound context (user + workspace)'
         
         t.truthy(result, 'Should return result');
         t.truthy(result.chatHistory, 'Should have processed chatHistory');
-        t.truthy(result.availableFiles, 'Should have availableFiles');
+        t.false('availableFiles' in result, 'File availability is exposed through file tools, not chat-history sync');
         
         // Verify files were stripped (replaced with placeholders)
         const processedContent = result.chatHistory[0].content;
@@ -836,4 +836,3 @@ test('sys_entity_agent processes real files from compound context (user + worksp
         }
     }
 });
-


### PR DESCRIPTION
## Summary
- remove the stale available-files prompt constant
- point file tool descriptions at ListFileCollection and SearchFileCollection
- update file history sync docs and assertions to match the current return contract

## Validation
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/fileToolInputContracts.test.js tests/unit/core/fileCollection.test.js
- node --check tests/integration/features/tools/fileCollection.test.js
- node --check tests/integration/graphql/async/stream/file_operations_agent.test.js