### PR TITLE
Add generic content utility pathways

### DIFF
--- a/pathways/categorize_feedback.js
+++ b/pathways/categorize_feedback.js
@@ -1,0 +1,36 @@
+import { Prompt } from '../server/prompt.js';
+
+const DEFAULT_FEEDBACK_CATEGORIES = [
+    'Brand Praise',
+    'Brand Complaint',
+    'Content Suggestion',
+    'Content Correction',
+    'General Feedback',
+    'Feature Suggestion',
+].join('\n');
+
+export default {
+    prompt: [
+        new Prompt({
+            messages: [
+                {
+                    role: 'system',
+                    content: `Assistant is an expert customer service AI tasked with categorizing customer feedback. When the user submits customer feedback with feedback ids, Assistant will categorize each feedback item into one of the following categories:
+
+{{{categories}}}
+
+Assistant must choose exactly one category from the provided list per feedback id and cannot create new categories. Assistant will return a list of the feedback ids and their corresponding categories in comma-separated, newline-delimited format so that it can easily be loaded as a CSV file or copied into a spreadsheet. Assistant will return the categorized feedback ids and no other notes or commentary.`,
+                },
+                { role: 'user', content: 'Customer feedback:\n\n{{{text}}}' },
+            ],
+        }),
+    ],
+    inputParameters: {
+        categories: DEFAULT_FEEDBACK_CATEGORIES,
+    },
+    model: 'oai-gpt4o',
+    joinChunksWith: '\n',
+    tokenRatio: 1,
+    enableDuplicateRequests: false,
+    timeout: 1800,
+};

--- a/pathways/create_article.js
+++ b/pathways/create_article.js
@@ -1,0 +1,39 @@
+export default {
+    inputParameters: {
+        targetHeadlineLength: 60,
+        targetSummaryLength: 120,
+        targetShortDescriptionLength: 80,
+        targetArticleLength: 750,
+        targetArticleParagraphs: 6,
+        language: 'English',
+        topics: 'News',
+        tags: '',
+        where: '',
+    },
+
+    model: 'oai-gpt4o',
+    enableDuplicateRequests: false,
+    useInputChunking: false,
+    enableCache: true,
+    json: true,
+    prompt: [
+        `Assistant is a highly skilled multilingual writer. Assistant generates attention-grabbing, informative, and engaging headlines, summaries, short descriptions, and article content based on a given list of topics, tags, and target locations.
+
+Assistant must return only a JSON object with these properties: "headline", "summary", "shortDescription", and "article".
+
+Use the following inputs:
+- Topic(s): {{{topics}}}
+- Tag(s): {{{tags}}}
+- Target location or audience: {{{where}}}
+- Language: {{{language}}}
+
+Constraints:
+- The headline must have at most {{{targetHeadlineLength}}} characters.
+- The summary must have at most {{{targetSummaryLength}}} characters.
+- The short description must have at most {{{targetShortDescriptionLength}}} characters.
+- The article content must have at most {{{targetArticleLength}}} characters.
+- The article should be split into {{{targetArticleParagraphs}}} paragraphs.
+
+Return only the JSON object. Do not include markdown, comments, or additional notation.`,
+    ],
+};

--- a/pathways/greeting.js
+++ b/pathways/greeting.js
@@ -1,0 +1,37 @@
+import { Prompt } from '../server/prompt.js';
+import { config } from '../config.js';
+
+const entityConstants = config.get('entityConstants');
+
+export default {
+    prompt: [
+        new Prompt({
+            messages: [
+                {
+                    role: 'system',
+                    content: `${entityConstants.AI_MEMORY}\n\n${entityConstants.AI_COMMON_INSTRUCTIONS}\n${entityConstants.AI_EXPERTISE}\n${entityConstants.AI_MEMORY_INSTRUCTIONS}\n\nInformation: {{{text}}}`,
+                },
+                {
+                    role: 'user',
+                    content: "You have already done some research on behalf of the user. The information you've collected is specified in the Information section above. Generate a professional and warm greeting that will appear on the dashboard of the logged in user. Assume this greeting is the first thing they see when they log in to the portal. If you know the user's name, include it in the greeting. The tone should be motivating but not overly casual. 1-2 sentences are ideal. If there's anything particularly interesting or timely in your research, mention it briefly. Do not use any additional tools or attempt to remember more information - just use the information available to you here.",
+                },
+            ],
+        }),
+    ],
+    useInputChunking: false,
+    enableDuplicateRequests: false,
+    model: 'oai-gpt41',
+    inputParameters: {
+        privateData: false,
+        chatHistory: [{ role: '', content: [] }],
+        contextId: '',
+        indexName: '',
+        semanticConfiguration: '',
+        roleInformation: '',
+        calculateEmbeddings: false,
+        dataSources: { type: 'array', items: { type: 'string' }, default: [] },
+        language: 'English',
+        aiName: 'Jarvis',
+    },
+    timeout: 300,
+};

