### PR TITLE
Add personal entity cleanup tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node start.js",
+    "cleanup:personal-entities": "node scripts/cleanup-personal-entities.js",
     "test": "ava"
   },
   "author": "",

--- a/scripts/cleanup-personal-entities.js
+++ b/scripts/cleanup-personal-entities.js
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+
+import "dotenv/config";
+import { MongoClient } from "mongodb";
+import {
+    classifyBlankOrphanEntities,
+    getEntitySignals,
+    resolveCanonicalPersonalEntity,
+    summarizeEntity,
+} from "./lib/personalEntityCleanup.js";
+
+const DEFAULT_LOCAL_URI = "mongodb://127.0.0.1:27017/cortex";
+
+function getArgValue(flag) {
+    const index = process.argv.indexOf(flag);
+    if (index === -1) {
+        return null;
+    }
+    return process.argv[index + 1] || null;
+}
+
+function getArgValues(flag) {
+    const values = [];
+    for (let index = 0; index < process.argv.length; index += 1) {
+        if (process.argv[index] === flag && process.argv[index + 1]) {
+            values.push(process.argv[index + 1]);
+        }
+    }
+    return values;
+}
+
+const shouldApply = process.argv.includes("--apply");
+const asJson = process.argv.includes("--json");
+const uri = getArgValue("--uri") || process.env.MONGO_URI || DEFAULT_LOCAL_URI;
+const explicitDbName = getArgValue("--db") || null;
+const defaultAiName = getArgValue("--default-ai-name") || "Jarvis";
+const defaultEntityNames = getArgValues("--default-name");
+const cleanupOptions = {
+    defaultAiName,
+    defaultEntityNames: defaultEntityNames.length
+        ? defaultEntityNames
+        : [defaultAiName],
+};
+
+async function loadCollections(db) {
+    const [users, entities] = await Promise.all([
+        db.collection("users")
+            .find(
+                {},
+                {
+                    projection: {
+                        userId: 1,
+                        username: 1,
+                        name: 1,
+                        contextId: 1,
+                        aiName: 1,
+                        personalEntityId: 1,
+                    },
+                },
+            )
+            .toArray(),
+        db.collection("entities").find({}).toArray(),
+    ]);
+
+    return { users, entities };
+}
+
+function buildPlan(users, entities, options) {
+    const resolutions = users
+        .map((user) => resolveCanonicalPersonalEntity(user, entities, options))
+        .filter((result) => result.status !== "no-related-entities");
+
+    const resolved = resolutions.filter((result) => result.status === "resolved");
+    const unresolved = resolutions.filter(
+        (result) => result.status === "unresolved",
+    );
+
+    const userPersonalEntityUpdates = [];
+    const canonicalEntityRepairs = [];
+    const duplicateEntityDeletes = [];
+    const futureReferencedEntityIds = new Set();
+
+    for (const result of resolved) {
+        const { user, canonical, orphanableDuplicates } = result;
+        const canonicalSignals = getEntitySignals(user, canonical, options);
+        futureReferencedEntityIds.add(canonical.id);
+
+        if (user.personalEntityId !== canonical.id) {
+            userPersonalEntityUpdates.push({
+                userId: user._id,
+                username: user.username,
+                from: user.personalEntityId || null,
+                to: canonical.id,
+            });
+        }
+
+        if (!canonicalSignals.owned || !canonicalSignals.associated) {
+            canonicalEntityRepairs.push({
+                entityId: canonical.id,
+                username: user.username,
+                contextId: user.contextId,
+                personalOwnerIdBefore: canonical.personalOwnerId || null,
+                createdByBefore: canonical.createdBy || null,
+                assocUserIdsBefore: Array.isArray(canonical.assocUserIds)
+                    ? canonical.assocUserIds
+                    : [],
+            });
+        } else if (canonical.personalOwnerId !== user.contextId) {
+            canonicalEntityRepairs.push({
+                entityId: canonical.id,
+                username: user.username,
+                contextId: user.contextId,
+                personalOwnerIdBefore: canonical.personalOwnerId || null,
+                createdByBefore: canonical.createdBy || null,
+                assocUserIdsBefore: Array.isArray(canonical.assocUserIds)
+                    ? canonical.assocUserIds
+                    : [],
+            });
+        }
+
+        for (const duplicate of orphanableDuplicates) {
+            duplicateEntityDeletes.push({
+                entityId: duplicate.id,
+                username: user.username,
+                canonicalEntityId: canonical.id,
+                summary: summarizeEntity(duplicate, user, options),
+            });
+        }
+    }
+
+    const orphanDeletes = classifyBlankOrphanEntities(
+        entities,
+        [...futureReferencedEntityIds],
+        options,
+    )
+        .filter(
+            (entity) =>
+                !duplicateEntityDeletes.some(
+                    (candidate) => candidate.entityId === entity.id,
+                ),
+        )
+        .map((entity) => ({
+            entityId: entity.id,
+            summary: summarizeEntity(entity, null, options),
+        }));
+
+    return {
+        resolved,
+        unresolved,
+        userPersonalEntityUpdates,
+        canonicalEntityRepairs,
+        duplicateEntityDeletes,
+        orphanDeletes,
+    };
+}
+
+async function applyPlan(db, plan) {
+    const users = db.collection("users");
+    const entities = db.collection("entities");
+    const applied = {
+        userPersonalEntityUpdates: 0,
+        canonicalEntityRepairs: 0,
+        duplicateEntityDeletes: 0,
+        orphanDeletes: 0,
+    };
+
+    for (const update of plan.userPersonalEntityUpdates) {
+        await users.updateOne(
+            { _id: update.userId },
+            { $set: { personalEntityId: update.to } },
+        );
+        applied.userPersonalEntityUpdates += 1;
+    }
+
+    for (const repair of plan.canonicalEntityRepairs) {
+        await entities.updateOne(
+            { id: repair.entityId },
+            {
+                $set: {
+                    personalOwnerId: repair.contextId,
+                    createdBy: repair.contextId,
+                },
+                $addToSet: {
+                    assocUserIds: repair.contextId,
+                },
+            },
+        );
+        applied.canonicalEntityRepairs += 1;
+    }
+
+    for (const deletion of plan.duplicateEntityDeletes) {
+        await entities.deleteOne({ id: deletion.entityId });
+        applied.duplicateEntityDeletes += 1;
+    }
+
+    for (const deletion of plan.orphanDeletes) {
+        await entities.deleteOne({ id: deletion.entityId });
+        applied.orphanDeletes += 1;
+    }
+
+    return applied;
+}
+
+function formatReport(uriValue, dbName, plan, options) {
+    return {
+        target: { uri: uriValue, db: dbName },
+        options,
+        summary: {
+            resolvedUsers: plan.resolved.length,
+            unresolvedUsers: plan.unresolved.length,
+            userPersonalEntityUpdates: plan.userPersonalEntityUpdates.length,
+            canonicalEntityRepairs: plan.canonicalEntityRepairs.length,
+            duplicateEntityDeletes: plan.duplicateEntityDeletes.length,
+            orphanDeletes: plan.orphanDeletes.length,
+        },
+        resolved: plan.resolved.map((result) => ({
+            username: result.user.username,
+            aiName: result.user.aiName || null,
+            currentPersonalEntityId: result.user.personalEntityId || null,
+            canonical: summarizeEntity(result.canonical, result.user, options),
+            related: result.related.map((entity) =>
+                summarizeEntity(entity, result.user, options),
+            ),
+            orphanableDuplicates: result.orphanableDuplicates.map((entity) =>
+                summarizeEntity(entity, result.user, options),
+            ),
+        })),
+        unresolved: plan.unresolved.map((result) => ({
+            username: result.user.username,
+            aiName: result.user.aiName || null,
+            reason: result.reason,
+            currentPersonalEntityId: result.user.personalEntityId || null,
+            related: result.related.map((entity) =>
+                summarizeEntity(entity, result.user, options),
+            ),
+            candidates: result.candidates.map((entity) =>
+                summarizeEntity(entity, result.user, options),
+            ),
+        })),
+        actions: {
+            userPersonalEntityUpdates: plan.userPersonalEntityUpdates,
+            canonicalEntityRepairs: plan.canonicalEntityRepairs,
+            duplicateEntityDeletes: plan.duplicateEntityDeletes,
+            orphanDeletes: plan.orphanDeletes,
+        },
+    };
+}
+
+async function main() {
+    const client = new MongoClient(uri);
+    await client.connect();
+
+    try {
+        const db = explicitDbName ? client.db(explicitDbName) : client.db();
+        const { users, entities } = await loadCollections(db);
+        const plan = buildPlan(users, entities, cleanupOptions);
+        const report = formatReport(uri, db.databaseName, plan, cleanupOptions);
+
+        if (asJson) {
+            console.log(JSON.stringify(report, null, 2));
+        } else {
+            console.log(`Target: ${report.target.uri} (${report.target.db})`);
+            console.log(shouldApply ? "Mode: APPLY" : "Mode: DRY RUN");
+            console.log(
+                `Resolved users: ${report.summary.resolvedUsers}, unresolved: ${report.summary.unresolvedUsers}`,
+            );
+            console.log(
+                `User pointer updates: ${report.summary.userPersonalEntityUpdates}`,
+            );
+            console.log(
+                `Canonical entity repairs: ${report.summary.canonicalEntityRepairs}`,
+            );
+            console.log(
+                `Duplicate entity deletes: ${report.summary.duplicateEntityDeletes}`,
+            );
+            console.log(`Blank orphan deletes: ${report.summary.orphanDeletes}`);
+            console.log();
+
+            if (report.actions.userPersonalEntityUpdates.length > 0) {
+                console.log("User personalEntityId updates:");
+                for (const update of report.actions.userPersonalEntityUpdates) {
+                    console.log(
+                        `  - ${update.username}: ${update.from || "<unset>"} -> ${update.to}`,
+                    );
+                }
+                console.log();
+            }
+
+            if (report.actions.duplicateEntityDeletes.length > 0) {
+                console.log("Duplicate entity deletes:");
+                for (const deletion of report.actions.duplicateEntityDeletes) {
+                    console.log(
+                        `  - ${deletion.username}: delete ${deletion.entityId} (${deletion.summary.name})`,
+                    );
+                }
+                console.log();
+            }
+
+            if (report.unresolved.length > 0) {
+                console.log("Unresolved users:");
+                for (const unresolved of report.unresolved) {
+                    console.log(
+                        `  - ${unresolved.username}: ${unresolved.reason} (${unresolved.related.length} related entities)`,
+                    );
+                }
+                console.log();
+            }
+        }
+
+        if (!shouldApply) {
+            return;
+        }
+
+        const applied = await applyPlan(db, plan);
+        if (asJson) {
+            console.log(JSON.stringify({ applied }, null, 2));
+        } else {
+            console.log("Applied:");
+            console.log(
+                `  userPersonalEntityUpdates=${applied.userPersonalEntityUpdates}`,
+            );
+            console.log(
+                `  canonicalEntityRepairs=${applied.canonicalEntityRepairs}`,
+            );
+            console.log(
+                `  duplicateEntityDeletes=${applied.duplicateEntityDeletes}`,
+            );
+            console.log(`  orphanDeletes=${applied.orphanDeletes}`);
+        }
+    } finally {
+        await client.close();
+    }
+}
+
+main().catch((error) => {
+    console.error(`Fatal error: ${error.message}`);
+    process.exit(1);
+});

