### PR TITLE
[codex] Update media prompt assistant default model

### DIFF
--- a/pathways/media_prompt_assistant.js
+++ b/pathways/media_prompt_assistant.js
@@ -166,7 +166,7 @@ Context:
     referenceCount: 0,
   },
   max_tokens: 2048,
-  model: 'oai-gpt4o',
+  model: 'oai-gpt54-mini',
   useInputChunking: false,
   enableDuplicateRequests: false,
   timeout: 30,

--- a/tests/unit/pathways/mediaPromptAssistant.test.js
+++ b/tests/unit/pathways/mediaPromptAssistant.test.js
@@ -9,8 +9,8 @@ function createResolver() {
   };
 }
 
-test("media prompt assistant uses the default OpenAI vision model", (t) => {
-  t.is(mediaPromptAssistant.model, "oai-gpt4o");
+test("media prompt assistant uses GPT 5.4 mini", (t) => {
+  t.is(mediaPromptAssistant.model, "oai-gpt54-mini");
 });
 
 test("media prompt assistant optimizes supplied prompts with model and reference context", async (t) => {


### PR DESCRIPTION
## Summary
- switch the media prompt assistant default model to GPT 5.4 mini
- update the focused media prompt assistant unit expectation

## Validation
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/mediaPromptAssistant.test.js