### PR TITLE
Polish Cortex GitHub README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
 # Cortex
 
-Cortex is an open model router and agent runtime for teams that do not want their AI stack trapped inside one provider, one SDK, or one brittle prompt chain.
+[![npm version](https://img.shields.io/npm/v/@aj-archipelago/cortex.svg)](https://www.npmjs.com/package/@aj-archipelago/cortex)
+[![License: MIT](https://img.shields.io/badge/license-MIT-2f855a.svg)](LICENSE)
+[![Node.js 20+](https://img.shields.io/badge/node-20%2B-2f855a.svg)](package.json)
 
-It gives you one programmable control plane for:
+Cortex is an open-source AI backend control plane: model routing, agent tools, OpenAI-compatible APIs, and private workspaces behind one programmable runtime.
 
-- **Any model, any time, any protocol.** Route OpenAI, Azure OpenAI, Gemini, Claude on Vertex, Grok, Replicate-hosted media models, Ollama, local models, and custom provider plugins through GraphQL, REST, OpenAI-compatible chat/completions/responses, and Anthropic-style messages APIs.
-- **Live model routing.** Use model groups, redirects, per-request model overrides, endpoint health, duplicate-request hedging, and background latency sampling so "the default model" can be a strategy instead of a hardcoded string.
-- **Agentic harnesses that can work.** `sys_entity_agent` combines entity configuration, tools, MCP discovery, client-side tools, request-scoped tools, streaming progress, tool-result compaction, and memory-aware context into one reusable agent pathway.
-- **Private containerized workspaces.** Cortex can attach an entity to its own isolated workspace: a Docker or Azure Container Instances sandbox with shell access, file APIs, checkpoint/restore, warm-pool provisioning, and secret injection.
+It is built for teams that want the modern AI stack without welding their product to one provider SDK, one brittle prompt chain, or one proprietary agent loop.
 
-Pathways are still here. They are useful. But the modern Cortex story is bigger: Cortex is the layer between your product and a chaotic model/provider/tool landscape. It lets you move fast without welding your application to yesterday's API.
+![Cortex architecture: applications connect to one Cortex runtime for model routing, agent tools, entity memory, and isolated workspaces.](docs/assets/cortex-architecture.svg)
+
+## What You Get
+
+- **One API for many providers.** Route OpenAI, Azure OpenAI, Gemini, Claude on Vertex, Grok, Replicate-hosted media models, Ollama, local models, and custom provider plugins through GraphQL, REST, OpenAI-compatible chat/completions/responses, and Anthropic-style messages APIs.
+- **Routing that can adapt.** Use model groups, redirects, per-request model overrides, endpoint health, duplicate-request hedging, and background latency sampling so "the default model" can be a strategy instead of a hardcoded string.
+- **An agent harness you can own.** `sys_entity_agent` combines entity configuration, tools, MCP discovery, client-side tools, request-scoped tools, streaming progress, tool-result compaction, and memory-aware context into one reusable agent pathway.
+- **Private workspaces for real work.** Attach each entity to an isolated Docker or Azure Container Instances workspace with shell access, file APIs, checkpoint/restore, warm-pool provisioning, and secret injection.
+- **Simple extension points.** Add a capability with one pathway file, then graduate to `executePathway` when you need validation, orchestration, custom tools, provider-specific handling, or richer result metadata.
 
 ## Why Cortex Exists
+
+The frontier AI product pattern is getting clearer: multi-model routing, agentic tool loops, entity personalization, memory, MCP-style tool discovery, client-side tool callbacks, and dedicated agent workspaces. Big products and funded startups are converging on those pieces because serious AI apps need more than a chat wrapper.
+
+Cortex puts those pieces in one open backend that you can run, inspect, customize, and embed.
 
 Model APIs keep changing. Capabilities move between providers. Latency shifts by region and hour. Agent tool catalogs grow until the model drowns in schemas. Workspace execution needs isolation, persistence, and recoverability. Product teams still need one stable API.
 
@@ -24,18 +35,74 @@ Cortex turns that mess into infrastructure:
 - An agent harness that can discover tools only when needed, execute them, stream progress, compact results, and continue the reasoning loop.
 - A workspace layer that can provision private sandboxes locally or in Azure and restore durable state after idle reaping.
 
-## Start Here
+## Why Cortex Instead Of...
+
+| Alternative                 | Good at                                    | Where Cortex is different                                                                                     |
+| --------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Provider SDKs               | Direct access to one provider's newest API | Cortex keeps product code behind a stable runtime while providers, models, and protocols change.              |
+| Model proxies               | Unifying model calls and keys              | Cortex also has pathways, entities, tools, streaming progress, memory-aware agents, and workspaces.           |
+| Prompt-chain frameworks     | Fast experimentation inside an app         | Cortex is a backend service with GraphQL, REST, auth, routing, cancellation, caching, and operational policy. |
+| Proprietary agent platforms | Polished hosted loops                      | Cortex gives you the loop, tool surface, and workspace architecture in code you can own.                      |
+
+## Start Here In 5 Minutes
 
 If you are new to Cortex, pick the lane closest to what you are building:
 
-| If you want to... | Start with... | Why |
-| --- | --- | --- |
-| Put one stable API in front of many model providers | [Model Configuration](#model-configuration) and [REST](#rest) | Define models once, expose GraphQL or OpenAI-compatible REST, and move callers with redirects/groups later. |
-| Build an agent with tools | [Agents And Entities](#agents-and-entities), then [Pathways](#pathways) | Entities define identity and tool access; pathways define the callable skills behind that agent. |
-| Give agents private compute | [Workspace Architecture](#workspace-architecture) | Workspaces give each entity a container for shell commands, files, checkpoints, and long-running work. |
-| Add a new capability | [Pathways](#pathways) | Most Cortex extensions are one pathway file plus, optionally, `executePathway` for orchestration. |
+| If you want to...                                   | Start with...                                                           | Why                                                                                                         |
+| --------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Put one stable API in front of many model providers | [Model Configuration](#model-configuration) and [REST](#rest)           | Define models once, expose GraphQL or OpenAI-compatible REST, and move callers with redirects/groups later. |
+| Build an agent with tools                           | [Agents And Entities](#agents-and-entities), then [Pathways](#pathways) | Entities define identity and tool access; pathways define the callable skills behind that agent.            |
+| Give agents private compute                         | [Workspace Architecture](#workspace-architecture)                       | Workspaces give each entity a container for shell commands, files, checkpoints, and long-running work.      |
+| Add a new capability                                | [Pathways](#pathways)                                                   | Most Cortex extensions are one pathway file plus, optionally, `executePathway` for orchestration.           |
 
-The shortest path is: run Cortex, call one pathway, then add one custom pathway. You do not need to understand every provider plugin or workspace knob before Cortex is useful.
+The shortest path is:
+
+1. Run Cortex locally.
+2. Call a built-in pathway through GraphQL.
+3. Enable OpenAI-compatible REST and call a model or agent.
+4. Add one custom pathway.
+5. Turn on entities, tools, and workspaces when your product needs them.
+
+You do not need to understand every provider plugin or workspace knob before Cortex is useful.
+
+## Try It
+
+```sh
+git clone git@github.com:aj-archipelago/cortex.git
+cd cortex
+npm install
+export OPENAI_API_KEY=<your key>
+CORTEX_ENABLE_REST=true npm start
+```
+
+By default Cortex starts GraphQL at `http://localhost:4000/graphql`. From another terminal:
+
+```sh
+curl http://localhost:4000/healthcheck
+```
+
+Then call a pathway through Cortex's generated REST API:
+
+```sh
+curl http://localhost:4000/rest/summary \
+  -H 'content-type: application/json' \
+  -d '{
+    "text": "Cortex routes model requests, runs pathways, and powers agentic tools."
+  }'
+```
+
+Or call the same pathway through Cortex's generated GraphQL schema:
+
+```sh
+curl http://localhost:4000/graphql \
+  -H 'content-type: application/json' \
+  -d '{
+    "query": "query($text: String!) { summary(text: $text) { result } }",
+    "variables": {
+      "text": "Cortex routes model requests, runs pathways, and powers agentic tools."
+    }
+  }'
+```
 
 ## What Cortex Is Not
 
@@ -99,66 +166,6 @@ The workspace stack includes:
 - Idle checkpointing and idle reaping so sleeping workspaces stop burning compute while preserving useful state.
 
 This follows the same pattern that has emerged in OpenClaw/NanoClaw-style systems: each agent gets a private, containerized machine room, not a shared scratchpad pretending to be isolation.
-
-## Quick Start
-
-Requirements:
-
-- Node.js 20 or newer is recommended.
-- At least one provider key, usually `OPENAI_API_KEY`.
-- Docker if you want local workspace containers.
-
-```sh
-git clone git@github.com:aj-archipelago/cortex.git
-cd cortex
-npm install
-export OPENAI_API_KEY=<your key>
-npm start
-```
-
-By default Cortex starts GraphQL at:
-
-```text
-http://localhost:4000/graphql
-```
-
-Health check:
-
-```sh
-curl http://localhost:4000/healthcheck
-```
-
-First GraphQL request:
-
-```sh
-curl http://localhost:4000/graphql \
-  -H 'content-type: application/json' \
-  -d '{
-    "query": "query($text: String!) { summary(text: $text) { result } }",
-    "variables": {
-      "text": "Cortex routes model requests, runs pathways, and powers agentic tools."
-    }
-  }'
-```
-
-First REST request, if you want OpenAI-compatible endpoints:
-
-```sh
-CORTEX_ENABLE_REST=true npm start
-```
-
-Then call it from another terminal:
-
-```sh
-curl http://localhost:4000/v1/chat/completions \
-  -H 'content-type: application/json' \
-  -d '{
-    "model": "gpt-5.4-mini",
-    "messages": [
-      { "role": "user", "content": "Say hello from Cortex in one sentence." }
-    ]
-  }'
-```
 
 ## Install As A Package
 
@@ -246,13 +253,11 @@ curl http://localhost:4000/v1/chat/completions \
 OpenAI-compatible model call:
 
 ```sh
-curl http://localhost:4000/v1/chat/completions \
+curl http://localhost:4000/v1/responses \
   -H 'content-type: application/json' \
   -d '{
     "model": "gpt-5.4-mini",
-    "messages": [
-      { "role": "user", "content": "Explain model groups in one paragraph." }
-    ]
+    "input": "Explain model groups in one paragraph."
   }'
 ```
 

--- a/docs/assets/cortex-architecture.svg
+++ b/docs/assets/cortex-architecture.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1200 560">
+  <title id="title">Cortex AI backend control plane architecture</title>
+  <desc id="desc">Applications connect to Cortex, which routes model requests, runs agent tool loops, manages entity memory, and provisions isolated workspaces.</desc>
+  <defs>
+    <linearGradient id="cortex-bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="54%" stop-color="#172554" />
+      <stop offset="100%" stop-color="#064e3b" />
+    </linearGradient>
+    <filter id="soft-shadow" color-interpolation-filters="sRGB" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.28" />
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#93c5fd" />
+    </marker>
+    <style>
+      .bg {
+        fill: url(#cortex-bg);
+      }
+      .eyebrow {
+        fill: #a7f3d0;
+        font: 600 18px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .headline {
+        fill: #f8fafc;
+        font: 800 48px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .subhead {
+        fill: #dbeafe;
+        font: 500 22px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .node {
+        fill: rgba(15, 23, 42, 0.72);
+        stroke: rgba(226, 232, 240, 0.36);
+        stroke-width: 1.5;
+        filter: url(#soft-shadow);
+      }
+      .center {
+        fill: rgba(14, 165, 233, 0.18);
+        stroke: #7dd3fc;
+        stroke-width: 2;
+        filter: url(#soft-shadow);
+      }
+      .label {
+        fill: #f8fafc;
+        font: 700 25px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .detail {
+        fill: #cbd5e1;
+        font: 500 18px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .small {
+        fill: #bfdbfe;
+        font: 600 16px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .flow {
+        fill: none;
+        stroke: #93c5fd;
+        stroke-width: 3;
+        marker-end: url(#arrow);
+      }
+    </style>
+  </defs>
+  <rect class="bg" width="1200" height="560" rx="24" />
+
+  <text class="eyebrow" x="62" y="70">OPEN-SOURCE AI BACKEND CONTROL PLANE</text>
+  <text class="headline" x="62" y="124">Cortex</text>
+  <text class="subhead" x="62" y="162">Model routing, agent tools, entity memory, and isolated workspaces in one runtime.</text>
+
+  <rect class="node" x="62" y="222" width="220" height="132" rx="14" />
+  <text class="label" x="92" y="274">Your App</text>
+  <text class="detail" x="92" y="309">GraphQL</text>
+  <text class="detail" x="92" y="335">REST and SDKs</text>
+
+  <rect class="center" x="418" y="196" width="364" height="184" rx="18" />
+  <text class="label" x="470" y="258">Cortex Runtime</text>
+  <text class="detail" x="470" y="296">Pathways and entities</text>
+  <text class="detail" x="470" y="322">Streaming progress</text>
+  <text class="detail" x="470" y="348">Auth, caching, policy</text>
+
+  <path class="flow" d="M 282 288 C 335 288, 356 288, 408 288" />
+
+  <rect class="node" x="894" y="58" width="244" height="108" rx="14" />
+  <text class="label" x="924" y="106">Models</text>
+  <text class="detail" x="924" y="138">OpenAI, Gemini, Claude</text>
+
+  <rect class="node" x="894" y="188" width="244" height="108" rx="14" />
+  <text class="label" x="924" y="236">Tools</text>
+  <text class="detail" x="924" y="268">MCP and client tools</text>
+
+  <rect class="node" x="894" y="318" width="244" height="108" rx="14" />
+  <text class="label" x="924" y="366">Memory</text>
+  <text class="detail" x="924" y="398">Entity personalization</text>
+
+  <rect class="node" x="894" y="448" width="244" height="72" rx="14" />
+  <text class="label" x="924" y="493">Workspaces</text>
+
+  <path class="flow" d="M 782 252 C 828 205, 842 138, 884 112" />
+  <path class="flow" d="M 782 276 C 825 260, 842 246, 884 242" />
+  <path class="flow" d="M 782 310 C 828 334, 842 366, 884 372" />
+  <path class="flow" d="M 782 342 C 826 416, 840 476, 884 484" />
+
+  <text class="small" x="62" y="484">Provider-compatible APIs outside. Owned routing, tools, and execution policy inside.</text>
+</svg>

--- a/docs/assets/cortex-social-preview.svg
+++ b/docs/assets/cortex-social-preview.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1280 640">
+  <title id="title">Cortex social preview</title>
+  <desc id="desc">Cortex is an open-source AI backend control plane for models, agents, tools, and workspaces.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="48%" stop-color="#172554" />
+      <stop offset="100%" stop-color="#065f46" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a" stop-opacity="0.92" />
+      <stop offset="100%" stop-color="#111827" stop-opacity="0.72" />
+    </linearGradient>
+    <filter id="shadow" color-interpolation-filters="sRGB" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#020617" flood-opacity="0.35" />
+    </filter>
+    <style>
+      .bg {
+        fill: url(#bg);
+      }
+      .panel {
+        fill: url(#panel);
+        stroke: rgba(226, 232, 240, 0.28);
+        stroke-width: 2;
+        filter: url(#shadow);
+      }
+      .eyebrow {
+        fill: #a7f3d0;
+        font: 700 26px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .title {
+        fill: #f8fafc;
+        font: 900 112px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .subtitle {
+        fill: #dbeafe;
+        font: 600 36px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .pill {
+        fill: rgba(15, 23, 42, 0.7);
+        stroke: rgba(147, 197, 253, 0.42);
+        stroke-width: 1.5;
+      }
+      .pill-text {
+        fill: #f8fafc;
+        font: 700 27px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .small {
+        fill: #bfdbfe;
+        font: 600 24px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .line {
+        fill: none;
+        stroke: #7dd3fc;
+        stroke-width: 4;
+        stroke-linecap: round;
+        opacity: 0.84;
+      }
+      .dot {
+        fill: #a7f3d0;
+      }
+    </style>
+  </defs>
+  <rect class="bg" width="1280" height="640" />
+  <path class="line" d="M 792 170 C 894 122, 962 158, 1078 98" />
+  <path class="line" d="M 808 300 C 932 268, 1008 310, 1148 242" />
+  <path class="line" d="M 790 430 C 902 484, 1020 424, 1162 512" />
+  <circle class="dot" cx="792" cy="170" r="8" />
+  <circle class="dot" cx="1078" cy="98" r="8" />
+  <circle class="dot" cx="808" cy="300" r="8" />
+  <circle class="dot" cx="1148" cy="242" r="8" />
+  <circle class="dot" cx="790" cy="430" r="8" />
+  <circle class="dot" cx="1162" cy="512" r="8" />
+
+  <rect class="panel" x="70" y="72" width="760" height="496" rx="28" />
+  <text class="eyebrow" x="116" y="146">OPEN-SOURCE AI BACKEND CONTROL PLANE</text>
+  <text class="title" x="112" y="278">Cortex</text>
+  <text class="subtitle" x="118" y="350">Models, agents, tools, memory,</text>
+  <text class="subtitle" x="118" y="398">and private workspaces.</text>
+
+  <rect class="pill" x="118" y="452" width="146" height="58" rx="29" />
+  <text class="pill-text" x="150" y="490">Route</text>
+  <rect class="pill" x="286" y="452" width="132" height="58" rx="29" />
+  <text class="pill-text" x="319" y="490">Tool</text>
+  <rect class="pill" x="440" y="452" width="148" height="58" rx="29" />
+  <text class="pill-text" x="474" y="490">Embed</text>
+  <rect class="pill" x="610" y="452" width="146" height="58" rx="29" />
+  <text class="pill-text" x="641" y="490">Scale</text>
+
+  <text class="small" x="900" y="166">OpenAI-compatible APIs</text>
+  <text class="small" x="900" y="296">MCP and client tools</text>
+  <text class="small" x="900" y="426">Docker and ACI workspaces</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aj-archipelago/cortex",
   "version": "1.4.34",
-  "description": "Cortex is a GraphQL API for AI. It provides a simple, extensible interface for using AI services from OpenAI, Azure and others.",
+  "description": "Open-source AI backend control plane for model routing, agent tools, OpenAI-compatible APIs, and private workspaces.",
   "private": false,
   "repository": {
     "type": "git",
@@ -10,10 +10,17 @@
   "keywords": [
     "cortex",
     "AI",
+    "ai-agent",
+    "ai-workspace",
     "router",
+    "model router",
+    "llm-router",
     "GPT",
     "agents",
     "entities",
+    "MCP",
+    "openai-compatible",
+    "anthropic-compatible",
     "prompt engineering",
     "LLM",
     "OpenAI",


### PR DESCRIPTION
## Summary
- sharpen the README's GitHub-facing positioning and quickstart
- add architecture and social-preview SVG assets
- align npm/package metadata with the AI backend control-plane story

## Verification
- git diff --check
- xmllint --noout docs/assets/cortex-architecture.svg docs/assets/cortex-social-preview.svg
- verified simplified quickstart with .env temporarily renamed: /healthcheck, /rest/summary, and GraphQL summary returned 200 OK