### PR TITLE
Fall back to next free port when preferred port is busy in development

### DIFF
--- a/lib/listenHttpServer.js
+++ b/lib/listenHttpServer.js
@@ -1,41 +1,85 @@
+import net from 'net';
+
+const isPortFree = (port) => new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', () => resolve(false));
+    srv.once('listening', () => {
+        srv.close((err) => resolve(!err));
+    });
+    srv.listen(port);
+});
+
+const findFreePort = async (preferredPort, maxAttempts) => {
+    const end = preferredPort + maxAttempts;
+    for (let port = preferredPort; port < end; port++) {
+        if (await isPortFree(port)) {
+            return port;
+        }
+    }
+    const err = new Error(`listen EADDRINUSE: no free port in range ${preferredPort}-${end - 1}`);
+    err.code = 'EADDRINUSE';
+    throw err;
+};
+
+const bindPort = (httpServer, port) => new Promise((resolve, reject) => {
+    const onError = (err) => {
+        httpServer.removeListener('listening', onListening);
+        reject(err);
+    };
+    const onListening = () => {
+        httpServer.removeListener('error', onError);
+        resolve(port);
+    };
+    httpServer.once('error', onError);
+    httpServer.once('listening', onListening);
+    try {
+        httpServer.listen(port);
+    } catch (err) {
+        httpServer.removeListener('error', onError);
+        httpServer.removeListener('listening', onListening);
+        reject(err);
+    }
+});
+
 /**
  * Bind httpServer to preferredPort. Optionally fall back to subsequent ports
  * when the preferred port is already in use (e.g. local development).
+ *
+ * When fallback is enabled, probes for a free port first so the real server
+ * (and any attached WebSocketServer) does not see EADDRINUSE retries —
+ * graphql-ws only handles the first `ws` error via `once('error')`.
+ *
  * @returns {Promise<number>} the port that was bound
  */
