### PR TITLE
[codex] Update generic grammar and taxonomy pathways

### DIFF
--- a/pathways/grammar.js
+++ b/pathways/grammar.js
@@ -1,30 +1,59 @@
 import { Prompt } from '../server/prompt.js';
+import { PathwayResolver } from '../server/pathwayResolver.js';
 
-export default {
-    temperature: 0,
-    prompt: [
-        new Prompt({
-            messages: [
-                {
-                    "role": "system", "content": `
-Assistant is a highly skilled copy editor for a prestigious news agency. 
+const defaultPrompt = [
+    {
+        role: "system",
+        content: `
+Assistant is a highly skilled copy editor for a prestigious news agency.
 When the user posts any text, assistant will correct all spelling and grammar in the text and change words to British English word spellings, while following the rules below:
 - Assistant will preserve HTML markup in the text, e.g. The <a href="https://bbc.com">British Broadcsating Corporation</a> reported on this fact yesterday. => The <a href="https://bbc.com">British Broadcasting Corporation</a> reportd on this fact yesterday.
 - Assistant will not modify or delete image URLs.
 - Assistant will not change self-closing tags (e.g. don't change <br/> to <br> or <br> to <br/>).
 - Assistant will preserve WordPress shortcodes in the text, e.g. foo [caption prop="x"] A biy inspects the insect [/caption] baz => foo [caption prop="x"] A boy inspects the insect [/caption] baz
-- Assistant will produce only the corrected text and no additional notes or commentary.` },
-                { "role": "user", "content": "The $20 bill was the wrong color." },
-                { "role": "assistant", "content": "The $20 bill was the wrong colour." },
-                { "role": "user", "content": `The <a href="https://bbc.com">British Broadcsating Corporation</a> reportd on this fact yesterday.` },
-                { "role": "assistant", "content": `The <a href="https://bbc.com">British Broadcasting Corporation</a> reported on this fact yesterday.` },
-                { "role": "user", "content": "{{{text}}}" }
-            ]
+- Assistant will produce only the corrected text and no additional notes or commentary.
+- When checking Arabic language text, assistant will use ى and ي in their appropriate places. Do not incorrectly change ى to ي or vice versa.`,
+    },
+    { role: "user", content: "The $20 bill was the wrong color." },
+    { role: "assistant", content: "The $20 bill was the wrong colour." },
+    { role: "user", content: `The <a href="https://bbc.com">British Broadcsating Corporation</a> reportd on this fact yesterday.` },
+    { role: "assistant", content: `The <a href="https://bbc.com">British Broadcasting Corporation</a> reported on this fact yesterday.` },
+    { role: "user", content: "{{{text}}}" },
+];
+
+export default {
+    temperature: 0,
+    prompt: [
+        new Prompt({
+            messages: defaultPrompt,
         }),
     ],
     inputFormat: 'html',
     useInputChunking: true,
     inputChunkSize: 1000,
     useParallelChunkProcessing: true,
-    model: 'oai-gpt4o'
-}
+    model: 'oai-gpt4o',
+    inputParameters: {
+        text: '',
+        model: 'oai-gpt4o',
+        userPrompt: '',
+        reasoningEffort: 'none',
+        json: false,
+        useInputChunking: true,
+        inputChunkSize: 1000,
+    },
+    resolver: async (_parent, args, contextValue) => {
+        const { config, pathway } = contextValue;
+
+        const pathwayConfig = {
+            ...pathway,
+            json: args.json,
+            useInputChunking: args.useInputChunking,
+            inputChunkSize: args.useInputChunking ? args.inputChunkSize : undefined,
+            prompt: [args.userPrompt || new Prompt({ messages: defaultPrompt })],
+        };
+
+        const pathwayResolver = new PathwayResolver({ config, pathway: pathwayConfig, args });
+        return await pathwayResolver.resolve(args);
+    },
+};

--- a/pathways/taxonomy.js
+++ b/pathways/taxonomy.js
@@ -6,13 +6,13 @@ import { Prompt } from "../server/prompt.js";
 import { PathwayResolver } from '../server/pathwayResolver.js';
 import { callPathway } from '../lib/pathwayTools.js';
 
-function getFilteredTaxonomyItems(taxonomyResult, taxonomySet) {
+export function getFilteredTaxonomyItems(taxonomyResult, taxonomySet) {
     // Normalize taxonomy item
     function normalizeTaxonomyItem(item) {
         return item.trim().toLowerCase().replace(/[.,]/g, '');
     }
 
-    const taxonomyItems = taxonomySet.split(',');
+    const taxonomyItems = taxonomySet.split(',').map(item => item.trim()).filter(Boolean);
     const filteredTaxonomyResult = taxonomyResult.reduce((acc, item) => {
         const normalizedItem = normalizeTaxonomyItem(item);
         const matchingItemIndex = taxonomyItems
@@ -45,6 +45,10 @@ export default {
         count: 5,
         taxonomyItems: '',
         taxonomyType: 'topic',
+        initialFilterPrompt: '',
+        singleSelectPrompt: '',
+        rankingPrompt: '',
+        model: 'oai-gpt4o',
     },
 
     // Set 'list' to true to indicate that the output is expected to be a list.
@@ -57,6 +61,9 @@ export default {
         const taxonomyItems = args.taxonomyItems;
         const taxonomyType = args.taxonomyType || 'topic';
         let text = args.text;
+        const initialFilterPrompt = args.initialFilterPrompt;
+        const singleSelectPrompt = args.singleSelectPrompt;
+        const rankingPrompt = args.rankingPrompt;
 
         // Summarize the input text
         text = await callPathway('summary', { ...args, targetLength: 0 });
@@ -85,7 +92,10 @@ export default {
             pathwayResolver.pathwayPrompt = [
                 new Prompt({
                     messages: [
-                        { "role": "system", "content": `Assistant is an AI editorial assistant for an online news agency tasked with identifying ${taxonomyType}s from a pre-determined list that fit a news article summary. When User posts a news article summary and a list of possible ${taxonomyType}s, assistant will carefully examine the ${taxonomyType}s in the list. If any of them are a high confidence match for the article, assistant will return the matching ${taxonomyType}s as a comma separated list. Assistant must only identify a ${taxonomyType} if assistant is sure the ${taxonomyType} is a good match for the article. Any ${taxonomyType}s that assistant returns must be in the list already - assistant cannot add new ${taxonomyType}s. If there are no good matches, assistant will respond with <none>. Assistant will return only the ${taxonomyType}s and no other notes or commentary.`},
+                        {
+                            "role": "system",
+                            "content": initialFilterPrompt?.replace(/\${taxonomyType}/g, taxonomyType) || `You are an AI editorial assistant for an online news agency, tasked with identifying the most appropriate ${taxonomyType}s from a pre-determined list based on a news article summary. When given a news article summary and a list of possible ${taxonomyType}s, carefully examine the ${taxonomyType}s in the list and select up to the top 10 that are highly relevant to the article content.\n\nPlease adhere to the following instructions:\n- Only identify a ${taxonomyType} if you are confident it is a good match for the article.\n- Return the matching ${taxonomyType}s as a comma-separated list.\n- Only use the ${taxonomyType}s provided in the list; do not add new ${taxonomyType}s.\n- If there are no suitable matches, respond with <none>.\n- Provide only the ${taxonomyType}s and no additional notes or commentary.`,
+                        },
                         { "role": "user", "content": `Article Summary: {{{text}}}\n\nPossible ${taxonomyType}s: ${taxonomyItemSet}\n\n`},
                     ]
                 }),
@@ -104,7 +114,10 @@ export default {
             pathwayResolver.pathwayPrompt = [
                 new Prompt({
                     messages: [
-                        { "role": "system", "content": `Assistant is an AI editorial assistant for an online news agency tasked with identifying a single ${taxonomyType} from a list that best fits a news article summary. When User posts a news article summary and a list of possible ${taxonomyType}s, assistant will carefully examine the ${taxonomyType}s in the list and return the one ${taxonomyType} that best represents the news article summary. Assistant will use high judgement when picking the correct ${taxonomyType}. Assistant will return only the ${taxonomyType} and no other notes or commentary.` },
+                        {
+                            "role": "system",
+                            "content": singleSelectPrompt?.replace(/\${taxonomyType}/g, taxonomyType) || `Assistant is an AI editorial assistant for an online news agency tasked with identifying a single ${taxonomyType} from a list that best fits a news article summary. When User posts a news article summary and a list of possible ${taxonomyType}s, assistant will carefully examine the ${taxonomyType}s in the list and return the one ${taxonomyType} that best represents the news article summary. Assistant will use high judgement when picking the correct ${taxonomyType}. Assistant will return only the ${taxonomyType} and no other notes or commentary.`,
+                        },
                         { "role": "user", "content": `Article Summary: {{{text}}}\n\nPossible ${taxonomyType}s: ${taxonomyItemResults.join(', ')}\n\n`},
                     ]
                 }),
@@ -113,7 +126,10 @@ export default {
             pathwayResolver.pathwayPrompt = [
                 new Prompt({
                     messages: [
-                        { "role": "system", "content": `Assistant is an AI editorial assistant for an online news agency tasked with identifying ${taxonomyType}s from a list that best fit a news article summary. When User posts a news article summary and a list of possible ${taxonomyType}s, assistant will carefully examine the ${taxonomyType}s in the list and return them in order of relevance to the article summary (best fit first). Assistant will return only the list of ${taxonomyType}s and no other notes or commentary. Assistant will not add ${taxonomyType}s to the list and will select only from User's posted ${taxonomyType}s.` },
+                        {
+                            "role": "system",
+                            "content": rankingPrompt?.replace(/\${taxonomyType}/g, taxonomyType) || `Assistant is an AI editorial assistant for an online news agency tasked with identifying ${taxonomyType}s from a list that best fit a news article summary. When User posts a news article summary and a list of possible ${taxonomyType}s, assistant will carefully examine the ${taxonomyType}s in the list and return them in order of relevance to the article summary (best fit first). Assistant will return only the list of ${taxonomyType}s and no other notes or commentary. Assistant will not add ${taxonomyType}s to the list and will select only from User's posted ${taxonomyType}s.`,
+                        },
                         { "role": "user", "content": `Article Summary: {{{text}}}\n\nPossible ${taxonomyType}s: ${taxonomyItemResults.join(', ')}\n\n`},
                     ]
                 }),

--- a/tests/unit/pathways/genericPathwayUpdates.test.js
+++ b/tests/unit/pathways/genericPathwayUpdates.test.js
@@ -1,0 +1,42 @@
+import test from "ava";
+import grammar from "../../../pathways/grammar.js";
+import taxonomy, {
+  getFilteredTaxonomyItems,
+} from "../../../pathways/taxonomy.js";
+
+test("grammar exposes runtime override parameters while keeping default HTML editing behavior", (t) => {
+  t.is(grammar.model, "oai-gpt4o");
+  t.is(grammar.inputFormat, "html");
+  t.true(grammar.useInputChunking);
+  t.is(grammar.inputChunkSize, 1000);
+  t.is(typeof grammar.resolver, "function");
+  t.is(grammar.inputParameters.userPrompt, "");
+  t.is(grammar.inputParameters.reasoningEffort, "none");
+  t.false(grammar.inputParameters.json);
+  t.true(grammar.inputParameters.useInputChunking);
+
+  const systemPrompt = grammar.prompt[0].messages[0].content;
+  t.regex(systemPrompt, /preserve HTML markup/);
+  t.regex(systemPrompt, /WordPress shortcodes/);
+  t.regex(systemPrompt, /Do not incorrectly change ى to ي or vice versa/);
+});
+
+test("taxonomy filters model output back to verbatim taxonomy items", (t) => {
+  const result = getFilteredTaxonomyItems(
+    ["climate", "Economy.", "not in list"],
+    "Climate, Economy, Politics",
+  );
+
+  t.deepEqual(result, ["Climate", "Economy"]);
+});
+
+test("taxonomy exposes configurable prompt templates and model selection", (t) => {
+  t.is(taxonomy.inputParameters.model, "oai-gpt4o");
+  t.is(taxonomy.inputParameters.initialFilterPrompt, "");
+  t.is(taxonomy.inputParameters.singleSelectPrompt, "");
+  t.is(taxonomy.inputParameters.rankingPrompt, "");
+  t.is(taxonomy.inputParameters.taxonomyType, "topic");
+  t.is(taxonomy.timeout, 240);
+  t.true(taxonomy.list);
+  t.is(typeof taxonomy.resolver, "function");
+});


### PR DESCRIPTION
## Summary
- add runtime prompt/json/chunking overrides to the grammar pathway while preserving default HTML editing behavior
- add configurable taxonomy prompt templates and model selection
- trim taxonomy candidates when filtering model output back to allowed values
- add focused unit coverage for the updated pathway contracts

## Tests
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/genericPathwayUpdates.test.js
- node --check pathways/grammar.js
- node --check pathways/taxonomy.js
- git diff --check