### PR TITLE
Remove duplicate provider request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is built for teams that want the modern AI stack without welding their produc
 ## What You Get
 
 - **One API for many providers.** Route OpenAI, Azure OpenAI, Gemini, Claude on Vertex, Grok, Replicate-hosted media models, Ollama, local models, and custom provider plugins through GraphQL, REST, OpenAI-compatible chat/completions/responses, and Anthropic-style messages APIs.
-- **Routing that can adapt.** Use model groups, redirects, per-request model overrides, endpoint health, duplicate-request hedging, and background latency sampling so "the default model" can be a strategy instead of a hardcoded string.
+- **Routing that can adapt.** Use model groups, redirects, per-request model overrides, endpoint health, and background latency sampling so "the default model" can be a strategy instead of a hardcoded string.
 - **An agent harness you can own.** `sys_entity_agent` combines entity configuration, tools, MCP discovery, client-side tools, request-scoped tools, streaming progress, tool-result compaction, and memory-aware context into one reusable agent pathway.
 - **Private workspaces for real work.** Attach each entity to an isolated Docker or Azure Container Instances workspace with shell access, file APIs, checkpoint/restore, warm-pool provisioning, and secret injection.
 - **Simple extension points.** Add a capability with one pathway file, then graduate to `executePathway` when you need validation, orchestration, custom tools, provider-specific handling, or richer result metadata.
@@ -809,7 +809,7 @@ Prompt and execution:
 | `temperature` | `number` | `0.9` | Passed into model plugins that support it. Also enables request caching when `temperature == 0` and global cache is on. |
 | `json` | `boolean` | `false` | Tells the response parser to parse/repair JSON output before returning. |
 | `parser` | `function` | unset | Custom output parser. Runs before built-in `list` or `json` parsing. |
-| `timeout` | `number` | `120` | Pathway timeout in seconds. Also influences provider request timeout and duplicate-request expiration. |
+| `timeout` | `number` | `120` | Pathway timeout in seconds. Also influences provider request timeout. |
 | `requestLoggingDisabled` | `boolean` | `false` | Suppresses non-error request logging while this pathway runs. |
 
 Inputs and generated parameters:
@@ -839,14 +839,12 @@ Chunking and context management:
 | `truncateFromFront` | `boolean` | `false` | Makes token truncation keep the beginning of long input instead of the end. Available to plugins through prompt parameters. |
 | `manageTokenLength` | `boolean` | `true` | Plugin-level hint to manage/truncate oversized prompts for model calls that support this behavior. Agentic pathways often set this false. |
 
-Caching, duplicate requests, and GraphQL cache:
+Caching and GraphQL cache:
 
 | Property | Type | Default | What it does |
 | --- | --- | --- | --- |
 | `enableCache` | `boolean` | unset | Enables provider-response cache for this pathway when global `CORTEX_ENABLE_CACHE` is true. Temperature `0` also enables caching. |
 | `enableGraphqlCache` | `boolean` | unset | Enables Apollo response cache hints when the pathway temperature is `0` and GraphQL cache is configured. |
-| `enableDuplicateRequests` | `boolean` | `false` | Allows hedged duplicate provider requests for latency spikes. If unset, the global config can still enable duplicates. |
-| `duplicateRequestAfter` | `number` | `10` | Seconds before Cortex sends a duplicate provider request when duplicate requests are enabled. |
 
 Tools and agent integration:
 
@@ -862,7 +860,7 @@ REST emulation:
 | --- | --- | --- | --- |
 | `emulateOpenAIChatModel` | `string` | unset | Exposes this pathway through `/v1/chat/completions` under the given model id when REST is enabled. |
 | `emulateOpenAICompletionModel` | `string` | unset | Exposes this pathway through `/v1/completions` under the given model id when REST is enabled. |
-| `restStreaming` | `object` | unset | Model-config helper used by generated REST streaming pathways. Can add input parameters, safety settings, timeout, or duplicate-request behavior. |
+| `restStreaming` | `object` | unset | Model-config helper used by generated REST streaming pathways. Can add input parameters, safety settings, or timeout. |
 
 Provider and plugin-specific pathway parameters:
 
@@ -919,7 +917,6 @@ Common environment variables:
 | `CORTEX_ENABLE_REST` | Enable REST routes. |
 | `CORTEX_ENABLE_CACHE` | Enable pathway cache. |
 | `CORTEX_ENABLE_GRAPHQL_CACHE` | Enable Apollo response cache. |
-| `CORTEX_ENABLE_DUPLICATE_REQUESTS` | Enable hedged duplicate requests. |
 | `OPENAI_API_KEY` | OpenAI API key. |
 | `CLAUDE_API_KEY` | Anthropic API key. |
 | `GEMINI_API_KEY` | Gemini API key. |

