### PR TITLE
Bump Cortex version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aj-archipelago/cortex",
-  "version": "1.4.34",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aj-archipelago/cortex",
-      "version": "1.4.34",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@aj-archipelago/merval": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aj-archipelago/cortex",
-  "version": "1.4.34",
+  "version": "1.5.0",
   "description": "Open-source AI backend control plane for model routing, agent tools, OpenAI-compatible APIs, and private workspaces.",
   "private": false,
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version from 1.4.34 to 1.5.0 after the GitHub README/positioning refresh
- update package-lock root version metadata

## Verification
- git diff --check
- verified package.json and package-lock.json versions are 1.5.0