### PR TITLE
Tighten pathway contract metadata

### DIFF
--- a/pathways/select_services.js
+++ b/pathways/select_services.js
@@ -6,5 +6,5 @@ export default {
             `Conversation:\n{{text}}\n\nInstructions:\nIn the above conversation fragment, the user may or may not have requested one of the following services:\n{"services": ["Coding", "Translate", "Transcribe", "Summary", "Headlines", "Entities", "Spelling", "Grammar", "Style", "Entities", "Newswires", "FileOrDocumentUpload"]}\nSelect the services the user requested (or none if none were requested) and return them as a JSON object called "services" below:\n\n`,
         ],
     model: 'oai-gpt4o',
+    json: true,
 }
-

--- a/pathways/tags.js
+++ b/pathways/tags.js
@@ -12,6 +12,10 @@ export default {
     inputParameters: {
         count: 5,
         tags: '',
+        initialFilterPrompt: '',
+        singleSelectPrompt: '',
+        rankingPrompt: '',
+        model: 'oai-gpt4o',
     },
 
     // Set 'list' to true to indicate that the output is expected to be a list.

--- a/pathways/topics.js
+++ b/pathways/topics.js
@@ -12,6 +12,10 @@ export default {
     inputParameters: {
         count: 5,
         topics: '',
+        initialFilterPrompt: '',
+        singleSelectPrompt: '',
+        rankingPrompt: '',
+        model: 'oai-gpt4o',
     },
 
     // Set 'list' to true to indicate that the output is expected to be a list.

--- a/tests/unit/pathways/pathwayContractCleanups.test.js
+++ b/tests/unit/pathways/pathwayContractCleanups.test.js
@@ -1,0 +1,18 @@
+import test from 'ava';
+
+import selectServices from '../../../pathways/select_services.js';
+import tags from '../../../pathways/tags.js';
+import topics from '../../../pathways/topics.js';
+
+test('taxonomy wrapper pathways expose taxonomy configuration inputs', (t) => {
+    for (const pathway of [tags, topics]) {
+        t.is(pathway.inputParameters.initialFilterPrompt, '');
+        t.is(pathway.inputParameters.singleSelectPrompt, '');
+        t.is(pathway.inputParameters.rankingPrompt, '');
+        t.is(pathway.inputParameters.model, 'oai-gpt4o');
+    }
+});
+
+test('select_services declares JSON output', (t) => {
+    t.true(selectServices.json);
+});


### PR DESCRIPTION
## Summary
- expose taxonomy prompt/model inputs on topic and tag wrapper pathways
- mark service-selection output as JSON
- add focused pathway contract coverage

## Validation
- node --check pathways/tags.js
- node --check pathways/topics.js
- node --check pathways/select_services.js
- node --check tests/unit/pathways/pathwayContractCleanups.test.js
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/pathwayContractCleanups.test.js
- git diff --check