--- a/scripts/lib/personalEntityCleanup.js
+++ b/scripts/lib/personalEntityCleanup.js
@@ -1,0 +1,280 @@
+const DEFAULT_AI_NAME = "Jarvis";
+
+function normalizeDefaultNames(options = {}) {
+    const names = options.defaultEntityNames?.length
+        ? options.defaultEntityNames
+        : [options.defaultAiName || DEFAULT_AI_NAME];
+
+    return new Set(names.map(normalizeName).filter(Boolean));
+}
+
+export function normalizeName(value) {
+    return String(value || "")
+        .trim()
+        .toLowerCase();
+}
+
+export function hasMeaningfulWorkspace(workspace) {
+    if (!workspace || typeof workspace !== "object") {
+        return false;
+    }
+
+    return Boolean(
+        workspace.shareName ||
+            workspace.containerId ||
+            workspace.url ||
+            workspace.secret ||
+            workspace.bootstrapSecret ||
+            workspace.status,
+    );
+}
+
+export function hasMeaningfulEntityState(entity) {
+    return Boolean(
+        hasMeaningfulWorkspace(entity?.workspace) ||
+            (entity?.resources || []).length > 0 ||
+            Object.keys(entity?.customTools || {}).length > 0 ||
+            Object.keys(entity?.secrets || {}).length > 0,
+    );
+}
+
+export function getEntitySignals(user, entity, options = {}) {
+    const aiName = normalizeName(user?.aiName || options.defaultAiName || DEFAULT_AI_NAME);
+    const entityName = normalizeName(entity?.name);
+    const assocUserIds = Array.isArray(entity?.assocUserIds)
+        ? entity.assocUserIds
+        : [];
+    const defaultNames = normalizeDefaultNames(options);
+
+    return {
+        referenced:
+            Boolean(user?.personalEntityId) && entity?.id === user.personalEntityId,
+        personalOwner:
+            Boolean(user?.contextId) && entity?.personalOwnerId === user.contextId,
+        owned: Boolean(user?.contextId) && entity?.createdBy === user.contextId,
+        associated:
+            Boolean(user?.contextId) && assocUserIds.includes(user.contextId),
+        aiNameMatch: Boolean(aiName) && entityName === aiName,
+        knownDefaultName: defaultNames.has(entityName),
+        meaningfulState: hasMeaningfulEntityState(entity),
+        blank: !hasMeaningfulEntityState(entity),
+    };
+}
+
+export function getRelatedEntitiesForUser(user, entities, options = {}) {
+    return entities
+        .filter((entity) => !entity?.isSystem)
+        .filter((entity) => {
+            const signals = getEntitySignals(user, entity, options);
+            return (
+                signals.referenced ||
+                signals.personalOwner ||
+                signals.owned ||
+                signals.associated
+            );
+        });
+}
+
+function isLikelyPersonalCandidate(user, entity, relatedCount, options) {
+    const signals = getEntitySignals(user, entity, options);
+    return (
+        signals.referenced ||
+        signals.personalOwner ||
+        signals.aiNameMatch ||
+        (relatedCount === 1 && (signals.owned || signals.associated))
+    );
+}
+
+function scoreCandidate(user, entity, options) {
+    const signals = getEntitySignals(user, entity, options);
+    let score = 0;
+
+    if (signals.personalOwner) score += 800;
+    if (signals.owned) score += 500;
+    if (signals.associated) score += 250;
+    if (signals.referenced) score += 200;
+    if (signals.aiNameMatch) score += 50;
+    if (signals.meaningfulState) score += 80;
+    if (!entity?.isSystem) score += 10;
+
+    return score;
+}
+
+function compareByRecency(a, b) {
+    const updatedA = new Date(a?.updatedAt || a?.createdAt || 0).getTime();
+    const updatedB = new Date(b?.updatedAt || b?.createdAt || 0).getTime();
+    return updatedB - updatedA;
+}
+
+function isLikelyPersonalDuplicate(user, entity, options) {
+    const signals = getEntitySignals(user, entity, options);
+    return (
+        signals.referenced ||
+        signals.personalOwner ||
+        signals.aiNameMatch ||
+        signals.knownDefaultName
+    );
+}
+
+export function resolveCanonicalPersonalEntity(user, entities, options = {}) {
+    const related = getRelatedEntitiesForUser(user, entities, options);
+    if (related.length === 0) {
+        return {
+            status: "no-related-entities",
+            user,
+            related: [],
+            candidates: [],
+            duplicates: [],
+            orphanableDuplicates: [],
+        };
+    }
+
+    let candidates = related.filter((entity) =>
+        isLikelyPersonalCandidate(user, entity, related.length, options),
+    );
+
+    if (candidates.length === 0 && related.length === 1) {
+        candidates = [...related];
+    }
+
+    if (candidates.length === 0) {
+        return {
+            status: "unresolved",
+            reason: "no-likely-personal-candidates",
+            user,
+            related,
+            candidates: [],
+            duplicates: [],
+            orphanableDuplicates: [],
+        };
+    }
+
+    const ranked = [...candidates].sort((left, right) => {
+        const scoreDiff =
+            scoreCandidate(user, right, options) - scoreCandidate(user, left, options);
+        return scoreDiff !== 0 ? scoreDiff : compareByRecency(left, right);
+    });
+
+    const top = ranked[0];
+    const second = ranked[1] || null;
+    const topSignals = getEntitySignals(user, top, options);
+    const statefulCandidates = ranked.filter(
+        (entity) => getEntitySignals(user, entity, options).meaningfulState,
+    );
+    const scoreGap =
+        second == null
+            ? Number.POSITIVE_INFINITY
+            : scoreCandidate(user, top, options) - scoreCandidate(user, second, options);
+
+    const hasStateConflict =
+        !topSignals.meaningfulState &&
+        ranked.some((entity) => {
+            if (entity.id === top.id) {
+                return false;
+            }
+            return getEntitySignals(user, entity, options).meaningfulState;
+        });
+
+    const hasStrongIdentity =
+        (topSignals.personalOwner || topSignals.owned) &&
+        topSignals.owned &&
+        topSignals.associated &&
+        (topSignals.aiNameMatch || topSignals.referenced);
+
+    if (statefulCandidates.length > 1) {
+        return {
+            status: "unresolved",
+            reason: "multiple-stateful-candidates",
+            user,
+            related,
+            candidates: ranked,
+            duplicates: [],
+            orphanableDuplicates: [],
+        };
+    }
+
+    if (hasStateConflict) {
+        return {
+            status: "unresolved",
+            reason: "stateful-conflict",
+            user,
+            related,
+            candidates: ranked,
+            duplicates: [],
+            orphanableDuplicates: [],
+        };
+    }
+
+    if (second && scoreGap < 100 && !hasStrongIdentity) {
+        return {
+            status: "unresolved",
+            reason: "ambiguous-score-gap",
+            user,
+            related,
+            candidates: ranked,
+            duplicates: [],
+            orphanableDuplicates: [],
+        };
+    }
+
+    const duplicates = related.filter((entity) => entity.id !== top.id);
+    const orphanableDuplicates = duplicates.filter(
+        (entity) =>
+            isLikelyPersonalDuplicate(user, entity, options) &&
+            !getEntitySignals(user, entity, options).meaningfulState,
+    );
+
+    return {
+        status: "resolved",
+        user,
+        canonical: top,
+        related,
+        candidates: ranked,
+        duplicates,
+        orphanableDuplicates,
+    };
+}
+
+export function classifyBlankOrphanEntities(
+    entities,
+    referencedEntityIds,
+    options = {},
+) {
+    const referenced = new Set(referencedEntityIds.filter(Boolean));
+
+    return entities.filter((entity) => {
+        const signals = getEntitySignals({}, entity, options);
+        const assocUserIds = Array.isArray(entity?.assocUserIds)
+            ? entity.assocUserIds
+            : [];
+
+        return (
+            !entity?.isSystem &&
+            !entity?.isDefault &&
+            !referenced.has(entity?.id) &&
+            !entity?.personalOwnerId &&
+            !entity?.createdBy &&
+            assocUserIds.length === 0 &&
+            !signals.meaningfulState &&
+            signals.knownDefaultName
+        );
+    });
+}
+
+export function summarizeEntity(entity, user = null, options = {}) {
+    const signals = getEntitySignals(user || {}, entity, options);
+    return {
+        id: entity?.id || null,
+        name: entity?.name || null,
+        personalOwnerId: entity?.personalOwnerId || null,
+        createdBy: entity?.createdBy || null,
+        assocUserIds: Array.isArray(entity?.assocUserIds)
+            ? entity.assocUserIds
+            : [],
+        workspace: hasMeaningfulWorkspace(entity?.workspace),
+        resources: (entity?.resources || []).length,
+        customTools: Object.keys(entity?.customTools || {}).length,
+        secrets: Object.keys(entity?.secrets || {}).length,
+        signals,
+    };
+}