-export const listenHttpServer = (httpServer, preferredPort, { allowFallback = false, maxAttempts = 100 } = {}) => {
-    const tryListen = (port) => new Promise((resolve, reject) => {
-        const onError = (err) => {
-            httpServer.removeListener('listening', onListening);
-            reject(err);
-        };
-        const onListening = () => {
-            httpServer.removeListener('error', onError);
-            resolve(port);
-        };
-        httpServer.once('error', onError);
-        httpServer.once('listening', onListening);
-        try {
-            httpServer.listen(port);
-        } catch (err) {
-            httpServer.removeListener('error', onError);
-            httpServer.removeListener('listening', onListening);
-            reject(err);
-        }
-    });
+export const listenHttpServer = async (
+    httpServer,
+    preferredPort,
+    { allowFallback = false, maxAttempts = 100 } = {},
+) => {
+    if (!allowFallback) {
+        return bindPort(httpServer, preferredPort);
+    }
 
-    const end = allowFallback ? preferredPort + maxAttempts : preferredPort + 1;
+    let start = preferredPort;
+    const end = preferredPort + maxAttempts;
+    let lastError;
 
-    const attempt = async (port) => {
+    while (start < end) {
+        const port = await findFreePort(start, end - start);
         try {
-            return await tryListen(port);
+            return await bindPort(httpServer, port);
         } catch (err) {
-            if (err.code !== 'EADDRINUSE' || !allowFallback || port + 1 >= end) {
+            lastError = err;
+            if (err.code !== 'EADDRINUSE') {
                 throw err;
             }
-            return attempt(port + 1);
+            // Lost the race after probing; try the next port.
+            start = port + 1;
         }
-    };
+    }
 
-    return attempt(preferredPort);
+    throw lastError || Object.assign(
+        new Error(`listen EADDRINUSE: no free port in range ${preferredPort}-${end - 1}`),
+        { code: 'EADDRINUSE' },
+    );
 };

--- a/lib/listenHttpServer.js
+++ b/lib/listenHttpServer.js
@@ -1,0 +1,41 @@
+/**
+ * Bind httpServer to preferredPort. Optionally fall back to subsequent ports
+ * when the preferred port is already in use (e.g. local development).
+ * @returns {Promise<number>} the port that was bound
+ */
+export const listenHttpServer = (httpServer, preferredPort, { allowFallback = false, maxAttempts = 100 } = {}) => {
+    const tryListen = (port) => new Promise((resolve, reject) => {
+        const onError = (err) => {
+            httpServer.removeListener('listening', onListening);
+            reject(err);
+        };
+        const onListening = () => {
+            httpServer.removeListener('error', onError);
+            resolve(port);
+        };
+        httpServer.once('error', onError);
+        httpServer.once('listening', onListening);
+        try {
+            httpServer.listen(port);
+        } catch (err) {
+            httpServer.removeListener('error', onError);
+            httpServer.removeListener('listening', onListening);
+            reject(err);
+        }
+    });
+
+    const end = allowFallback ? preferredPort + maxAttempts : preferredPort + 1;
+
+    const attempt = async (port) => {
+        try {
+            return await tryListen(port);
+        } catch (err) {
+            if (err.code !== 'EADDRINUSE' || !allowFallback || port + 1 >= end) {
+                throw err;
+            }
+            return attempt(port + 1);
+        }
+    };
+
+    return attempt(preferredPort);
+};

--- a/server/graphql.js
+++ b/server/graphql.js
@@ -27,6 +27,7 @@ import subscriptions from './subscriptions.js';
 import { getMessageTypeDefs } from './typeDef.js';
 import { buildRestEndpoints } from './rest.js';
 import { executeWorkspaceResolver, getExecuteWorkspaceTypeDefs } from './executeWorkspace.js';
+import { listenHttpServer } from '../lib/listenHttpServer.js';
 import crypto from 'crypto';
 
 // Utility functions
@@ -310,9 +311,18 @@ const build = async (config) => {
         buildRestEndpoints(pathways, app, server, config);
 
         // Now that our HTTP server is fully set up, we can listen to it.
-        httpServer.listen(config.get('PORT'), () => {
-            logger.info(`🚀 Server is now running at http://localhost:${config.get('PORT')}/graphql`);
-        });
+        // In development, fall back to the next free port if the preferred one is busy.
+        const preferredPort = config.get('PORT');
+        const allowFallback = config.get('env') === 'development' || config.get('env') === 'debug';
+        const boundPort = await listenHttpServer(httpServer, preferredPort, { allowFallback });
+
+        if (boundPort !== preferredPort) {
+            logger.warn(`Port ${preferredPort} is in use; bound to ${boundPort} instead`);
+            config.set('PORT', boundPort);
+            process.env.CORTEX_PORT = String(boundPort);
+        }
+
+        logger.info(`🚀 Server is now running at http://localhost:${boundPort}/graphql`);
     };
 
     return { server, startServer, startTestServer, cache, plugins, typeDefs, resolvers }

--- a/server/graphql.js
+++ b/server/graphql.js
@@ -222,6 +222,9 @@ const build = async (config) => {
     const keepAlive = config.get('subscriptionKeepAlive');
     logger.info(`Starting web socket server with subscription keep alive: ${keepAlive}`);
     const serverCleanup = useServer({ schema }, wsServer, keepAlive);
+    // graphql-ws only attaches once('error'); absorb later bind errors so port
+    // fallback / rare listen races cannot crash the process as unhandled.
+    wsServer.on('error', () => {});
 
     const server = new ApolloServer({
         schema: schema,

--- a/start.js
+++ b/start.js
@@ -4,5 +4,7 @@ import { loadLocalEnvFiles } from './lib/loadLocalEnv.js';
   loadLocalEnvFiles();
   const { default: startServerFactory } = await import('./index.js');
   const { startServer } = await startServerFactory();
-  startServer && startServer();
+  if (startServer) {
+    await startServer();
+  }
 })();

--- a/tests/unit/server/listenHttpServer.test.js
+++ b/tests/unit/server/listenHttpServer.test.js
@@ -1,0 +1,54 @@
+import test from 'ava';
+import http from 'http';
+import { listenHttpServer } from '../../../lib/listenHttpServer.js';
+
+const occupyPort = (port) => new Promise((resolve, reject) => {
+    const server = http.createServer((_req, res) => res.end('ok'));
+    server.once('error', reject);
+    server.listen(port, () => resolve(server));
+});
+
+const closeServer = (server) => new Promise((resolve, reject) => {
+    if (!server?.listening) return resolve();
+    server.close((err) => (err ? reject(err) : resolve()));
+});
+
+test('listens on the preferred port when available', async (t) => {
+    const blocker = await occupyPort(0);
+    const preferredPort = blocker.address().port;
+    await closeServer(blocker);
+
+    const server = http.createServer();
+    t.teardown(() => closeServer(server));
+
+    const bound = await listenHttpServer(server, preferredPort, { allowFallback: false });
+    t.is(bound, preferredPort);
+    t.is(server.address().port, preferredPort);
+});
+
+test('falls back to the next free port when preferred is busy', async (t) => {
+    const blocker = await occupyPort(0);
+    const preferredPort = blocker.address().port;
+    t.teardown(() => closeServer(blocker));
+
+    const server = http.createServer();
+    t.teardown(() => closeServer(server));
+
+    const bound = await listenHttpServer(server, preferredPort, { allowFallback: true, maxAttempts: 10 });
+    t.true(bound > preferredPort);
+    t.is(server.address().port, bound);
+});
+
+test('throws EADDRINUSE when fallback is disabled', async (t) => {
+    const blocker = await occupyPort(0);
+    const preferredPort = blocker.address().port;
+    t.teardown(() => closeServer(blocker));
+
+    const server = http.createServer();
+    t.teardown(() => closeServer(server));
+
+    const err = await t.throwsAsync(() =>
+        listenHttpServer(server, preferredPort, { allowFallback: false }),
+    );
+    t.is(err.code, 'EADDRINUSE');
+});

--- a/tests/unit/server/listenHttpServer.test.js
+++ b/tests/unit/server/listenHttpServer.test.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import http from 'http';
+import { WebSocketServer } from 'ws';
 import { listenHttpServer } from '../../../lib/listenHttpServer.js';
 
 const occupyPort = (port) => new Promise((resolve, reject) => {
@@ -51,4 +52,31 @@ test('throws EADDRINUSE when fallback is disabled', async (t) => {
         listenHttpServer(server, preferredPort, { allowFallback: false }),
     );
     t.is(err.code, 'EADDRINUSE');
+});
+
+test('fallback works with an attached WebSocketServer (graphql-ws once error)', async (t) => {
+    // Reproduce the production crash path: ws forwards httpServer errors to
+    // WebSocketServer, and graphql-ws only handles the first via once('error').
+    const blockerA = await occupyPort(0);
+    const preferredPort = blockerA.address().port;
+    const blockerB = await occupyPort(preferredPort + 1);
+    t.teardown(async () => {
+        await closeServer(blockerA);
+        await closeServer(blockerB);
+    });
+
+    const server = http.createServer();
+    const wsServer = new WebSocketServer({ server, path: '/graphql' });
+    // Mimic graphql-ws: only the first error is handled.
+    wsServer.once('error', () => {});
+    // Durable absorber used by Cortex after useServer().
+    wsServer.on('error', () => {});
+    t.teardown(async () => {
+        wsServer.close();
+        await closeServer(server);
+    });
+
+    const bound = await listenHttpServer(server, preferredPort, { allowFallback: true, maxAttempts: 10 });
+    t.true(bound >= preferredPort + 2);
+    t.is(server.address().port, bound);
 });


### PR DESCRIPTION
## Summary
- In development/debug, if `CORTEX_PORT` is already in use, bind the next available port instead of failing with `EADDRINUSE`
- Log a warning when falling back and update config/`CORTEX_PORT` to the bound port
- Production still fails hard if the preferred port is busy

## Test plan
- [ ] With nothing on 4000, `npm start` / `npm run dev` binds to 4000 as usual
- [ ] With another process on 4000, the server binds to the next free port and logs the fallback warning
- [ ] Confirm GraphQL playground opens at the logged URL
- [ ] `npm test -- tests/unit/server/listenHttpServer.test.js`


Made with [Cursor](https://cursor.com)