--- a/config.js
+++ b/config.js
@@ -88,11 +88,6 @@ var config = convict({
         default: true,
         env: 'CORTEX_ENABLE_CACHE'
     },
-    enableDuplicateRequests: {
-        format: Boolean,
-        default: true,
-        env: 'CORTEX_ENABLE_DUPLICATE_REQUESTS'
-    },
     enableGraphqlCache: {
         format: Boolean,
         default: false,
@@ -636,7 +631,6 @@ const buildPathways = async (config) => {
                     useInputChunking: false,
                     emulateOpenAIChatModel: modelConfig.emulateOpenAIChatModel,
                     ...(restConfig.geminiSafetySettings && { geminiSafetySettings: restConfig.geminiSafetySettings }),
-                    ...(restConfig.enableDuplicateRequests !== undefined && { enableDuplicateRequests: restConfig.enableDuplicateRequests }),
                     ...(restConfig.timeout && { timeout: restConfig.timeout })
                 };
             }

--- a/lib/modelRequestLog.js
+++ b/lib/modelRequestLog.js
@@ -80,7 +80,6 @@ export const buildModelRequestLogBase = ({ url, data, traceFields = {}, axiosCon
         method: axiosConfigObj?.method || 'POST',
         stream: axiosConfigObj?.responseType === 'stream' || Boolean(data?.stream),
         retry: traceFields.retry,
-        duplicateIndex: traceFields.duplicateIndex,
         ...buildModelRequestPayloadSummary(data),
     };
 };

--- a/lib/requestExecutor.js
+++ b/lib/requestExecutor.js
@@ -444,15 +444,6 @@ const requestWithMonitor = async (endpoint, url, data, axiosConfigObj, traceFiel
 }
 
 const MAX_RETRY = 6; // retries for error handling
-const MAX_DUPLICATE_REQUESTS = 3; // duplicate requests to manage latency spikes
-const DUPLICATE_REQUEST_AFTER = 10; // 10 seconds
-
-const getDuplicateRequestDelay = (index, duplicateRequestAfter) => {
-    const duplicateRequestTime = duplicateRequestAfter * Math.pow(2, index) - duplicateRequestAfter;
-    const jitter = duplicateRequestTime * 0.2 * Math.random();
-    const duplicateRequestTimeout = Math.max(0, duplicateRequestTime + jitter);
-    return duplicateRequestTimeout;
-}
 
 const runWithLimiter = (cortexRequest, endpoint, scheduleOptions, task) => {
     if (cortexRequest?.bypassLimiter) {
@@ -498,14 +489,10 @@ const registerAbortRequest = (requestId, abortRequest) => {
 };
 
 const makeRequest = async (cortexRequest) => {
-    let promises = [];
     // retry certain errors up to MAX_RETRY times
     const maxRetry = cortexRequest?.bypassLimiter ? 1 : MAX_RETRY;
     for (let i = 0; i < maxRetry; i++) {
         const { url, data, params, headers, cache, selectedEndpoint, requestId, pathway, model, stream, method} = cortexRequest;
-        const enableDuplicateRequests = pathway?.enableDuplicateRequests !== undefined ? pathway.enableDuplicateRequests : config.get('enableDuplicateRequests');
-        const maxDuplicateRequests = enableDuplicateRequests ? MAX_DUPLICATE_REQUESTS : 1;
-        const duplicateRequestAfter = (pathway?.duplicateRequestAfter || DUPLICATE_REQUEST_AFTER) * 1000;
         const traceBase = {
             requestId,
             pathway: pathway?.name,
@@ -517,13 +504,12 @@ const makeRequest = async (cortexRequest) => {
             ...traceBase,
             retry: i,
             streamRequested: Boolean(stream || params?.stream || data?.stream),
-            maxDuplicateRequests,
         });
 
         const axiosConfigObj = applyBypassTimeout(cortexRequest, { params, headers, cache, method });
         const streamRequested = (stream || params?.stream || data?.stream);
-        // if we're using streaming, duplicate requests are
-        // not supported, so we just push one promise into the array
+        let resultPromise;
+
         if (streamRequested && model.supportsStreaming) {
             const streamAbortController = new AbortController();
             axiosConfigObj.responseType = 'stream';
@@ -538,93 +524,46 @@ const makeRequest = async (cortexRequest) => {
             if (cancelableRequestId !== requestId) {
                 registerAbortRequest(requestId, abortProviderRequest);
             }
-            promises.push(runWithLimiter(
+            resultPromise = runWithLimiter(
                 cortexRequest,
                 selectedEndpoint,
                 { expiration: pathway.timeout * 1000 + 1000, id: `${requestId}_${uuidv4()}` },
                 () => requestWithMonitor(selectedEndpoint, url, data, axiosConfigObj, {
                     ...traceBase,
                     endpoint: selectedEndpoint?.name || 'default',
-                    duplicateIndex: 0,
                     retry: i,
                 })
-            ));
+            );
         } else {
             if (streamRequested) {
                 logger.info(`[${requestId}] ${model.name || 'This model'} does not support streaming; sending non-streaming request`);
-                axiosConfigObj.params.stream = false;
-                data.stream = false;
+                if (axiosConfigObj.params) {
+                    axiosConfigObj.params.stream = false;
+                }
+                if (data) {
+                    data.stream = false;
+                }
             }
-            // if we're not streaming, we push at least one promise
-            // into the array, but if we're supporting duplicate
-            // requests we push one for each potential duplicate,
-            // heading to a new endpoint (if available) and
-            // staggered by a jittered amount of time
-            const controllers = Array.from({ length: maxDuplicateRequests }, () => new AbortController());
-            promises = controllers.map((controller, index) =>
-                new Promise((resolve, reject) => {
-                    setTimeout(async () => {
-                        try {
-                            if (index > 0) {
-                                cortexRequest.selectNewEndpoint();
-                            }
-                            const { url, data, params, headers, cache, selectedEndpoint, requestId, pathway, model } = cortexRequest;
-                            const endpointName = selectedEndpoint.name || model;
-                            if (!cortexRequest.bypassLimiter && !selectedEndpoint.limiter) {
-                                throw new Error(`No limiter for endpoint ${endpointName}!`);
-                            }
-                            const axiosConfigObj = applyBypassTimeout(cortexRequest, { params, headers, cache, method });
 
-                            let response = null;
-                            let duration = null;
-
-                            if (!controller.signal?.aborted) {
-
-                                axiosConfigObj.signal = controller.signal;
-                                axiosConfigObj.headers['X-Cortex-Request-Index'] = index;
-
-                                if (index > 0) {
-                                    logger.info(`[${requestId}] taking too long; sending duplicate request ${index} to ${endpointName} API`);
-                                }
-
-                                ({ response, duration } = await runWithLimiter(
-                                    cortexRequest,
-                                    selectedEndpoint,
-                                    { expiration: pathway.timeout * 1000 + 1000, id: `${requestId}_${uuidv4()}` },
-                                    () => requestWithMonitor(selectedEndpoint, url, data, axiosConfigObj, {
-                                        requestId,
-                                        pathway: pathway?.name,
-                                        model: model?.name,
-                                        modelType: model?.type,
-                                        endpoint: endpointName,
-                                        duplicateIndex: index,
-                                        retry: i,
-                                    })
-                                ));
-
-                            }
-
-                            resolve({ response, duration });
-
-                        } catch (error) {
-                            if (error.name === 'AbortError' || error.name === 'CanceledError') {
-                                reject(error);
-                            } else {
-                                logger.error(`[${requestId}] request ${index} failed with error: ${error?.response?.data?.message || error?.response?.data?.error?.message || error?.message || error}`);
-                                reject(error);
-                            }
-                        } finally {
-                            controllers.forEach(controller => controller.abort());
-                        }
-                    }, getDuplicateRequestDelay(index, duplicateRequestAfter));
-                })
-            );
+            const endpointName = selectedEndpoint.name || model?.name || model;
+            if (!cortexRequest.bypassLimiter && !selectedEndpoint.limiter) {
+                resultPromise = Promise.reject(new Error(`No limiter for endpoint ${endpointName}!`));
+            } else {
+                resultPromise = runWithLimiter(
+                    cortexRequest,
+                    selectedEndpoint,
+                    { expiration: pathway.timeout * 1000 + 1000, id: `${requestId}_${uuidv4()}` },
+                    () => requestWithMonitor(selectedEndpoint, url, data, axiosConfigObj, {
+                        ...traceBase,
+                        endpoint: endpointName,
+                        retry: i,
+                    })
+                );
+            }
         }
 
-        // no requests have been made yet, but the promises array
-        // is full, so now we execute them in parallel
         try {
-            const { response, duration } = await Promise.race(promises);
+            const { response, duration } = await resultPromise;
 
             // if response status is 2xx
             if (response?.status >= 200 && response?.status < 300) {

--- a/pathways/azure_video_translate.js
+++ b/pathways/azure_video_translate.js
@@ -1,7 +1,6 @@
 export default {
     prompt: "",
     model: "azure-video-translate",
-    enableDuplicateRequests: false,
     inputParameters: {
         mode: "",
         apiversion: "",

--- a/pathways/basePathway.js
+++ b/pathways/basePathway.js
@@ -21,8 +21,6 @@ export default {
     useInputSummarization: false, // true or false - instead of chunking, summarize the input and act on the summary    
     truncateFromFront: false, // true or false - if true, truncate from the front of the input instead of the back
     timeout: 120, // seconds, cancels the pathway after this many seconds
-    enableDuplicateRequests: false, // true or false - if true, duplicate requests are sent if the request is not completed after duplicateRequestAfter seconds
-    duplicateRequestAfter: 10, // seconds, if the request is not completed after this many seconds, a backup request is sent
     // override the default execution of the pathway
     // callback signature: executeOverride({args: object, runAllPrompts: function})
     // args: the input arguments to the pathway

--- a/pathways/bing_afagent.js
+++ b/pathways/bing_afagent.js
@@ -15,7 +15,6 @@ export default {
         set_lang: 'en'
     },
     timeout: 400,
-    enableDuplicateRequests: false,
     model: 'azure-bing-agent',
     useInputChunking: false,
     instructions: `You are a Bing search agent responding to user queries.

--- a/pathways/call_tools.js
+++ b/pathways/call_tools.js
@@ -198,7 +198,6 @@ const TOOLS = [
 
 export default {
     useInputChunking: false,
-    enableDuplicateRequests: false,
     useSingleTokenStream: false,
     inputParameters: { 
         chatHistory: [{role: '', content: []}],

--- a/pathways/categorize.js
+++ b/pathways/categorize.js
@@ -16,7 +16,6 @@ export default {
     inputChunkSize: 1000,
     joinChunksWith: '\n',
     tokenRatio: 0.75,
-    enableDuplicateRequests: false,
     timeout: 1800,
 }
 

--- a/pathways/categorize_feedback.js
+++ b/pathways/categorize_feedback.js
@@ -31,6 +31,5 @@ Assistant must choose exactly one category from the provided list per feedback i
     model: 'oai-gpt4o',
     joinChunksWith: '\n',
     tokenRatio: 1,
-    enableDuplicateRequests: false,
     timeout: 1800,
 };

--- a/pathways/chat_code.js
+++ b/pathways/chat_code.js
@@ -15,5 +15,4 @@ export default {
     },
     tokenRatio: 0.75,
     useInputChunking: false,
-    enableDuplicateRequests: false,
 }

--- a/pathways/chat_title.js
+++ b/pathways/chat_title.js
@@ -23,5 +23,4 @@ export default {
     model: 'oai-gpt41-mini',
     useInputChunking: false,
     temperature: 0,
-    enableDuplicateRequests: false
 };

--- a/pathways/code_human_input.js
+++ b/pathways/code_human_input.js
@@ -28,7 +28,6 @@ async function sendMessageToQueue(data) {
 
 export default {
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         codeRequestId: "",
         text: "",

--- a/pathways/code_review.js
+++ b/pathways/code_review.js
@@ -11,7 +11,6 @@ export default {
     ],
     model: 'oai-gpt4o',
     tokenRatio: 0.75,
-    enableDuplicateRequests: false,
 }
 
 

--- a/pathways/cognitive_delete.js
+++ b/pathways/cognitive_delete.js
@@ -6,6 +6,5 @@ export default {
         chatId: ``,
     },
     mode: 'delete', 
-    enableDuplicateRequests: false,
     timeout: 300,
 };

--- a/pathways/cognitive_insert.js
+++ b/pathways/cognitive_insert.js
@@ -12,6 +12,5 @@ export default {
     },
     mode: 'index', // 'index' or 'search',
     inputChunkSize:  500,
-    enableDuplicateRequests: false,
     timeout: 3000,
 };

--- a/pathways/cognitive_search.js
+++ b/pathways/cognitive_search.js
@@ -9,6 +9,5 @@ export default {
         semanticConfiguration: ``,
         chatId: ``,
     },
-    enableDuplicateRequests: false,
     timeout: 300,
 };

--- a/pathways/create_article.js
+++ b/pathways/create_article.js
@@ -12,7 +12,6 @@ export default {
     },
 
     model: 'oai-gpt4o',
-    enableDuplicateRequests: false,
     useInputChunking: false,
     enableCache: true,
     json: true,

--- a/pathways/embeddings.js
+++ b/pathways/embeddings.js
@@ -8,7 +8,6 @@ export default {
     inputParameters: {
         input: [],
     },
-    enableDuplicateRequests: false,
     timeout: 300,
 };
 

--- a/pathways/format_paragraph_turbo.js
+++ b/pathways/format_paragraph_turbo.js
@@ -10,7 +10,5 @@ export default {
     ],
     //inputChunkSize: 500,
     model: 'oai-gpt4o',
-    enableDuplicateRequests: true,
-    duplicateRequestAfter: 20,
 
 }

--- a/pathways/gemini_15_vision.js
+++ b/pathways/gemini_15_vision.js
@@ -15,7 +15,6 @@ export default {
     max_tokens: 2048,
     model: 'gemini-pro-15-vision',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     geminiSafetySettings: [{category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH'},
         {category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH'},

--- a/pathways/gemini_vision.js
+++ b/pathways/gemini_vision.js
@@ -15,6 +15,5 @@ export default {
     max_tokens: 2048,
     model: 'gemini-pro-vision',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
 }

--- a/pathways/google_cse.js
+++ b/pathways/google_cse.js
@@ -22,6 +22,5 @@ export default {
         fileType: ''
     },
     timeout: 400,
-    enableDuplicateRequests: false,
     model: 'google-cse',
 };

--- a/pathways/greeting.js
+++ b/pathways/greeting.js
@@ -19,7 +19,6 @@ export default {
         }),
     ],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     model: 'oai-gpt41',
     inputParameters: {
         privateData: false,

--- a/pathways/headline_custom.js
+++ b/pathways/headline_custom.js
@@ -27,7 +27,6 @@ export default {
     list: true,
     model: 'oai-gpt4o',
     useInputChunking: false,
-    enableDuplicateRequests: false,
 
     // Custom resolver to generate headlines by reprompting if they are too long
     resolver: async (_parent, args, contextValue, _info) => {

--- a/pathways/image.js
+++ b/pathways/image.js
@@ -1,5 +1,4 @@
 export default {
     prompt:["{{text}}"],
     model: 'oai-dalle3',
-    enableDuplicateRequests: false,
 }

--- a/pathways/image_flux.js
+++ b/pathways/image_flux.js
@@ -1,7 +1,6 @@
 export default {
   prompt: ["{{text}}"],
 
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "runware-flux-schnell",
     negativePrompt: "",

--- a/pathways/image_gemini_25.js
+++ b/pathways/image_gemini_25.js
@@ -79,7 +79,6 @@ export default {
     max_tokens: 32000,
     model: 'gemini-flash-25-image',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     geminiSafetySettings: [
         {category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE'},

--- a/pathways/image_gemini_3.js
+++ b/pathways/image_gemini_3.js
@@ -89,7 +89,6 @@ export default {
     max_tokens: 64576,
     model: 'gemini-pro-3-image',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     geminiSafetySettings: [
         {category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE'},

--- a/pathways/image_gemini_31.js
+++ b/pathways/image_gemini_31.js
@@ -89,7 +89,6 @@ export default {
     max_tokens: 32000,
     model: 'gemini-flash-31-image',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     geminiSafetySettings: [
         {category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE'},

--- a/pathways/image_gpt_image_2.js
+++ b/pathways/image_gpt_image_2.js
@@ -8,7 +8,6 @@ const inputImageSlots = Object.fromEntries(
 export default {
     prompt: ["{{text}}"],
     model: 'oai-gpt-image-2',
-    enableDuplicateRequests: false,
     timeout: 600,
     inputParameters: {
         text: "",

--- a/pathways/image_prompt_optimizer_gemini_25.js
+++ b/pathways/image_prompt_optimizer_gemini_25.js
@@ -144,6 +144,5 @@ Examples of how to reference input images:
     max_tokens: 4096,
     model: 'oai-gpt41',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 30,
 }

--- a/pathways/image_qwen.js
+++ b/pathways/image_qwen.js
@@ -1,7 +1,6 @@
 export default {
   prompt: ["{{text}}"],
 
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "replicate-qwen-image", // Options: "replicate-qwen-image", "replicate-qwen-image-edit-plus", or "replicate-qwen-image-edit-2511"
     negativePrompt: "",

--- a/pathways/image_recraft.js
+++ b/pathways/image_recraft.js
@@ -1,7 +1,6 @@
 export default {
   prompt: ["{{text}}"],
 
-  enableDuplicateRequests: false,
   model: "replicate-recraft-v3",
   inputParameters: {
     size: "1024x1024",

--- a/pathways/image_seedream4.js
+++ b/pathways/image_seedream4.js
@@ -1,6 +1,5 @@
 export default {
   prompt: ["{{text}}"],
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "replicate-seedream-4",
     size: "2K", // Options: "1K", "2K", "4K", "custom"

--- a/pathways/image_seedream45.js
+++ b/pathways/image_seedream45.js
@@ -1,6 +1,5 @@
 export default {
   prompt: ["{{text}}"],
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "replicate-seedream-4.5",
     size: "2K", // Options: "2K", "4K"

--- a/pathways/image_seedream5lite.js
+++ b/pathways/image_seedream5lite.js
@@ -1,6 +1,5 @@
 export default {
   prompt: ["{{text}}"],
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "replicate-seedream-5-lite",
     size: "2K", // Options: "2K", "3K"

--- a/pathways/lyria_prompt_optimizer.js
+++ b/pathways/lyria_prompt_optimizer.js
@@ -56,6 +56,5 @@ The user has selected an input image for Lyria. Make the prompt explicitly use t
   max_tokens: 2048,
   model: "oai-gpt-chat-latest",
   useInputChunking: false,
-  enableDuplicateRequests: false,
   timeout: 30,
 };

--- a/pathways/media_generate.js
+++ b/pathways/media_generate.js
@@ -761,7 +761,6 @@ export default {
     },
     model: 'oai-gpt4o', // placeholder — executePathway delegates to sub-pathways
     timeout: 60 * 30,
-    enableDuplicateRequests: false,
 
     executePathway: async ({ args, resolver }) => {
         const modelId = args.model;

--- a/pathways/media_prompt_assistant.js
+++ b/pathways/media_prompt_assistant.js
@@ -168,6 +168,5 @@ Context:
   max_tokens: 2048,
   model: 'oai-gpt54-mini',
   useInputChunking: false,
-  enableDuplicateRequests: false,
   timeout: 30,
 };

--- a/pathways/media_prompt_tags.js
+++ b/pathways/media_prompt_tags.js
@@ -30,6 +30,5 @@ Rules:
     },
     json: true,
     temperature: 0,
-    enableDuplicateRequests: false,
     timeout: 60,
 };

--- a/pathways/music_lyria.js
+++ b/pathways/music_lyria.js
@@ -12,6 +12,5 @@ export default {
   max_tokens: 8192,
   model: "google-lyria-3-music",
   useInputChunking: false,
-  enableDuplicateRequests: false,
   timeout: 60 * 10,
 };

--- a/pathways/music_replicate.js
+++ b/pathways/music_replicate.js
@@ -1,7 +1,6 @@
 export default {
   prompt: ["{{text}}"],
 
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "replicate-elevenlabs-music",
     duration: 10,

--- a/pathways/rag.js
+++ b/pathways/rag.js
@@ -20,7 +20,6 @@ export default {
         ]}),
     ],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     model: 'oai-gpt4o',
     inputParameters: {
         privateData: false,    

--- a/pathways/rag_jarvis.js
+++ b/pathways/rag_jarvis.js
@@ -20,7 +20,6 @@ export default {
         ]}),
     ],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     model: 'oai-gpt4o',
     inputParameters: {
         privateData: false,    

--- a/pathways/rag_search_helper.js
+++ b/pathways/rag_search_helper.js
@@ -17,5 +17,4 @@ export default {
     ],
     model: 'oai-gpt4o',
     useInputChunking: false,
-    enableDuplicateRequests: false,
 }

--- a/pathways/readme.js
+++ b/pathways/readme.js
@@ -11,7 +11,6 @@ export default {
     ],
     model: 'oai-gpt4o',
     tokenRatio: 0.75,
-    enableDuplicateRequests: false,
     timeout: 1800,
 }
 

--- a/pathways/release_notes.js
+++ b/pathways/release_notes.js
@@ -11,6 +11,5 @@ export default {
     ],
     model: 'oai-gpt4o',
     tokenRatio: 0.75,
-    enableDuplicateRequests: false,
 }
 

--- a/pathways/retrieval.js
+++ b/pathways/retrieval.js
@@ -18,6 +18,5 @@ export default {
     },
     model: `azure-extension`,
     useInputChunking: false,
-    enableDuplicateRequests: false,
 }
 

--- a/pathways/styleguide/styleguide.js
+++ b/pathways/styleguide/styleguide.js
@@ -23,7 +23,6 @@ export default {
     // inputFormat: 'html',
     useInputChunking: true,
     inputChunkSize: 500,
-    enableDuplicateRequests: false,
     useParallelChunkProcessing: true,
     model: 'oai-gpt4o',
     executePathway: async ({ args, runAllPrompts }) => {

--- a/pathways/styleguide/styleguide_html.js
+++ b/pathways/styleguide/styleguide_html.js
@@ -96,7 +96,6 @@ export default {
     inputFormat: 'html',
     useInputChunking: true,
     inputChunkSize: 500,
-    enableDuplicateRequests: false,
     useParallelChunkProcessing: false,
     model: 'oai-gpt4o',
     inputParameters: {

--- a/pathways/styleguidemulti.js
+++ b/pathways/styleguidemulti.js
@@ -123,5 +123,4 @@ export default {
     inputChunkSize: 500,
     useParallelChunkProcessing: true,
     model: 'oai-gpt4o',
-    enableDuplicateRequests: false,
 }

--- a/pathways/system/entity/memory/sys_memory_format.js
+++ b/pathways/system/entity/memory/sys_memory_format.js
@@ -26,7 +26,6 @@ export default {
     useInputChunking: true,
     inputChunkSize: 1000,
     useParallelChunkProcessing: true,
-    enableDuplicateRequests: false,
     requestLoggingDisabled: true,
     timeout: 300,
 }

--- a/pathways/system/entity/memory/sys_memory_manager.js
+++ b/pathways/system/entity/memory/sys_memory_manager.js
@@ -23,7 +23,6 @@ export default {
     model: 'cortex-default-small-fast',
     reasoningEffort: 'none',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 300,
     executePathway: async ({args, resolver}) => {
         try {

--- a/pathways/system/entity/memory/sys_memory_process.js
+++ b/pathways/system/entity/memory/sys_memory_process.js
@@ -71,7 +71,6 @@ Each modification object should look like:
     model: 'cortex-default-small-fast',
     reasoningEffort: 'none',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     json: true,
     timeout: 300,
     executePathway: async ({args, runAllPrompts}) => {

--- a/pathways/system/entity/memory/sys_memory_update.js
+++ b/pathways/system/entity/memory/sys_memory_update.js
@@ -31,7 +31,6 @@ export default {
     model: 'cortex-default-small-fast',
     reasoningEffort: 'none',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     json: true,
     timeout: 300,
     executePathway: async ({args, runAllPrompts}) => {

--- a/pathways/system/entity/memory/sys_search_memory.js
+++ b/pathways/system/entity/memory/sys_search_memory.js
@@ -30,7 +30,6 @@ export default {
     model: 'cortex-default-small-fast',
     reasoningEffort: 'none',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     requestLoggingDisabled: true,
     timeout: 300,
     executePathway: async ({args, runAllPrompts}) => {

--- a/pathways/system/entity/sys_compress_context.js
+++ b/pathways/system/entity/sys_compress_context.js
@@ -51,7 +51,6 @@ Provide a clear summary preserving all URLs, citations, and numerical data.`
     },
     model: 'gemini-flash-3-vision',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 120,
     
     executePathway: async ({args, runAllPrompts}) => {

--- a/pathways/system/entity/sys_entity_agent.js
+++ b/pathways/system/entity/sys_entity_agent.js
@@ -1210,7 +1210,6 @@ export {
 export default {
     emulateOpenAIChatModel: 'cortex-agent',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     useSingleTokenStream: false,
     manageTokenLength: false, // Agentic models handle context management themselves
     inputParameters: {

--- a/pathways/system/entity/sys_entity_continue.js
+++ b/pathways/system/entity/sys_entity_continue.js
@@ -6,7 +6,6 @@ import { chatArgsHasImageUrl, removeOldImageAndFileContent } from '../../../lib/
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         privateData: false,
         useMemory: true,    

--- a/pathways/system/entity/sys_entity_start.js
+++ b/pathways/system/entity/sys_entity_start.js
@@ -35,7 +35,6 @@ async function sendMessageToQueue(data) {
 
 export default {
     useInputChunking: false,
-    enableDuplicateRequests: false,
     model: 'oai-gpt4o',
     useSingleTokenStream: false,
     inputParameters: {

--- a/pathways/system/entity/sys_generator_ack.js
+++ b/pathways/system/entity/sys_generator_ack.js
@@ -16,5 +16,4 @@ export default {
         model: "oai-gpt4o-mini",
     },
     useInputChunking: false,
-    enableDuplicateRequests: false
 }

--- a/pathways/system/entity/sys_generator_expert.js
+++ b/pathways/system/entity/sys_generator_expert.js
@@ -16,7 +16,6 @@ export default {
     },
     model: 'oai-gpt4o',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     executePathway: async ({args, runAllPrompts, resolver}) => {
         let result;

--- a/pathways/system/entity/sys_generator_image.js
+++ b/pathways/system/entity/sys_generator_image.js
@@ -8,7 +8,6 @@ import { insertToolCallAndResults } from './memory/shared/sys_memory_helpers.js'
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         privateData: false,
         useMemory: true,    

--- a/pathways/system/entity/sys_generator_memory.js
+++ b/pathways/system/entity/sys_generator_memory.js
@@ -12,7 +12,6 @@ export default {
     },
     model: 'oai-gpt41-mini',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     executePathway: async ({args, resolver}) => {
 
         const { aiStyle, AI_STYLE_ANTHROPIC, AI_STYLE_OPENAI } = args;

--- a/pathways/system/entity/sys_generator_quick.js
+++ b/pathways/system/entity/sys_generator_quick.js
@@ -10,7 +10,6 @@ export default {
         model: 'oai-gpt41-mini',
     },
     useInputChunking: false,
-    enableDuplicateRequests: false,
     executePathway: async ({args, runAllPrompts, resolver}) => {
 
         let pathwayResolver = resolver;

--- a/pathways/system/entity/sys_generator_reasoning.js
+++ b/pathways/system/entity/sys_generator_reasoning.js
@@ -17,7 +17,6 @@ export default {
     },
     model: 'oai-o3-mini',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     executePathway: async ({args, runAllPrompts, resolver}) => {
         let timeoutId;

--- a/pathways/system/entity/sys_generator_results.js
+++ b/pathways/system/entity/sys_generator_results.js
@@ -11,7 +11,6 @@ const TOKEN_RATIO = 1.0;
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         privateData: false,
         useMemory: false,    

--- a/pathways/system/entity/sys_generator_video_vision.js
+++ b/pathways/system/entity/sys_generator_video_vision.js
@@ -17,7 +17,6 @@ export default {
     max_tokens: 4096,
     model: 'oai-gpt4o',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     
     executePathway: async ({args, runAllPrompts, resolver}) => {

--- a/pathways/system/entity/sys_generator_voice_converter.js
+++ b/pathways/system/entity/sys_generator_voice_converter.js
@@ -16,6 +16,5 @@ export default {
     },
     model: 'oai-gpt4o',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
 }

--- a/pathways/system/entity/sys_generator_voice_filler.js
+++ b/pathways/system/entity/sys_generator_voice_filler.js
@@ -16,7 +16,6 @@ export default {
     },
     model: 'oai-gpt4o-mini',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     json: true,
     timeout: 600,
 }

--- a/pathways/system/entity/sys_generator_voice_sample.js
+++ b/pathways/system/entity/sys_generator_voice_sample.js
@@ -17,7 +17,6 @@ export default {
         aiStyle: "OpenAI",
     },
     useInputChunking: false,
-    enableDuplicateRequests: false,
     executePathway: async ({args, runAllPrompts}) => {
 
         args = {

--- a/pathways/system/entity/sys_image_prompt_builder.js
+++ b/pathways/system/entity/sys_image_prompt_builder.js
@@ -32,6 +32,5 @@ Example response with 2 prompts creating 3 images total: [{"prompt": "A beautifu
         ]}),
     ],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     json: true
 }

--- a/pathways/system/entity/sys_query_builder.js
+++ b/pathways/system/entity/sys_query_builder.js
@@ -95,7 +95,6 @@ Example JSON objects and messages for different queries:
     ],
     model: 'oai-gpt4o',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     json: true,
     ...config.get('entityConstants')
 }

--- a/pathways/system/entity/sys_router_code.js
+++ b/pathways/system/entity/sys_router_code.js
@@ -32,6 +32,5 @@ Always output just the valid JSON object with all these fields.`,
     ],
     model: 'oai-gpt4o',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     json: true,
 }

--- a/pathways/system/entity/sys_router_tool.js
+++ b/pathways/system/entity/sys_router_tool.js
@@ -76,6 +76,5 @@ Return only the JSON object without additional commentary.`,
         ]}),
     ],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     json: true,
 }

--- a/pathways/system/entity/tools/sys_tool_analyzefile.js
+++ b/pathways/system/entity/tools/sys_tool_analyzefile.js
@@ -23,7 +23,6 @@ export default {
     max_tokens: 8192,
     model: 'gemini-flash-3-vision',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     geminiSafetySettings: [{category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH'},
         {category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH'},

--- a/pathways/system/entity/tools/sys_tool_coding.js
+++ b/pathways/system/entity/tools/sys_tool_coding.js
@@ -20,7 +20,6 @@ export default {
     max_tokens: 100000,
     model: 'oai-o3',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     // Tool disabled for now
     toolDefinition: [{

--- a/pathways/system/entity/tools/sys_tool_codingagent.js
+++ b/pathways/system/entity/tools/sys_tool_codingagent.js
@@ -42,7 +42,6 @@ export default {
     max_tokens: 100000,
     model: 'oai-gpt41',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     toolDefinition: [{
         type: "function",

--- a/pathways/system/entity/tools/sys_tool_cognitive_search.js
+++ b/pathways/system/entity/tools/sys_tool_cognitive_search.js
@@ -8,7 +8,6 @@ import { getSearchResultId } from '../../../../lib/util.js';
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         text: '',
         filter: '',

--- a/pathways/system/entity/tools/sys_tool_create_media.js
+++ b/pathways/system/entity/tools/sys_tool_create_media.js
@@ -95,7 +95,6 @@ function formatVeoVideoInput(videoUrl) {
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         model: 'oai-gpt4o',
         contextId: '',

--- a/pathways/system/entity/tools/sys_tool_image.js
+++ b/pathways/system/entity/tools/sys_tool_image.js
@@ -6,7 +6,6 @@ import { uploadFileToCloud, addFileToCollection, resolveFileParameter, buildFile
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         model: 'oai-gpt4o',
     },

--- a/pathways/system/entity/tools/sys_tool_image_gemini.js
+++ b/pathways/system/entity/tools/sys_tool_image_gemini.js
@@ -6,7 +6,6 @@ import { uploadImageToCloud, addFileToCollection, resolveFileParameter, buildFil
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         model: 'oai-gpt4o',
         contextId: '',

--- a/pathways/system/entity/tools/sys_tool_mermaid.js
+++ b/pathways/system/entity/tools/sys_tool_mermaid.js
@@ -73,7 +73,6 @@ export default {
     },
     model: 'oai-gpt5-chat',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     toolDefinition: [{
         type: "function",

--- a/pathways/system/entity/tools/sys_tool_planner.js
+++ b/pathways/system/entity/tools/sys_tool_planner.js
@@ -21,7 +21,6 @@ export default {
     model: 'oai-gpt51',
     reasoningEffort: 'high',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     toolDefinition: {
         type: "function",

--- a/pathways/system/entity/tools/sys_tool_slides_gemini.js
+++ b/pathways/system/entity/tools/sys_tool_slides_gemini.js
@@ -14,7 +14,6 @@ import {
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         model: 'oai-gpt4o',
         contextId: '',

--- a/pathways/system/entity/tools/sys_tool_verify.js
+++ b/pathways/system/entity/tools/sys_tool_verify.js
@@ -21,7 +21,6 @@ export default {
     },
     max_tokens: 100000,
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     toolDefinition: [{
         type: "function",

--- a/pathways/system/entity/tools/sys_tool_video_veo.js
+++ b/pathways/system/entity/tools/sys_tool_video_veo.js
@@ -68,7 +68,6 @@ function extractVideoInfo(video) {
 export default {
     prompt: [],
     useInputChunking: false,
-    enableDuplicateRequests: false,
     inputParameters: {
         model: 'oai-gpt4o',
         contextId: '',

--- a/pathways/system/sys_parse_numbered_object_list.js
+++ b/pathways/system/sys_parse_numbered_object_list.js
@@ -13,7 +13,6 @@ export default {
     model: 'oai-gpt4o',
     temperature: 0.0,
     enableCache: true,
-    enableDuplicateRequests: false,
     json: true
 }
 

--- a/pathways/system/sys_repair_json.js
+++ b/pathways/system/sys_repair_json.js
@@ -15,5 +15,4 @@ export default {
     },
     temperature: 0.0,
     enableCache: true,
-    enableDuplicateRequests: false,
 }

--- a/pathways/system/sys_test_response_reasonableness.js
+++ b/pathways/system/sys_test_response_reasonableness.js
@@ -15,6 +15,5 @@ export default {
         modelResponse: '',
     },
     model: 'oai-gpt4o-mini',
-    enableDuplicateRequests: false,
     json: true
 } 

--- a/pathways/system/workspaces/run_workspace_prompt.js
+++ b/pathways/system/workspaces/run_workspace_prompt.js
@@ -6,7 +6,6 @@ import { Prompt } from '../../../server/prompt.js';
 export default {
     emulateOpenAIChatModel: 'cortex-agent',
     useInputChunking: false,
-    enableDuplicateRequests: false,
     useSingleTokenStream: false,
 
     inputParameters: {

--- a/pathways/system/workspaces/workspace_applet_edit.js
+++ b/pathways/system/workspaces/workspace_applet_edit.js
@@ -2,7 +2,6 @@ import { Prompt } from '../../../server/prompt.js';
 
 export default {
     useInputChunking: false,
-    enableDuplicateRequests: false,
     useSingleTokenStream: false,
     prompt: [
         new Prompt({

--- a/pathways/tag_image.js
+++ b/pathways/tag_image.js
@@ -36,7 +36,6 @@ All arrays should contain relevant items found in a category, or an empty array 
         model: 'oai-gpt4o',
     },
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
     manageTokenLength: false,
     json: true,

--- a/pathways/timeline.js
+++ b/pathways/timeline.js
@@ -48,5 +48,4 @@ export default {
         date: new Date().toDateString(),
     },
     temperature: 0.0,
-    enableDuplicateRequests: false,
 }

--- a/pathways/topics_sentiment.js
+++ b/pathways/topics_sentiment.js
@@ -13,7 +13,6 @@ export default {
     //inputChunkSize: 1000,
     joinChunksWith: '\n',
     tokenRatio: 1,
-    enableDuplicateRequests: false,
     timeout: 1800,
 }
 

--- a/pathways/transcribe.js
+++ b/pathways/transcribe.js
@@ -12,5 +12,4 @@ export default {
         maxWordsPerLine: 0,
     },
     timeout: 3600, // in seconds
-    enableDuplicateRequests: false,
 };

--- a/pathways/transcribe_gemini.js
+++ b/pathways/transcribe_gemini.js
@@ -26,7 +26,6 @@ export default {
         contextId: ``,
     },
     timeout: 3600, // in seconds
-    enableDuplicateRequests: false,
     geminiSafetySettings: [{category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH'},
         {category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH'},
         {category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH'},

--- a/pathways/transcribe_neuralspace.js
+++ b/pathways/transcribe_neuralspace.js
@@ -12,7 +12,6 @@ export default {
         maxWordsPerLine: 0,
     },
     timeout: 3600, // in seconds
-    enableDuplicateRequests: false,
 };
 
 

--- a/pathways/translate.js
+++ b/pathways/translate.js
@@ -14,6 +14,5 @@ export default {
     },
     inputChunkSize: 500,
     model: 'oai-gpt4o',
-    enableDuplicateRequests: false,
 
 }

--- a/pathways/translate_gpt4.js
+++ b/pathways/translate_gpt4.js
@@ -14,6 +14,5 @@ export default {
     },
     inputChunkSize: 500,
     model: 'oai-gpt4',
-    enableDuplicateRequests: false,
 
 }

--- a/pathways/translate_gpt4_omni.js
+++ b/pathways/translate_gpt4_omni.js
@@ -14,7 +14,6 @@ export default {
     },
     inputChunkSize: 1000,
     model: 'oai-gpt4o',
-    enableDuplicateRequests: false,
     useParallelChunkProcessing: true,
 
 }

--- a/pathways/translate_gpt4_turbo.js
+++ b/pathways/translate_gpt4_turbo.js
@@ -14,6 +14,5 @@ export default {
     },
     inputChunkSize: 500,
     model: 'oai-gpt4-turbo',
-    enableDuplicateRequests: false,
 
 }

--- a/pathways/translate_groq.js
+++ b/pathways/translate_groq.js
@@ -31,6 +31,5 @@ export default {
     },
     inputChunkSize: 1000,
     model: 'groq-chat',
-    enableDuplicateRequests: false,
     useParallelChunkProcessing: true,
 }

--- a/pathways/translate_json_values.js
+++ b/pathways/translate_json_values.js
@@ -13,7 +13,6 @@ export default {
         tokenRatio: 0.2,
     },
     model: 'oai-gpt4o',
-    enableDuplicateRequests: false,
     useInputChunking: false,
     enableCache: true,
     json: true,

--- a/pathways/translate_subtitle.js
+++ b/pathways/translate_subtitle.js
@@ -105,7 +105,6 @@ export default {
   },
   useInputChunking: false,
   model: "oai-gpt4o",
-  enableDuplicateRequests: false,
   timeout: 3600,
   executePathway: async ({args, resolver}) => {
     try {

--- a/pathways/translate_subtitle_helper.js
+++ b/pathways/translate_subtitle_helper.js
@@ -27,6 +27,5 @@ Output only the translated subtitles in a <SUBTITLES> tag with no other text or 
     },
     useInputChunking: false,
     model: 'oai-gpt4o',
-    enableDuplicateRequests: false,
     timeout: 3600,
 }

--- a/pathways/translate_turbo.js
+++ b/pathways/translate_turbo.js
@@ -14,6 +14,5 @@ export default {
     },
     inputChunkSize: 500,
     model: 'oai-gpturbo',
-    enableDuplicateRequests: false,
 
 }

--- a/pathways/tts_gemini.js
+++ b/pathways/tts_gemini.js
@@ -13,6 +13,5 @@ export default {
   max_tokens: 8192,
   model: "google-gemini-3.1-flash-tts",
   useInputChunking: false,
-  enableDuplicateRequests: false,
   timeout: 60 * 5,
 };

--- a/pathways/tts_replicate.js
+++ b/pathways/tts_replicate.js
@@ -38,6 +38,5 @@ export default {
 
   max_tokens: 8192,
   useInputChunking: false,
-  enableDuplicateRequests: false,
   timeout: 60 * 10,
 };

--- a/pathways/video_grok_imagine.js
+++ b/pathways/video_grok_imagine.js
@@ -1,7 +1,6 @@
 export default {
   prompt: ["{{text}}"],
 
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "replicate-grok-imagine-video",
     aspectRatio: "auto",

--- a/pathways/video_kling.js
+++ b/pathways/video_kling.js
@@ -1,7 +1,6 @@
 export default {
   prompt: ["{{text}}"],
 
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "replicate-kling-v2.5-turbo-pro",
     aspectRatio: "16:9",

--- a/pathways/video_seedance.js
+++ b/pathways/video_seedance.js
@@ -1,7 +1,6 @@
 export default {
   prompt: ["{{text}}"],
 
-  enableDuplicateRequests: false,
   inputParameters: {
     model: "replicate-seedance-1-pro",
     resolution: "1080p",

--- a/pathways/video_veo.js
+++ b/pathways/video_veo.js
@@ -9,7 +9,6 @@
 export default {
   prompt: ["Generate a video based on the following description: {{text}}"],
 
-  enableDuplicateRequests: false,
   inputParameters: {
     text: "",
     image: "",

--- a/pathways/vision.js
+++ b/pathways/vision.js
@@ -15,6 +15,5 @@ export default {
     },
     max_tokens: 1024,
     useInputChunking: false,
-    enableDuplicateRequests: false,
     timeout: 600,
 }

--- a/tests/unit/lib/modelRequestLog.test.js
+++ b/tests/unit/lib/modelRequestLog.test.js
@@ -26,7 +26,6 @@ test('buildModelRequestLogBase summarizes OpenAI Responses requests without prom
             modelType: 'OPENAI-RESPONSES',
             endpoint: 'EUS2',
             retry: 0,
-            duplicateIndex: 0,
         },
         axiosConfigObj: {
             responseType: 'stream',

--- a/tests/unit/pathways/genericEditorialPathways.test.js
+++ b/tests/unit/pathways/genericEditorialPathways.test.js
@@ -6,7 +6,6 @@ import styleguideHtml from "../../../pathways/styleguide/styleguide_html.js";
 
 test("azure_video_translate exposes the Azure video translation parameter surface", (t) => {
   t.is(azureVideoTranslate.model, "azure-video-translate");
-  t.false(azureVideoTranslate.enableDuplicateRequests);
   t.false(azureVideoTranslate.enableCache);
   t.is(azureVideoTranslate.timeout, 60 * 60);
 

--- a/tests/unit/pathways/genericOverlayPathways.test.js
+++ b/tests/unit/pathways/genericOverlayPathways.test.js
@@ -8,7 +8,6 @@ const internalNamesPattern = new RegExp(`${'Al ' + 'Jazeera'}|${'La' + 'beeb'}`,
 
 test('categorize_feedback exposes generic feedback categories and CSV-style output', t => {
     t.is(categorizeFeedback.model, 'oai-gpt4o');
-    t.false(categorizeFeedback.enableDuplicateRequests);
     t.regex(categorizeFeedback.inputParameters.categories, /Brand Praise/);
     t.regex(categorizeFeedback.inputParameters.categories, /Feature Suggestion/);
 
@@ -21,7 +20,6 @@ test('categorize_feedback exposes generic feedback categories and CSV-style outp
 
 test('greeting generates dashboard copy using generic entity defaults', t => {
     t.is(greeting.model, 'oai-gpt41');
-    t.false(greeting.enableDuplicateRequests);
     t.is(greeting.inputParameters.aiName, 'Jarvis');
     t.is(greeting.inputParameters.language, 'English');
 

--- a/tests/unit/pathways/gptImage2Pathway.test.js
+++ b/tests/unit/pathways/gptImage2Pathway.test.js
@@ -10,7 +10,6 @@ import sysModelMetadata from "../../../pathways/system/sys_model_metadata.js";
 test("image_gpt_image_2 declares the Azure OpenAI image pathway contract", (t) => {
   t.is(imageGptImage2.model, "oai-gpt-image-2");
   t.is(imageGptImage2.timeout, 600);
-  t.false(imageGptImage2.enableDuplicateRequests);
   t.is(imageGptImage2.inputParameters.text, "");
   t.is(imageGptImage2.inputParameters.size, "");
   t.is(imageGptImage2.inputParameters.quality, "");
@@ -117,7 +116,7 @@ test("default example exposes GPT Image 2 metadata without service-specific cred
 
   t.truthy(model);
   t.is(model.type, "OPENAI-DALLE3");
-  t.is(model.endpoints[0].headers["api-key"], "{{AZURE_OPENAI_API_KEY}}");
+  t.is(model.endpoints[0].headers.Authorization, "Bearer {{OPENAI_API_KEY}}");
   t.false(model.endpoints[0].url.includes("archipelago"));
   t.is(model.metadata.displayName, "GPT Image 2");
   t.is(model.metadata.category, "image");

--- a/tests/unit/pathways/utilityPathways.test.js
+++ b/tests/unit/pathways/utilityPathways.test.js
@@ -10,7 +10,6 @@ test('pass pathway returns the input text template with a configured model', (t)
 test('translate_json_values requests JSON output and disables chunking', (t) => {
     t.true(translateJsonValues.json);
     t.false(translateJsonValues.useInputChunking);
-    t.false(translateJsonValues.enableDuplicateRequests);
     t.true(translateJsonValues.enableCache);
     t.is(translateJsonValues.model, 'oai-gpt4o');
 


### PR DESCRIPTION
## Summary
- remove hedged duplicate provider request execution from requestExecutor
- remove duplicate request config/env and generated REST pathway plumbing
- drop pathway-level duplicate request flags and docs/tests for the removed surface

## Validation
- node --check lib/requestExecutor.js
- node --check over all pathways/**/*.js
- git diff --check
- npx ava tests/unit/lib/modelRequestLog.test.js tests/unit/pathways/genericEditorialPathways.test.js tests/unit/pathways/genericOverlayPathways.test.js tests/unit/pathways/gptImage2Pathway.test.js tests/unit/pathways/utilityPathways.test.js tests/unit/core/cancelRequestAbort.test.js tests/unit/core/modelSampler.test.js tests/unit/core/modelGroups.test.js tests/unit/core/modelRedirects.test.js

Note: full npm test was not used as a gate because it runs long live integrations in this repo.