### PR TITLE
[codex] Handle empty AppTek translation results

### DIFF
--- a/pathways/translate_apptek.js
+++ b/pathways/translate_apptek.js
@@ -19,6 +19,9 @@ export default {
         try {
             // Execute the primary AppTek translation
             const result = await runAllPrompts(args);
+            if (result === null || result === undefined) {
+                throw new Error('AppTek translation returned no result');
+            }
             return result;
         } catch (error) {
             // If AppTek translation fails, use the configured fallback pathway
@@ -31,6 +34,10 @@ export default {
                     text: args.text, 
                     to: args.to || pathwayResolver.pathway.inputParameters.to,
                 }, pathwayResolver);
+
+                if (fallbackResult === null || fallbackResult === undefined) {
+                    throw new Error(`${fallbackPathway} returned no result`);
+                }
                 
                 logger.verbose(`Successfully used ${fallbackPathway} as fallback`);
                 return fallbackResult;

--- a/tests/unit/plugins/translate_apptek.test.js
+++ b/tests/unit/plugins/translate_apptek.test.js
@@ -131,3 +131,19 @@ test('pathway has executePathway function', async (t) => {
     t.truthy(pathway.default.executePathway);
     t.is(typeof pathway.default.executePathway, 'function');
 });
+
+test('executePathway treats missing AppTek output as a fallback-triggering failure', async (t) => {
+    const pathway = await import('../../../pathways/translate_apptek.js');
+
+    const error = await t.throwsAsync(() => pathway.default.executePathway({
+        args: {
+            text: 'Hello, how are you?',
+            to: 'es',
+            fallbackPathway: 'missing_fallback_pathway',
+        },
+        runAllPrompts: async () => null,
+        resolver: { pathway: pathway.default },
+    }));
+
+    t.is(error.message, 'AppTek translation returned no result');
+});


### PR DESCRIPTION
## Summary
- treat null or undefined AppTek translation output as a failure so fallback handling runs
- treat null or undefined fallback output as a fallback failure
- add focused unit coverage for missing primary output

## Tests
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/plugins/translate_apptek.test.js
- node --check pathways/translate_apptek.js
- node --check tests/unit/plugins/translate_apptek.test.js
- git diff --check