### PR TITLE
Tighten remaining pathway contracts

### DIFF
--- a/pathways/locations.js
+++ b/pathways/locations.js
@@ -14,6 +14,8 @@ export default {
     inputParameters: {
         count: 5,
         locations: '',
+        locationPrompt: '',
+        model: 'oai-gpt4o',
     },
 
     // Set 'list' to true to indicate that the output is expected to be a list.
@@ -53,7 +55,7 @@ export default {
             pathwayResolver.pathwayPrompt = [
                 new Prompt({
                     messages: [
-                        { "role": "system", "content": "Assistant is an AI editorial assistant for an online news agency tasked with identifying locations from a pre-determined list that fit a news article summary. When User posts a news article summary and a list of possible locations, assistant will carefully examine the locations in the list. If any of them are a high confidence match for the article, assistant will return the matching locations as a comma separated list. Assistant must only identify a location if assistant is sure the location is a good match for the article. Any locations that assistant returns must be in the list already - assistant cannot add new locations. If there are no good matches, assistant will respond with <none>." },
+                        { "role": "system", "content": args.locationPrompt || "Assistant is an AI editorial assistant for an online news agency tasked with identifying locations from a pre-determined list that fit a news article summary. When User posts a news article summary and a list of possible locations, assistant will carefully examine the locations in the list. If any of them are a high confidence match for the article, assistant will return the matching locations as a comma separated list. Assistant must only identify a location if assistant is sure the location is a good match for the article. Any locations that assistant returns must be in the list already - assistant cannot add new locations. If there are no good matches, assistant will respond with <none>." },
                         { "role": "user", "content": `Article Summary:\n\n{{{text}}}\n\nPossible locations: ${locationSet}`},
                     ]
                 }),

--- a/pathways/select_extension.js
+++ b/pathways/select_extension.js
@@ -2,5 +2,6 @@
 export default {
     prompt: `User text: {{text}}\n\n Your Instructions: Analyze user text and extract all the following information. Decide to route messages to a knowledge base expert system when the user needs some information or documents or articles, or if user asks question that require specific knowledge, or if some extra knowledge can help you reply better; also anything related to news, articles, geopolitical entities, or current events should be forwarded as those can be found in the expert system. The expert system should not be consulted if the users message is just conversational. You will reply this in field useExpertSystem with true or false. Also in the text, the user may or may not have requested one of the following services:\n{"services": ["Coding", "Translate", "Transcribe", "Summary", "Headlines", "Entities", "Spelling", "Grammar", "Style", "Entities", "Newswires", "FileOrDocumentUpload"]}\nSelect the services the user requested (or none if none were requested) and return them as a JSON object field called "services". Also return the user text's language in language field in ISO 639-3 format. You will reply with the single valid JSON object (no other text or commentary) that must include JSON fields: useExpertSystem, services, language.\n\n`,
     model: 'oai-gpt4o',
+    json: true,
     useInputChunking: false,
 }

--- a/tests/unit/pathways/pathwayContractFinal.test.js
+++ b/tests/unit/pathways/pathwayContractFinal.test.js
@@ -1,0 +1,13 @@
+import test from 'ava';
+
+import locations from '../../../pathways/locations.js';
+import selectExtension from '../../../pathways/select_extension.js';
+
+test('locations exposes prompt and model override inputs', (t) => {
+    t.is(locations.inputParameters.locationPrompt, '');
+    t.is(locations.inputParameters.model, 'oai-gpt4o');
+});
+
+test('select_extension declares JSON output', (t) => {
+    t.true(selectExtension.json);
+});


### PR DESCRIPTION
## Summary
- expose locations prompt/model override inputs
- mark extension-selection output as JSON
- add focused pathway contract coverage

## Validation
- node --check pathways/locations.js
- node --check pathways/select_extension.js
- node --check tests/unit/pathways/pathwayContractFinal.test.js
- CORTEX_CONFIG_FILE=config/default.example.json npm test -- tests/unit/pathways/pathwayContractFinal.test.js
- git diff --check