### PR TITLE
Load local env files on startup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
+OPENAI_API_KEY=_______________________
 AZURE_OAI_API_KEY=_______________________
 APPTEK_API_KEY=""
 APPTEK_API_ENDPOINT="https://api.apptek.com"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules/
 .env
+.env.local
 .vscode/
 **/__pycache__
 **/.venv

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ You do not need to understand every provider plugin or workspace knob before Cor
 git clone git@github.com:aj-archipelago/cortex.git
 cd cortex
 npm install
-export OPENAI_API_KEY=<your key>
 CORTEX_ENABLE_REST=true npm start
 ```
+
+Set `OPENAI_API_KEY` in your shell, `.env`, or `.env.local` before starting. Cortex loads `.env` and `.env.local` automatically for local runs; explicit shell variables win.
 
 By default Cortex starts GraphQL at `http://localhost:4000/graphql`. From another terminal:
 

--- a/lib/loadLocalEnv.js
+++ b/lib/loadLocalEnv.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+
+export function loadLocalEnvFiles({
+    cwd = process.cwd(),
+    env = process.env,
+    files = ['.env', '.env.local'],
+} = {}) {
+    const explicitKeys = new Set(Object.keys(env));
+    const loaded = [];
+
+    for (const file of files) {
+        const envPath = path.resolve(cwd, file);
+        if (!fs.existsSync(envPath)) continue;
+
+        const parsed = dotenv.parse(fs.readFileSync(envPath));
+        for (const [key, value] of Object.entries(parsed)) {
+            if (explicitKeys.has(key)) continue;
+            env[key] = value;
+        }
+        loaded.push(envPath);
+    }
+
+    return loaded;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "main": "index.js",
   "scripts": {
+    "dev": "node start.js",
     "start": "node start.js",
     "cleanup:personal-entities": "node scripts/cleanup-personal-entities.js",
     "test": "ava"

--- a/start.js
+++ b/start.js
@@ -1,6 +1,8 @@
-import startServerFactory from './index.js';
+import { loadLocalEnvFiles } from './lib/loadLocalEnv.js';
 
 (async () => {
+  loadLocalEnvFiles();
+  const { default: startServerFactory } = await import('./index.js');
   const { startServer } = await startServerFactory();
   startServer && startServer();
 })();

--- a/tests/unit/loadLocalEnv.test.js
+++ b/tests/unit/loadLocalEnv.test.js
@@ -1,0 +1,47 @@
+import test from 'ava';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { loadLocalEnvFiles } from '../../lib/loadLocalEnv.js';
+
+function tempDir(t) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cortex-env-test-'));
+    t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }));
+    return dir;
+}
+
+test('loadLocalEnvFiles loads .env values', (t) => {
+    const cwd = tempDir(t);
+    fs.writeFileSync(path.join(cwd, '.env'), 'OPENAI_API_KEY=from-env\nCORTEX_ENABLE_REST=true\n');
+
+    const env = {};
+    const loaded = loadLocalEnvFiles({ cwd, env });
+
+    t.deepEqual(loaded, [path.join(cwd, '.env')]);
+    t.is(env.OPENAI_API_KEY, 'from-env');
+    t.is(env.CORTEX_ENABLE_REST, 'true');
+});
+
+test('loadLocalEnvFiles lets .env.local override .env', (t) => {
+    const cwd = tempDir(t);
+    fs.writeFileSync(path.join(cwd, '.env'), 'OPENAI_API_KEY=from-env\nMODEL=base\n');
+    fs.writeFileSync(path.join(cwd, '.env.local'), 'OPENAI_API_KEY=from-local\nLOCAL_ONLY=yes\n');
+
+    const env = {};
+    loadLocalEnvFiles({ cwd, env });
+
+    t.is(env.OPENAI_API_KEY, 'from-local');
+    t.is(env.MODEL, 'base');
+    t.is(env.LOCAL_ONLY, 'yes');
+});
+
+test('loadLocalEnvFiles does not override explicit environment values', (t) => {
+    const cwd = tempDir(t);
+    fs.writeFileSync(path.join(cwd, '.env'), 'OPENAI_API_KEY=from-env\n');
+    fs.writeFileSync(path.join(cwd, '.env.local'), 'OPENAI_API_KEY=from-local\n');
+
+    const env = { OPENAI_API_KEY: 'from-shell' };
+    loadLocalEnvFiles({ cwd, env });
+
+    t.is(env.OPENAI_API_KEY, 'from-shell');
+});


### PR DESCRIPTION
## Summary
- load .env and .env.local before Cortex config initializes
- preserve explicit shell environment values over local files
- add npm run dev as a startup alias and document the local env behavior

## Verification
- npx ava tests/unit/loadLocalEnv.test.js
- git diff --check