### PR TITLE
Tighten memory and applet helper defaults

### DIFF
--- a/pathways/system/entity/tools/sys_tool_remember.js
+++ b/pathways/system/entity/tools/sys_tool_remember.js
@@ -35,6 +35,6 @@ export default {
             args.chatHistory.push({role: "user", content: args.detailedInstructions});
         }
         resolver.tool = JSON.stringify({ toolUsed: "memory" });
-        return await callPathway('sys_search_memory', { ...args, stream: false, section: 'memoryAll', updateContext: true });
+        return await callPathway('sys_search_memory', { ...args, stream: false, section: 'memoryAll', updateContext: true, reasoningEffort: 'none' });
     }
 }

--- a/pathways/system/entity/tools/sys_tool_store_memory.js
+++ b/pathways/system/entity/tools/sys_tool_store_memory.js
@@ -10,6 +10,7 @@ export default {
     toolDefinition: [{
         type: "function",
         icon: "💾",
+        toolCost: 1,
         function: {
             name: "StoreMemory",
             description: "Use this tool to store information to your memory. Use this when the user asks you to remember something, or when you want to save important information from the conversation for future reference.",
@@ -88,9 +89,10 @@ export default {
                 return JSON.stringify({ error: `Invalid section: ${section}. Must be one of: ${validSections.join(', ')}` });
             }
             
-            // Use memory-specific priority if it's a valid number (1, 2, or 3), otherwise use default
-            const priority = (typeof memory.priority === 'number' && [1, 2, 3].includes(memory.priority))
-                ? memory.priority
+            // Use memory-specific priority if it's valid (1, 2, or 3), otherwise use default.
+            const parsedPriority = Number.parseInt(memory.priority, 10);
+            const priority = [1, 2, 3].includes(parsedPriority)
+                ? parsedPriority
                 : defaultPriority;
             
             // Format as: priority|timestamp|content

--- a/pathways/system/sys_repair_json.js
+++ b/pathways/system/sys_repair_json.js
@@ -10,8 +10,10 @@ export default {
         })
     ],
     model: 'oai-gpt4o-mini',
+    inputParameters: {
+        reasoningEffort: 'none',
+    },
     temperature: 0.0,
     enableCache: true,
     enableDuplicateRequests: false,
 }
-

--- a/pathways/system/workspaces/workspace_applet_edit.js
+++ b/pathways/system/workspaces/workspace_applet_edit.js
@@ -9,7 +9,7 @@ export default {
             messages: [
                 {
                     role: "system",
-                    content: `You are a UI/UX expert assistant. Your task is to help Al Jazeera employees design and create applets for company use, or discuss the design of such applets. 
+                    content: `You are a UI/UX expert assistant. Your task is to help users design and create applets, or discuss the design of such applets.
                     
                     Each applet is a single page application that should be responsive to the screen size, accessible, secure, and performant.
 
@@ -551,7 +551,7 @@ export default {
                     10. Implement data export/import features for user convenience
 
                     {{#if promptDetails}}
-                    Available promptDetails for this workspace:
+                    Available promptDetails for this applet:
                     {{promptDetails}}
                     {{/if}}
 
@@ -574,7 +574,7 @@ export default {
                     - Add real-time collaboration features when applicable
                     - Implement proper caching strategies
                     - Add proper logging and monitoring hooks
-                    - Implement proper security measures (input sanitization, CSRF protection)
+                    - Implement proper security measures (input validation, CSRF protection)
 
                     When creating UI components, follow these guidelines:
                     - Use clean, semantic HTML with descriptive class names
@@ -657,4 +657,4 @@ export default {
     model: 'gemini-pro-25-vision',
     timeout: 600,
     stream: true,
-} 
+}

--- a/tests/unit/pathways/memoryToolContracts.test.js
+++ b/tests/unit/pathways/memoryToolContracts.test.js
@@ -1,0 +1,17 @@
+import test from "ava";
+import storeMemory from "../../../pathways/system/entity/tools/sys_tool_store_memory.js";
+import searchMemory from "../../../pathways/system/entity/tools/sys_tool_remember.js";
+import repairJson from "../../../pathways/system/sys_repair_json.js";
+
+test("StoreMemory is budgeted as a cheap tool", (t) => {
+  t.is(storeMemory.toolDefinition[0].toolCost, 1);
+});
+
+test("StoreMemory accepts numeric-string priorities defensively", (t) => {
+  t.regex(String(storeMemory.executePathway), /Number\.parseInt\(memory\.priority, 10\)/);
+});
+
+test("SearchMemory and JSON repair disable reasoning by default", (t) => {
+  t.regex(String(searchMemory.executePathway), /reasoningEffort:\s*['"]none['"]/);
+  t.is(repairJson.inputParameters.reasoningEffort, "none");
+});


### PR DESCRIPTION
## Summary
- mark memory storage as a low-cost tool and handle numeric-string memory priorities
- disable reasoning for memory lookup and JSON repair helper calls
- make the applet editor prompt generic and applet-focused

## Tests
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/memoryToolContracts.test.js