--- a/tests/scripts/personalEntityCleanup.test.js
+++ b/tests/scripts/personalEntityCleanup.test.js
@@ -1,0 +1,108 @@
+import test from "ava";
+import {
+    classifyBlankOrphanEntities,
+    resolveCanonicalPersonalEntity,
+} from "../../scripts/lib/personalEntityCleanup.js";
+
+test("resolveCanonicalPersonalEntity prefers the owned aiName match over a stale referenced default", (t) => {
+    const user = {
+        username: "lana@example.com",
+        contextId: "ctx-1",
+        aiName: "Lana",
+        personalEntityId: "stale-jarvis",
+    };
+    const entities = [
+        {
+            id: "stale-jarvis",
+            name: "Jarvis",
+            createdBy: null,
+            assocUserIds: [],
+        },
+        {
+            id: "real-lana",
+            name: "Lana",
+            createdBy: "ctx-1",
+            assocUserIds: ["ctx-1"],
+        },
+    ];
+
+    const result = resolveCanonicalPersonalEntity(user, entities);
+
+    t.is(result.status, "resolved");
+    t.is(result.canonical.id, "real-lana");
+    t.deepEqual(
+        result.orphanableDuplicates.map((entity) => entity.id),
+        ["stale-jarvis"],
+    );
+});
+
+test("resolveCanonicalPersonalEntity leaves conflicting stateful candidates unresolved", (t) => {
+    const user = {
+        username: "lana@example.com",
+        contextId: "ctx-1",
+        aiName: "Lana",
+        personalEntityId: "stale-jarvis",
+    };
+    const entities = [
+        {
+            id: "stale-jarvis",
+            name: "Jarvis",
+            createdBy: null,
+            assocUserIds: [],
+            workspace: { shareName: "workspace-old" },
+        },
+        {
+            id: "real-lana",
+            name: "Lana",
+            createdBy: "ctx-1",
+            assocUserIds: ["ctx-1"],
+        },
+    ];
+
+    const result = resolveCanonicalPersonalEntity(user, entities);
+
+    t.is(result.status, "unresolved");
+    t.is(result.reason, "stateful-conflict");
+});
+
+test("classifyBlankOrphanEntities only returns blank unowned default-name orphans", (t) => {
+    const entities = [
+        { id: "jarvis-1", name: "Jarvis", assocUserIds: [], createdBy: null },
+        {
+            id: "lana-1",
+            name: "Lana",
+            assocUserIds: [],
+            createdBy: null,
+        },
+        {
+            id: "jarvis-2",
+            name: "Jarvis",
+            assocUserIds: [],
+            createdBy: null,
+            workspace: { shareName: "workspace-old" },
+        },
+    ];
+
+    const result = classifyBlankOrphanEntities(entities, []);
+
+    t.deepEqual(
+        result.map((entity) => entity.id),
+        ["jarvis-1"],
+    );
+});
+
+test("default names can be configured for non-default deployments", (t) => {
+    const entities = [
+        { id: "custom-1", name: "CustomBot", assocUserIds: [], createdBy: null },
+        { id: "jarvis-1", name: "Jarvis", assocUserIds: [], createdBy: null },
+    ];
+
+    const result = classifyBlankOrphanEntities(entities, [], {
+        defaultAiName: "CustomBot",
+    });
+
+    t.deepEqual(
+        result.map((entity) => entity.id),
+        ["custom-1"],
+    );
+});


### PR DESCRIPTION
## Summary
- add a dry-run/apply cleanup utility for personal entity pointers and duplicate blank defaults
- extract cleanup ranking/classification logic into a unit-tested helper
- add an npm script for running the maintenance workflow

## Validation
- node --check scripts/lib/personalEntityCleanup.js
- node --check scripts/cleanup-personal-entities.js
- node --check tests/scripts/personalEntityCleanup.test.js
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/scripts/personalEntityCleanup.test.js
- git diff --check