--- a/pathways/personalize.js
+++ b/pathways/personalize.js
@@ -1,0 +1,26 @@
+import { Prompt } from '../server/prompt.js';
+
+export default {
+    prompt: [
+        new Prompt({
+            messages: [
+                {
+                    role: 'system',
+                    content: 'Assistant is a personal content assistant. Assistant extracts a maximum of {{count}} items from a given array of candidate content, choosing the items that are most relevant to the user based on their interests. These interests are deduced from an array of questions the user has asked and an array of content items they have recently viewed. Assistant will respond only with the most interesting and relevant items and no additional notes or commentary. Assistant will respond with a JSON array and no other output.',
+                },
+                {
+                    role: 'user',
+                    content: 'Here are the questions the user has asked:\n{{questions}}\n---\nHere are the content items the user has recently viewed:\n{{itemsViewed}}\n---\nHere are the candidate items to choose from:\n{{text}}\n',
+                },
+            ],
+        }),
+    ],
+    inputParameters: {
+        count: 4,
+        questions: '',
+        itemsViewed: '',
+    },
+    model: 'oai-gpt4o',
+    temperature: 0.0,
+    json: true,
+};

--- a/tests/unit/pathways/genericOverlayPathways.test.js
+++ b/tests/unit/pathways/genericOverlayPathways.test.js
@@ -1,0 +1,57 @@
+import test from 'ava';
+import categorizeFeedback from '../../../pathways/categorize_feedback.js';
+import greeting from '../../../pathways/greeting.js';
+import personalize from '../../../pathways/personalize.js';
+import createArticle from '../../../pathways/create_article.js';
+
+const internalNamesPattern = new RegExp(`${'Al ' + 'Jazeera'}|${'La' + 'beeb'}`, 'i');
+
+test('categorize_feedback exposes generic feedback categories and CSV-style output', t => {
+    t.is(categorizeFeedback.model, 'oai-gpt4o');
+    t.false(categorizeFeedback.enableDuplicateRequests);
+    t.regex(categorizeFeedback.inputParameters.categories, /Brand Praise/);
+    t.regex(categorizeFeedback.inputParameters.categories, /Feature Suggestion/);
+
+    const [systemMessage, userMessage] = categorizeFeedback.prompt[0].messages;
+    t.regex(systemMessage.content, /categorizing customer feedback/);
+    t.regex(systemMessage.content, /comma-separated, newline-delimited/);
+    t.is(userMessage.content, 'Customer feedback:\n\n{{{text}}}');
+    t.false(internalNamesPattern.test(systemMessage.content));
+});
+
+test('greeting generates dashboard copy using generic entity defaults', t => {
+    t.is(greeting.model, 'oai-gpt41');
+    t.false(greeting.enableDuplicateRequests);
+    t.is(greeting.inputParameters.aiName, 'Jarvis');
+    t.is(greeting.inputParameters.language, 'English');
+
+    const userMessage = greeting.prompt[0].messages[1].content;
+    t.regex(userMessage, /dashboard/);
+    t.regex(userMessage, /1-2 sentences/);
+    t.false(internalNamesPattern.test(userMessage));
+});
+
+test('personalize selects relevant content items as JSON', t => {
+    t.true(personalize.json);
+    t.is(personalize.inputParameters.count, 4);
+    t.true('questions' in personalize.inputParameters);
+    t.true('itemsViewed' in personalize.inputParameters);
+
+    const [systemMessage, userMessage] = personalize.prompt[0].messages;
+    t.regex(systemMessage.content, /personal content assistant/);
+    t.regex(systemMessage.content, /JSON array/);
+    t.regex(userMessage.content, /candidate items/);
+    t.false(internalNamesPattern.test(systemMessage.content + userMessage.content));
+});
+
+test('create_article returns a constrained generic article JSON contract', t => {
+    t.true(createArticle.json);
+    t.true(createArticle.enableCache);
+    t.false(createArticle.useInputChunking);
+    t.is(createArticle.inputParameters.targetShortDescriptionLength, 80);
+
+    const prompt = createArticle.prompt[0];
+    t.regex(prompt, /"headline", "summary", "shortDescription", and "article"/);
+    t.regex(prompt, /Return only the JSON object/);
+    t.false(internalNamesPattern.test(prompt));
+});


### PR DESCRIPTION
## Summary
- add reusable pathways for feedback categorization, dashboard greetings, personalized content selection, and article drafting
- add focused contract coverage for the new pathway defaults and output expectations

## Tests
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/genericOverlayPathways.test.js
- node --check pathways/categorize_feedback.js pathways/greeting.js pathways/personalize.js pathways/create_article.js tests/unit/pathways/genericOverlayPathways.test.js
- git diff --check